### PR TITLE
add back test DB methods that are needed for teardown

### DIFF
--- a/pkg/serialize/schema.go
+++ b/pkg/serialize/schema.go
@@ -347,15 +347,6 @@ func convertIndexesToDto(indexes []*Index) []*engineTypes.Index {
 	return entityIndexes
 }
 
-func UnmarshalSchema(b []byte) (*Schema, error) {
-	var schema Schema
-	err := json.Unmarshal(b, &schema)
-	if err != nil {
-		return nil, err
-	}
-	return &schema, nil
-}
-
 func UnmarshalDatasetIdentifier(b []byte) (*DatasetIdentifier, error) {
 	var dsIdent DatasetIdentifier
 	err := json.Unmarshal(b, &dsIdent)

--- a/pkg/sql/testing/testing.go
+++ b/pkg/sql/testing/testing.go
@@ -40,3 +40,12 @@ func (w *wrappedSqliteClient) Savepoint() (sql.Savepoint, error) {
 func (w *wrappedSqliteClient) CreateSession() (sql.Session, error) {
 	return w.SqliteClient.CreateSession()
 }
+
+// we need to get rid of close and delete since the teardown function will handle that
+func (w *wrappedSqliteClient) Close() error {
+	return nil
+}
+
+func (w *wrappedSqliteClient) Delete() error {
+	return nil
+}

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -6,14 +6,11 @@ import (
 	"fmt"
 	"path/filepath"
 	"testing"
-	"time"
 
 	"github.com/kwilteam/kwil-db/pkg/log"
 	"github.com/kwilteam/kwil-db/pkg/utils"
 	"github.com/kwilteam/kwil-db/test/acceptance"
 	"github.com/kwilteam/kwil-db/test/specifications"
-
-	"github.com/stretchr/testify/assert"
 )
 
 var remote = flag.Bool("remote", false, "run tests against remote environment")
@@ -55,8 +52,10 @@ func TestKwildAcceptance(t *testing.T) {
 
 			// setup
 
-			driver, chainDeployer, runningCfg := acceptance.GetDriver(ctx, t, c.driverType, cfg, tLogger, path)
+			driver, runningCfg := acceptance.GetDriver(ctx, t, c.driverType, cfg, tLogger, path)
 			secondDriver := acceptance.NewClient(ctx, t, c.driverType, runningCfg, tLogger)
+
+			/* xxx
 
 			// NOTE: only local env test, public network test takes too long
 			// thus here test assume user is funded
@@ -81,6 +80,8 @@ func TestKwildAcceptance(t *testing.T) {
 
 			// chain sync, wait kwil to register user
 			time.Sleep(cfg.ChainSyncWaitTime)
+
+			*/
 
 			// running forever for local development
 			if *dev {


### PR DESCRIPTION
This is replacing https://github.com/kwilteam/kwil-db/pull/170 since @brennanjl got the ABCI app in a runnable state in https://github.com/kwilteam/kwil-db/pull/172.

Here I'm just fixing a few things that were either unaddressed by or regressed in https://github.com/kwilteam/kwil-db/pull/169

This adds back a couple of methods on the wrappedSqliteClient in pkg/sql/testing that were there to prevent a panic due to double closing. These were accidentally removed in a previous commit.

This also removes an exported function that was mistakenly added in the last commit as well, UnmarshalSchema. There is already a deserialize method that also converts to the engine/type.Schema type.

Lastly, it fixes a compile error on one acceptance test file. Gavin is actually fixing them properly, but the intent of the last commit was to stop all the build errors.