### PR TITLE
fix: add x-api-key header back

### DIFF
--- a/internal/pkg/gateway/middleware/cors/cors.go
+++ b/internal/pkg/gateway/middleware/cors/cors.go
@@ -7,7 +7,7 @@ import (
 
 const (
 	AllowMethods = "GET, POST, PUT, PATCH, DELETE, OPTIONS"
-	AllowHeaders = "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, ResponseType"
+	AllowHeaders = "Accept, Content-Type, Content-Length, Accept-Encoding, Authorization, ResponseType, X-Api-Key"
 )
 
 func allowedOrigin(cors []string, origin string) bool {


### PR DESCRIPTION
not compatiable with SDK, need x-api-key header