### PR TITLE
replace deprecated rand.Seed with crypto/rand impl

### DIFF
--- a/pkg/sql/sqlite/savepoint.go
+++ b/pkg/sql/sqlite/savepoint.go
@@ -1,8 +1,7 @@
 package sqlite
 
 import (
-	"math/rand"
-	"time"
+	"github.com/kwilteam/kwil-db/pkg/utils/random"
 )
 
 func (c *Connection) Savepoint() (*Savepoint, error) {
@@ -54,9 +53,7 @@ func (sp *Savepoint) Rollback() error {
 var letterRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
 var alphanumericRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
 
-func init() {
-	rand.Seed(time.Now().UnixNano())
-}
+var rnd = random.New()
 
 func randomSavepointName(length int) string {
 	if length < 2 {
@@ -65,11 +62,11 @@ func randomSavepointName(length int) string {
 
 	result := make([]rune, length)
 	// First character must be a letter
-	result[0] = letterRunes[rand.Intn(len(letterRunes))]
+	result[0] = letterRunes[rnd.Intn(len(letterRunes))]
 
 	// Rest of the characters can be alphanumeric
 	for i := 1; i < length; i++ {
-		result[i] = alphanumericRunes[rand.Intn(len(alphanumericRunes))]
+		result[i] = alphanumericRunes[rnd.Intn(len(alphanumericRunes))]
 	}
 
 	return string(result)

--- a/pkg/utils/random/crypto.go
+++ b/pkg/utils/random/crypto.go
@@ -1,0 +1,38 @@
+package random
+
+import (
+	crand "crypto/rand"
+	"encoding/binary"
+	"math/rand"
+)
+
+// Source is a cryptographically secure random number source that satisfies the
+// math/rand.Source and math/rand.Source64 interfaces, which are required to
+// make a new math/rand.Rand instance that uses crypto/rand. See also New, for a
+// new Rand instance using this source.
+var Source source
+
+type source struct{}
+
+func (source) Uint64() uint64 {
+	var b [8]byte
+	crand.Read(b[:])
+	return binary.LittleEndian.Uint64(b[:])
+}
+
+func (cs source) Int63() int64 {
+	return int64(cs.Uint64() & ^uint64(1<<63)) // clear top bit, mask with (1<<63 - 1)
+}
+
+func (source) Seed(int64) {} // crypto/rand source is not seeded
+
+var _ rand.Source = Source
+var _ rand.Source64 = Source
+var _ rand.Source = &Source
+var _ rand.Source64 = &Source
+
+// New creates a new math/rand.Rand number generator that uses the
+// cryptographically secure source of randomness.
+func New() *rand.Rand {
+	return rand.New(Source)
+}


### PR DESCRIPTION
Reopening Jon's PR (apologies, I totally dropped the ball on merging this).  I went to look for it to use it within the new transactions and could not find it!

See deprecation message and note about Go 1.20 changes: https://pkg.go.dev/math/rand#Seed