### PR TITLE
remove cometbft awareness from txsvc

### DIFF
--- a/internal/controller/grpc/txsvc/v1/broadcast.go
+++ b/internal/controller/grpc/txsvc/v1/broadcast.go
@@ -2,13 +2,11 @@ package txsvc
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
 
-	"github.com/cometbft/cometbft/crypto/tmhash"
 	txpb "github.com/kwilteam/kwil-db/api/protobuf/tx/v1"
 	"github.com/kwilteam/kwil-db/pkg/crypto"
 	kTx "github.com/kwilteam/kwil-db/pkg/tx"
@@ -26,13 +24,7 @@ func (s *Service) Broadcast(ctx context.Context, req *txpb.BroadcastRequest) (*t
 		return nil, status.Errorf(codes.Unauthenticated, "failed to verify transaction: %s", err)
 	}
 
-	bts, err := json.Marshal(tx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to serialize transaction data: %w", err)
-	}
-	hash := tmhash.Sum(bts)
-
-	_, err = s.cometBftClient.BroadcastTxAsync(ctx, bts)
+	hash, err := s.chainClient.BroadcastTxAsync(ctx, tx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to broadcast transaction with error:  %s", err)
 	}

--- a/internal/controller/grpc/txsvc/v1/service.go
+++ b/internal/controller/grpc/txsvc/v1/service.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"math/big"
 
-	ctypes "github.com/cometbft/cometbft/rpc/core/types"
-	"github.com/cometbft/cometbft/types"
 	txpb "github.com/kwilteam/kwil-db/api/protobuf/tx/v1"
 	"github.com/kwilteam/kwil-db/pkg/balances"
 	engineTypes "github.com/kwilteam/kwil-db/pkg/engine/types"
@@ -21,15 +19,15 @@ type Service struct {
 	engine       EngineReader
 	accountStore AccountReader
 
-	cometBftClient BlockchainBroadcaster
+	chainClient BlockchainBroadcaster
 }
 
-func NewService(engine EngineReader, accountStore AccountReader, cometBftClient BlockchainBroadcaster, opts ...TxSvcOpt) *Service {
+func NewService(engine EngineReader, accountStore AccountReader, chainClient BlockchainBroadcaster, opts ...TxSvcOpt) *Service {
 	s := &Service{
-		log:            log.NewNoOp(),
-		engine:         engine,
-		accountStore:   accountStore,
-		cometBftClient: cometBftClient,
+		log:          log.NewNoOp(),
+		engine:       engine,
+		accountStore: accountStore,
+		chainClient:  chainClient,
 	}
 
 	for _, opt := range opts {
@@ -54,7 +52,5 @@ type AccountReader interface {
 }
 
 type BlockchainBroadcaster interface {
-	// TODO: this should be refactored to: BroadcastTxAsync(ctx context.Context, tx tx.Transaction) error
-	// this will remove abci and cometbft as a dependency from this package, and functionally works the same
-	BroadcastTxAsync(ctx context.Context, tx types.Tx) (*ctypes.ResultBroadcastTx, error)
+	BroadcastTxAsync(ctx context.Context, tx *tx.Transaction) (hash []byte, err error)
 }


### PR DESCRIPTION
@brennanjl the latest dep injection commit is looking nice so far.  I noticed one bug, and I addressed the broadcaster interface TODO here.  I'm not sure all the `build*` functions really need the entire `coreDependencies` struct as an arg, but it works.

This wraps the cometbft client with a more generic definition of the `BroadcastTxAsync` that uses Kwil types.
`txsvc` doesn't use cometbft packages anymore.

This also fixes a bug in app/kwild/server where the grpc service pointer was always set to nil in the Service instance.