### PR TITLE
feat(sql-parser): support sql scalar function `error`

### DIFF
--- a/pkg/engine/sqlparser/parser_test.go
+++ b/pkg/engine/sqlparser/parser_test.go
@@ -681,6 +681,8 @@ func TestParseRawSQL_syntax_valid(t *testing.T) {
 		{"expr function coalesce", "select coalesce(1,2)",
 			genSimpleFunctionSelectTree(&tree.FunctionCOALESCE,
 				genLiteralExpression("1"), genLiteralExpression("2"))},
+		{"expr function error", "select error('error message')",
+			genSimpleFunctionSelectTree(&tree.FunctionERROR, genLiteralExpression(`'error message'`))},
 		{"expr function format", `select format('%d',2)`,
 			genSimpleFunctionSelectTree(&tree.FunctionFORMAT,
 				genLiteralExpression(`'%d'`), genLiteralExpression("2"))},

--- a/pkg/engine/sqlparser/visitor.go
+++ b/pkg/engine/sqlparser/visitor.go
@@ -118,7 +118,7 @@ func (v *KFSqliteVisitor) visitExpr(ctx sqlgrammar.IExprContext) tree.Expression
 		return nil
 	}
 
-	// order is important, map to expr definition in Antlr kf-sqlgrammar(not exactly)
+	// order is important, map to expr definition in Antlr sql-grammar(not exactly)
 	switch {
 	// primary expressions
 	case ctx.Literal_value() != nil:

--- a/pkg/engine/tree/functions.go
+++ b/pkg/engine/tree/functions.go
@@ -86,6 +86,11 @@ var (
 		FunctionName: "coalesce",
 		Min:          2,
 	}}
+	FunctionERROR = ScalarFunction{AnySQLFunction{
+		FunctionName: "error",
+		Min:          1,
+		Max:          1,
+	}}
 	FunctionFORMAT = ScalarFunction{AnySQLFunction{
 		FunctionName: "format",
 		Min:          1,
@@ -197,6 +202,7 @@ var SQLFunctions = map[string]SQLFunction{
 	// Scalar functions
 	"abs":      &FunctionABS,
 	"coalesce": &FunctionCOALESCE,
+	"error":    &FunctionERROR,
 	"format":   &FunctionFORMAT,
 	"glob":     &FunctionGLOB,
 	"hex":      &FunctionHEX,


### PR DESCRIPTION
support sql scalar function `error`.
example:  `select error('some error msg')`