### PR TITLE
replace deprecated rand.Seed with crypto/rand impl

### DIFF
--- a/pkg/sql/driver/savepoint.go
+++ b/pkg/sql/driver/savepoint.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"math/rand"
-	"time"
 
 	"github.com/kwilteam/go-sqlite"
+	"github.com/kwilteam/kwil-db/pkg/utils/random"
+
 	"go.uber.org/zap"
 )
 
@@ -119,9 +119,7 @@ func (s *Savepoint) ApplyChangeset(changeset *bytes.Buffer) error {
 var letterRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
 var alphanumericRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
+var rnd = random.New()
 
 func randomSavepointName(length int) string {
 	if length < 2 {
@@ -130,11 +128,11 @@ func randomSavepointName(length int) string {
 
 	result := make([]rune, length)
 	// First character must be a letter
-	result[0] = letterRunes[rand.Intn(len(letterRunes))]
+	result[0] = letterRunes[rnd.Intn(len(letterRunes))]
 
 	// Rest of the characters can be alphanumeric
 	for i := 1; i < length; i++ {
-		result[i] = alphanumericRunes[rand.Intn(len(alphanumericRunes))]
+		result[i] = alphanumericRunes[rnd.Intn(len(alphanumericRunes))]
 	}
 
 	return string(result)

--- a/pkg/sql/sqlite/savepoint.go
+++ b/pkg/sql/sqlite/savepoint.go
@@ -1,8 +1,7 @@
 package sqlite
 
 import (
-	"math/rand"
-	"time"
+	"github.com/kwilteam/kwil-db/pkg/utils/random"
 )
 
 func (c *Connection) Savepoint() (*Savepoint, error) {
@@ -54,9 +53,7 @@ func (sp *Savepoint) Rollback() error {
 var letterRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
 var alphanumericRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
+var rnd = random.New()
 
 func randomSavepointName(length int) string {
 	if length < 2 {
@@ -65,11 +62,11 @@ func randomSavepointName(length int) string {
 
 	result := make([]rune, length)
 	// First character must be a letter
-	result[0] = letterRunes[rand.Intn(len(letterRunes))]
+	result[0] = letterRunes[rnd.Intn(len(letterRunes))]
 
 	// Rest of the characters can be alphanumeric
 	for i := 1; i < length; i++ {
-		result[i] = alphanumericRunes[rand.Intn(len(alphanumericRunes))]
+		result[i] = alphanumericRunes[rnd.Intn(len(alphanumericRunes))]
 	}
 
 	return string(result)

--- a/pkg/utils/random/crypto.go
+++ b/pkg/utils/random/crypto.go
@@ -1,0 +1,38 @@
+package random
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
+)
+
+// Source is a cryptographically secure random number source that satisfies the
+// math/rand.Source and math/rand.Source64 interfaces, which are required to
+// make a new math/rand.Rand instance that uses crypto/rand. See also New, for a
+// new Rand instance using this source.
+var Source source
+
+type source struct{}
+
+func (source) Uint64() uint64 {
+	var b [8]byte
+	crand.Read(b[:])
+	return binary.LittleEndian.Uint64(b[:])
+}
+
+func (cs source) Int63() int64 {
+	return int64(cs.Uint64() & ^uint64(1<<63)) // clear top bit, mask with (1<<63 - 1)
+}
+
+func (source) Seed(int64) {} // crypto/rand source is not seeded
+
+var _ rand.Source = Source
+var _ rand.Source64 = Source
+var _ rand.Source = &Source
+var _ rand.Source64 = &Source
+
+// New creates a new math/rand.Rand number generator that uses the
+// cryptographically secure source of randomness.
+func New() *rand.Rand {
+	return rand.New(Source)
+}


### PR DESCRIPTION
Another minor change as I go through the kwil-db code...

See deprecation message and note about Go 1.20 changes: https://pkg.go.dev/math/rand#Seed

`math/rand.Seed` is deprecated.  The `math/rand` package's source automatically seeds randomly on initialization, hence the deprecation.

This switches to a small wrapper around `crypto/rand.Read` to make a `math/rand.Source` required to instantiate a `*math/rand.Rand` with the source from the `crypto/rand`. package