### PR TITLE
added backwards compatibility for schemas that use the old action versions

### DIFF
--- a/pkg/engine/db/README.md
+++ b/pkg/engine/db/README.md
@@ -1,0 +1,27 @@
+# Metadata Store
+
+The metadata store is responsible for storing, retrieving, and upgrading database metadata.
+
+This document tracks the types of metadata and their changes (reflected in migrations)
+
+## Types
+
+- Table: a table in a database
+- Procedure: a predefined set of statements to be executed (formerly known as "action")
+- Extension: an imported / used extension within a database
+
+### Table
+
+Current Version: 1
+
+### Procedure
+
+Current Version: 2
+
+#### Changelog
+
+- Version 2: Changed the meaning of `public/private`.  `public=true` still means the same thing, however `public=false` now means that a [procedure] is private and cannot be called externally.  Previously, `public=false` meant that a procedure could only be called by the database owner.  This has been replaced with an `owner` modifier.
+
+### Extension
+
+Current Version 1

--- a/pkg/engine/db/db.go
+++ b/pkg/engine/db/db.go
@@ -17,15 +17,15 @@ import (
 )
 
 type DB struct {
-	sqldb SqlDB
+	Sqldb SqlDB
 }
 
 func (d *DB) Close() error {
-	return d.sqldb.Close()
+	return d.Sqldb.Close()
 }
 
 func (d *DB) Delete() error {
-	return d.sqldb.Delete()
+	return d.Sqldb.Delete()
 }
 
 func (d *DB) Prepare(ctx context.Context, query string) (*PreparedStatement, error) {
@@ -56,7 +56,7 @@ func (d *DB) Prepare(ctx context.Context, query string) (*PreparedStatement, err
 		return nil, err
 	}
 
-	prepStmt, err := d.sqldb.Prepare(generatedSql)
+	prepStmt, err := d.Sqldb.Prepare(generatedSql)
 	if err != nil {
 		return nil, err
 	}
@@ -68,16 +68,16 @@ func (d *DB) Prepare(ctx context.Context, query string) (*PreparedStatement, err
 }
 
 func (d *DB) Query(ctx context.Context, stmt string, args map[string]any) ([]map[string]any, error) {
-	return d.sqldb.Query(ctx, stmt, args)
+	return d.Sqldb.Query(ctx, stmt, args)
 }
 
 func (d *DB) Savepoint() (sql.Savepoint, error) {
-	return d.sqldb.Savepoint()
+	return d.Sqldb.Savepoint()
 }
 
 func NewDB(ctx context.Context, sqldb SqlDB) (*DB, error) {
 	db := &DB{
-		sqldb: sqldb,
+		Sqldb: sqldb,
 	}
 
 	err := db.initMetadataTable(ctx)

--- a/pkg/engine/db/db_test.go
+++ b/pkg/engine/db/db_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kwilteam/kwil-db/pkg/engine/db/test"
 	"github.com/kwilteam/kwil-db/pkg/engine/types"
 	"github.com/kwilteam/kwil-db/pkg/engine/types/testdata"
+	"github.com/kwilteam/kwil-db/pkg/sql"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -197,4 +198,35 @@ func Test_Prepare(t *testing.T) {
 			assert.Equal(t, tt.wantErr, err != nil)
 		})
 	}
+}
+
+type baseMockDatastore struct {
+}
+
+func (b *baseMockDatastore) Close() error {
+	return nil
+}
+
+func (b *baseMockDatastore) Delete() error {
+	return nil
+}
+
+func (b *baseMockDatastore) Execute(ctx context.Context, stmt string, args map[string]any) error {
+	return nil
+}
+
+func (b *baseMockDatastore) Prepare(stmt string) (sql.Statement, error) {
+	return nil, nil
+}
+
+func (b *baseMockDatastore) Query(ctx context.Context, query string, args map[string]any) ([]map[string]any, error) {
+	return nil, nil
+}
+
+func (b *baseMockDatastore) Savepoint() (sql.Savepoint, error) {
+	return nil, nil
+}
+
+func (b *baseMockDatastore) TableExists(ctx context.Context, table string) (bool, error) {
+	return false, nil
 }

--- a/pkg/engine/db/persist.go
+++ b/pkg/engine/db/persist.go
@@ -9,7 +9,7 @@ import (
 
 const (
 	tableVersion     = 1
-	procedureVersion = 1
+	procedureVersion = 2
 	extensionVersion = 1
 )
 
@@ -20,7 +20,7 @@ func (d *DB) persistTableMetadata(ctx context.Context, table *types.Table) error
 		return err
 	}
 
