### PR TITLE
implemented fix for non-determinism in account-stores SQL schema

### DIFF
--- a/pkg/balances/sql.go
+++ b/pkg/balances/sql.go
@@ -35,17 +35,11 @@ func (a *AccountStore) prepareStatements() error {
 const (
 	sqlInitTables = `
 CREATE TABLE IF NOT EXISTS accounts (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
-	address TEXT NOT NULL UNIQUE,
+	address TEXT PRIMARY KEY,
 	balance TEXT NOT NULL,
 	nonce INTEGER NOT NULL
-	);
-
-CREATE TABLE IF NOT EXISTS chains (
-	id INTEGER PRIMARY KEY AUTOINCREMENT,
-	chain_code INTEGER NOT NULL UNIQUE,
-	height INTEGER NOT NULL
-);`
+	) WITHOUT ROWID, STRICT;
+	`
 )
 
 func getTableInits() []string {


### PR DESCRIPTION
I fixed the issue discussed on Slack where:
- auto-increment is non-deterministic
- SQLite's ROWIDs are non-deterministic
- SQLite's flexible typing can get us into trouble

I made the wallet address the primary key here; it's not exactly the best solution, but there is also no way in which it would change.  If we were to migrate accounts to a KV store (which we can do easily with my other PR), the account would certainly be the key.  Given these two things, I figured it was ok to make the primary key the address.