### PR TITLE
fixed bug where deployed databases with invalid SQL would fail but no…

### DIFF
--- a/internal/usecases/datasets/mock_test.go
+++ b/internal/usecases/datasets/mock_test.go
@@ -161,6 +161,10 @@ func (m *mockDataset) Savepoint() (sqldb.Savepoint, error) {
 	return &mockSavepoint{}, nil
 }
 
+func (m *mockDataset) Delete(txCtx *dto.TxContext) error {
+	return nil
+}
+
 type mockResult struct {
 }
 

--- a/pkg/engine/dataset.go
+++ b/pkg/engine/dataset.go
@@ -39,6 +39,8 @@ type Dataset interface {
 
 	// Name returns the name of the dataset.
 	Name() string
+
+	Delete(txCtx *dto.TxContext) error
 }
 
 // internalDataset exposes more than the public Dataset interface.

--- a/pkg/engine/tree/delete.go
+++ b/pkg/engine/tree/delete.go
@@ -1,6 +1,10 @@
 package tree
 
-import sqlwriter "github.com/kwilteam/kwil-db/pkg/engine/tree/sql-writer"
+import (
+	"fmt"
+
+	sqlwriter "github.com/kwilteam/kwil-db/pkg/engine/tree/sql-writer"
+)
 
 type Delete struct {
 	CTE        []*CTE
@@ -10,7 +14,12 @@ type Delete struct {
 func (d *Delete) ToSQL() (str string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = r.(error)
+			err2, ok := r.(error)
+			if !ok {
+				err2 = fmt.Errorf("%v", r)
+			}
+
+			err = err2
 		}
 	}()
 

--- a/pkg/engine/tree/insert.go
+++ b/pkg/engine/tree/insert.go
@@ -14,7 +14,12 @@ type Insert struct {
 func (ins *Insert) ToSQL() (str string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = r.(error)
+			err2, ok := r.(error)
+			if !ok {
+				err2 = fmt.Errorf("%v", r)
+			}
+
+			err = err2
 		}
 	}()
 

--- a/pkg/engine/tree/select.go
+++ b/pkg/engine/tree/select.go
@@ -14,7 +14,12 @@ type Select struct {
 func (s *Select) ToSQL() (str string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = r.(error)
+			err2, ok := r.(error)
+			if !ok {
+				err2 = fmt.Errorf("%v", r)
+			}
+
+			err = err2
 		}
 	}()
 

--- a/pkg/engine/tree/update.go
+++ b/pkg/engine/tree/update.go
@@ -1,6 +1,10 @@
 package tree
 
-import sqlwriter "github.com/kwilteam/kwil-db/pkg/engine/tree/sql-writer"
+import (
+	"fmt"
+
+	sqlwriter "github.com/kwilteam/kwil-db/pkg/engine/tree/sql-writer"
+)
 
 // Update Statement with CTEs
 type Update struct {
@@ -11,7 +15,12 @@ type Update struct {
 func (u *Update) ToSQL() (str string, err error) {
 	defer func() {
 		if r := recover(); r != nil {
-			err = r.(error)
+			err2, ok := r.(error)
+			if !ok {
+				err2 = fmt.Errorf("%v", r)
+			}
+
+			err = err2
 		}
 	}()
 

--- a/test/acceptance/helper.go
+++ b/test/acceptance/helper.go
@@ -4,10 +4,16 @@ import (
 	"context"
 	"crypto/ecdsa"
 	"fmt"
-	"github.com/kwilteam/kwil-db/pkg/kuneiform/schema"
 	"os"
 
+	"github.com/kwilteam/kwil-db/pkg/kuneiform/schema"
+
 	//"github.com/kwilteam/kwil-db/cmd/kwil-cli/app"
+	"math/big"
+	"runtime"
+	"testing"
+	"time"
+
 	"github.com/kwilteam/kwil-db/internal/app/kwild"
 	"github.com/kwilteam/kwil-db/pkg/chain/types"
 	"github.com/kwilteam/kwil-db/pkg/client"
@@ -16,10 +22,6 @@ import (
 	"github.com/kwilteam/kwil-db/test/acceptance/utils/deployer"
 	eth_deployer "github.com/kwilteam/kwil-db/test/acceptance/utils/deployer/eth-deployer"
 	"github.com/kwilteam/kwil-db/test/specifications"
-	"math/big"
-	"runtime"
-	"testing"
-	"time"
 
 	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/stretchr/testify/require"
@@ -175,7 +177,6 @@ func arch() string {
 func setSchemaLoader(cfg TestEnvCfg) {
 	specifications.SetSchemaLoader(
 		&specifications.FileDatabaseSchemaLoader{
-			FilePath: cfg.DBSchemaFilePath,
 			Modifier: func(db *schema.Schema) {
 				db.Owner = cfg.UserAddr
 				// NOTE: this is a hack to make sure the db name is temporary unique

--- a/test/acceptance/test-data/invalid_sql_syntax.kf
+++ b/test/acceptance/test-data/invalid_sql_syntax.kf
@@ -1,0 +1,15 @@
+database invalid_sql_syntax;
+
+table users {
+    id int primary notnull,
+    username text default("sds"),
+    age int min(0),
+    dob text,
+    wallet text unique
+}
+
+action invalid_sql() public {
+    SELECT *
+    FROM users AS u1
+    INNER JOIN users AS u2 ON 1 = 1;
+}

--- a/test/acceptance/test-data/invalid_sql_syntax_fixed.kf
+++ b/test/acceptance/test-data/invalid_sql_syntax_fixed.kf
@@ -1,0 +1,15 @@
+database invalid_sql_syntax;
+
+table users {
+    id int primary notnull,
+    username text default("sds"),
+    age int min(0),
+    dob text,
+    wallet text unique
+}
+
+action invalid_sql() public {
+    SELECT *
+    FROM users AS u1
+    INNER JOIN users AS u2 ON u1.id = u2.id;
+}

--- a/test/specifications/deploy_database.go
+++ b/test/specifications/deploy_database.go
@@ -2,8 +2,9 @@ package specifications
 
 import (
 	"context"
-	"github.com/kwilteam/kwil-db/pkg/kuneiform/schema"
 	"testing"
+
+	"github.com/kwilteam/kwil-db/pkg/kuneiform/schema"
 
 	"github.com/stretchr/testify/assert"
 )
@@ -16,13 +17,39 @@ type DatabaseDeployDsl interface {
 
 func DatabaseDeploySpecification(ctx context.Context, t *testing.T, deploy DatabaseDeployDsl) {
 	t.Logf("Executing database deploy specification")
+	testDeployFailure(ctx, t, deploy)
+
 	// Given a valid database schema
-	db := SchemaLoader.Load(t)
+	db := SchemaLoader.Load(t, schema_testdb)
 
 	// When i deploy the database
 	err := deploy.DeployDatabase(ctx, db)
 
 	// Then i expect success
+	assert.NoError(t, err)
+
+	// And i expect database should exist
+	err = deploy.DatabaseShouldExists(ctx, db.Owner, db.Name)
+	assert.NoError(t, err)
+
+}
+
+func testDeployFailure(ctx context.Context, t *testing.T, deploy DatabaseDeployDsl) {
+	db := SchemaLoader.LoadWithoutValidation(t, schema_invalidSQLSyntax)
+
+	// Deploy faulty database and expect error
+	err := deploy.DeployDatabase(ctx, db)
+	assert.Error(t, err)
+
+	// And i expect database should not exist
+	err = deploy.DatabaseShouldExists(ctx, db.Owner, db.Name)
+	assert.Error(t, err)
+
+	// read in fixed schema
+	db = SchemaLoader.Load(t, schema_invalidSQLSyntaxFixed)
+
+	// Deploy fault database and expect error
+	err = deploy.DeployDatabase(ctx, db)
 	assert.NoError(t, err)
 
 	// And i expect database should exist

--- a/test/specifications/drop_database.go
+++ b/test/specifications/drop_database.go
@@ -16,7 +16,7 @@ type DatabaseDropDsl interface {
 func DatabaseDropSpecification(ctx context.Context, t *testing.T, drop DatabaseDropDsl) {
 	t.Logf("Executing database drop specification")
 	// Given a valid database schema
-	db := SchemaLoader.Load(t)
+	db := SchemaLoader.Load(t, schema_testdb)
 
 	// When i drop the database, it should success
 	err := drop.DropDatabase(ctx, db.Name)

--- a/test/specifications/execute_delete_query.go
+++ b/test/specifications/execute_delete_query.go
@@ -10,7 +10,7 @@ import (
 func ExecuteDBDeleteSpecification(ctx context.Context, t *testing.T, execute ExecuteQueryDsl) {
 	t.Logf("Executing delete action specification")
 	// Given a valid database schema
-	db := SchemaLoader.Load(t)
+	db := SchemaLoader.Load(t, schema_testdb)
 	dbID := GenerateSchemaId(db.Owner, db.Name)
 
 	actionName := "delete_user"

--- a/test/specifications/execute_insert_query.go
+++ b/test/specifications/execute_insert_query.go
@@ -29,7 +29,7 @@ type ExecuteQueryDsl interface {
 func ExecuteDBInsertSpecification(ctx context.Context, t *testing.T, execute ExecuteQueryDsl) {
 	t.Logf("Executing insert action specification")
 	// Given a valid database schema
-	db := SchemaLoader.Load(t)
+	db := SchemaLoader.Load(t, schema_testdb)
 	dbID := GenerateSchemaId(db.Owner, db.Name)
 
 	createUserActionName := "create_user"

--- a/test/specifications/execute_permissioned_actions.go
+++ b/test/specifications/execute_permissioned_actions.go
@@ -21,7 +21,7 @@ func ExecutePermissionedActionSpecification(ctx context.Context, t *testing.T, e
 	// create_user is public, list_users is private
 	t.Logf("Executing permissioned action specification")
 
-	db := SchemaLoader.Load(t)
+	db := SchemaLoader.Load(t, schema_testdb)
 	dbID := GenerateSchemaId(db.Owner, db.Name)
 
 	createUserQueryInputs := []map[string]any{

--- a/test/specifications/execute_update_query.go
+++ b/test/specifications/execute_update_query.go
@@ -12,7 +12,7 @@ import (
 func ExecuteDBUpdateSpecification(ctx context.Context, t *testing.T, execute ExecuteQueryDsl) {
 	t.Logf("Executing update action specification")
 	// Given a valid database schema
-	db := SchemaLoader.Load(t)
+	db := SchemaLoader.Load(t, schema_testdb)
 	dbID := GenerateSchemaId(db.Owner, db.Name)
 	actionName := "update_username"
 	userQ := userTable{

--- a/test/specifications/schemas.go
+++ b/test/specifications/schemas.go
@@ -1,0 +1,28 @@
+package specifications
+
+const prependedFilePath = "./test-data/"
+
+func getSchemaFilePath(schemaName string) string {
+	return prependedFilePath + schemaName + ".kf"
+}
+
+type testSchema struct {
+	FileName string
+}
+
+func (s *testSchema) GetFilePath() string {
+	return getSchemaFilePath(s.FileName)
+}
+
+var (
+	schema_testdb = &testSchema{
+		FileName: "test_db",
+	}
+	schema_invalidSQLSyntax = &testSchema{
+		FileName: "invalid_sql_syntax",
+	}
+
+	schema_invalidSQLSyntaxFixed = &testSchema{
+		FileName: "invalid_sql_syntax_fixed",
+	}
+)

--- a/test/specifications/vars.go
+++ b/test/specifications/vars.go
@@ -1,7 +1,7 @@
 package specifications
 
 var (
-	SchemaLoader DatabaseSchemaLoader = &FileDatabaseSchemaLoader{FilePath: ""}
+	SchemaLoader DatabaseSchemaLoader = &FileDatabaseSchemaLoader{}
 )
 
 func SetSchemaLoader(loader DatabaseSchemaLoader) {


### PR DESCRIPTION
Luke had found a bug where, if he deployed a schema with invalid SQL, it would reach the server and fail, but remain registered as an active schema in the server.  This should be fixed now.

I also added an integration test to test for this since this has happened before.