-	return d.persistVersionedMetadata(ctx, table.Name, metadataTypeTable, &versionedMetadata{
+	return d.persistVersionedMetadata(ctx, table.Name, metadataTypeTable, &VersionedMetadata{
 		Version: tableVersion,
 		Data:    bts,
 	})
@@ -43,7 +43,7 @@ func (d *DB) StoreProcedure(ctx context.Context, procedure *types.Procedure) err
 		return err
 	}
 
-	return d.persistVersionedMetadata(ctx, procedure.Name, metadataTypeProcedure, &versionedMetadata{
+	return d.persistVersionedMetadata(ctx, procedure.Name, metadataTypeProcedure, &VersionedMetadata{
 		Version: procedureVersion,
 		Data:    bts,
 	})
@@ -56,7 +56,7 @@ func (d *DB) ListProcedures(ctx context.Context) ([]*types.Procedure, error) {
 		return nil, err
 	}
 
-	return decodeMetadata[types.Procedure](meta)
+	return decodeVersionedProcedures(meta)
 }
 
 // StoreExtension stores an extension in the database
@@ -66,7 +66,7 @@ func (d *DB) StoreExtension(ctx context.Context, extension *types.Extension) err
 		return err
 	}
 
-	return d.persistVersionedMetadata(ctx, extension.Alias, metadataTypeExtension, &versionedMetadata{
+	return d.persistVersionedMetadata(ctx, extension.Alias, metadataTypeExtension, &VersionedMetadata{
 		Version: extensionVersion,
 		Data:    bts,
 	})

--- a/pkg/engine/db/procedures.go
+++ b/pkg/engine/db/procedures.go
@@ -1,0 +1,65 @@
+package db
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kwilteam/kwil-db/pkg/engine/types"
+)
+
+/*
+	Typesit could be worth doing a migration instead of upgrading on the fly
+*/
+
+func decodeVersionedProcedures(meta []*VersionedMetadata) ([]*types.Procedure, error) {
+	procedures := make([]*types.Procedure, len(meta))
+	for i, proc := range meta {
+		procedure, err := decodeProcedure(proc.Version, proc.Data)
+		if err != nil {
+			return nil, err
+		}
+
+		procedures[i] = procedure
+	}
+
+	return procedures, nil
+}
+
+func decodeProcedure(version int, procedureBytes []byte) (*types.Procedure, error) {
+	procedure := &types.Procedure{}
+	err := json.Unmarshal(procedureBytes, procedure)
+	if err != nil {
+		return nil, err
+	}
+
+	for {
+		switch version {
+		case 1:
+			procedure = upgradeProcedure_v1_To_v2(procedure)
+			version++
+		case procedureVersion:
+			return procedure, nil
+		default:
+			return nil, fmt.Errorf("unknown procedure version %d", version)
+		}
+	}
+}
+
+// upgradeProcedure_v1_To_v2 upgrades a procedure from version 1 to version
+// If a v1 procedure is private, we change it to public and add an owner modifier.
+func upgradeProcedure_v1_To_v2(oldProc *types.Procedure) *types.Procedure {
+	newProc := &types.Procedure{
+		Name:       oldProc.Name,
+		Args:       oldProc.Args,
+		Statements: oldProc.Statements,
+		Public:     oldProc.Public,
+		Modifiers:  oldProc.Modifiers,
+	}
+
+	if !oldProc.Public {
+		newProc.EnsureContainsModifier(types.ModifierOwner)
+		newProc.Public = true
+	}
+
+	return newProc
+}

--- a/pkg/engine/db/table.go
+++ b/pkg/engine/db/table.go
@@ -10,7 +10,7 @@ import (
 
 // CreateTable creates a new table and persists the metadata to the database
 func (d *DB) CreateTable(ctx context.Context, table *types.Table) error {
-	savepoint, err := d.sqldb.Savepoint()
+	savepoint, err := d.Sqldb.Savepoint()
 	if err != nil {
 		return fmt.Errorf("failed to create savepoint: %w", err)
 	}
@@ -36,14 +36,14 @@ func (d *DB) deployTable(ctx context.Context, table *types.Table) error {
 		return err
 	}
 
-	savepoint, err := d.sqldb.Savepoint()
+	savepoint, err := d.Sqldb.Savepoint()
 	if err != nil {
 		return err
 	}
 	defer savepoint.Rollback()
 
 	for _, ddlStmt := range ddlStmts {
-		err = d.sqldb.Execute(ctx, ddlStmt, nil)
+		err = d.Sqldb.Execute(ctx, ddlStmt, nil)
 		if err != nil {
 			return err
 		}

--- a/pkg/engine/db/upgrade_test.go
+++ b/pkg/engine/db/upgrade_test.go
@@ -1,0 +1,163 @@
+package db_test
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/kwilteam/kwil-db/pkg/engine/db"
+	"github.com/kwilteam/kwil-db/pkg/engine/types"
+	"github.com/stretchr/testify/assert"
+)
+
+// TODO: test storing old versions and upgrading
+
+func Test_UpgradingProcedures(t *testing.T) {
+
+	type testCase struct {
+		name              string
+		storedProcedure   versionedProcedure
+		returnedProcedure *types.Procedure
+	}
+
+	testCases := []testCase{
+		{
+			name: "stored v1",
+			storedProcedure: versionedProcedure{
+				Version: 1,
+				Procedure: &types.Procedure{
+					Name: "test_v1",
+					Args: []string{
+						"$arg1",
+						"$arg2",
+					},
+					Statements: []string{
+						"SELECT * FROM users WHERE id = $arg1",
+					},
+					Public: false,
+				},
+			},
+			returnedProcedure: &types.Procedure{
+				Name: "test_v1",
+				Args: []string{
+					"$arg1",
+					"$arg2",
+				},
+				Statements: []string{
+					"SELECT * FROM users WHERE id = $arg1",
+				},
+				Public: true,
+				Modifiers: []types.Modifier{
+					types.ModifierOwner,
+				},
+			},
+		},
+		{
+			name: "stored v2",
+			storedProcedure: versionedProcedure{
+				Version: 2,
+				Procedure: &types.Procedure{
+					Name: "test_v1",
+					Args: []string{
+						"$arg1",
+						"$arg2",
+					},
+					Statements: []string{
+						"SELECT * FROM users WHERE id = $arg1",
+					},
+					Public: false,
+					Modifiers: []types.Modifier{
+						types.ModifierAuthenticated,
+					},
+				},
+			},
+			returnedProcedure: &types.Procedure{
+				Name: "test_v1",
+				Args: []string{
+					"$arg1",
+					"$arg2",
+				},
+				Statements: []string{
+					"SELECT * FROM users WHERE id = $arg1",
+				},
+				Public: false,
+				Modifiers: []types.Modifier{
+					types.ModifierAuthenticated,
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			datastore := &procedureStore{
+				procedures: []*versionedProcedure{
+					&tc.storedProcedure,
+				},
+			}
+			database := db.DB{
+				Sqldb: datastore,
+			}
+
+			ctx := context.Background()
+			returnedProcedures, err := database.ListProcedures(ctx)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if len(returnedProcedures) != 1 {
+				t.Fatalf("expected 1 procedure, got %v", len(returnedProcedures))
+			}
+
+			returned := returnedProcedures[0]
+
+			assert.Equal(t, *tc.returnedProcedure, *returned)
+		})
+	}
+}
+
+// we only need to implement Query
+type procedureStore struct {
+	procedures []*versionedProcedure
+	baseMockDatastore
+}
+
+func (m procedureStore) Query(ctx context.Context, query string, args map[string]interface{}) ([]map[string]interface{}, error) {
+	/*
+		needs to return map[string]any{
+			"identifier": "procedure_name",
+			"content":    json.Marshal(&db.VersionMetadata{Version: int64(version), Data: json.Marshal(&types.Prrocedure{})}),
+		}
+	*/
+
+	returnVals := []map[string]interface{}{}
+
+	for _, procedure := range m.procedures {
+		serializedProc, err := json.Marshal(procedure.Procedure)
+		if err != nil {
+			return nil, err
+		}
+
+		dbVersionedProcedure := &db.VersionedMetadata{
+			Version: procedure.Version,
+			Data:    serializedProc,
+		}
+
+		contentBytes, err := json.Marshal(dbVersionedProcedure)
+		if err != nil {
+			return nil, err
+		}
+
+		returnVals = append(returnVals, map[string]interface{}{
+			"identifier": procedure.Procedure.Name,
+			"content":    contentBytes,
+		})
+	}
+
+	return returnVals, nil
+}
+
+type versionedProcedure struct {
+	Version   int
+	Procedure *types.Procedure
+}

--- a/pkg/engine/types/procedure.go
+++ b/pkg/engine/types/procedure.go
@@ -52,3 +52,16 @@ func (p *Procedure) IsOwnerOnly() bool {
 
 	return false
 }
+
+func (p *Procedure) EnsureContainsModifier(mod Modifier) {
+	contains := false
+	for _, m := range p.Modifiers {
+		if m == mod {
+			contains = true
+		}
+	}
+
+	if !contains {
+		p.Modifiers = append(p.Modifiers, mod)
+	}
+}


### PR DESCRIPTION
Any old schemas deployed that use `private` actions as a way to grant access to only the owner (instead of the new functionality that involves scoping) will automatically be forward compatible.