### PR TITLE
fix: remove cors header when proxy to graphql

### DIFF
--- a/internal/controller/http/v0/graphql/rproxy.go
+++ b/internal/controller/http/v0/graphql/rproxy.go
@@ -89,6 +89,10 @@ func (g *RProxy) makeHasuraHandler(fn http.HandlerFunc) http.HandlerFunc {
 
 		// restore body
 		r.Body = io.NopCloser(bytes.NewReader(bodyBytes))
+
+		// avoid duplicated CORS issue, since hasura will set CORS headers
+		w.Header().Del("Access-Control-Allow-Origin")
+		w.Header().Del("Access-Control-Allow-Methods")
 		fn(w, r)
 	}
 }

--- a/internal/pkg/gateway/middleware/cors/cors.go
+++ b/internal/pkg/gateway/middleware/cors/cors.go
@@ -6,8 +6,8 @@ import (
 )
 
 const (
-	AllowMethods = "GET, POST, PATCH, DELETE"
-	AllowHeaders = "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, ResponseType, X-Api-Key"
+	AllowMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
+	AllowHeaders = "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, ResponseType"
 )
 
 func allowedOrigin(cors []string, origin string) bool {


### PR DESCRIPTION
fix duplicated cors header issue