### PR TITLE
CI: narrow target of build and lint

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,7 +6,8 @@ on:
   workflow_dispatch:
   push:
     branches:
-      - "dev"
+      - dev
+      - main
 
 jobs:
   unit-test:
@@ -48,9 +49,9 @@ jobs:
         run: |
           task pb:compile:v1
 
-      - name: Compile all packages
+      - name: Compile packages, apps, and specs
         run: |
-          go build ./...
+          go build ./pkg/... ./cmd/... ./test/specifications/...
 
       - name: Lint
         uses: golangci/golangci-lint-action@v3
@@ -58,12 +59,7 @@ jobs:
           install-mode: "binary"
           version: "latest"
           skip-pkg-cache: true
-          # args: --timeout=30m --config=.golangci.yml --issues-exit-code=0 
-
-      - name: Generate go vendor
-        #for faster builds and private repos, need to run this after pb:compile:v1
-        run: |
-          task vendor
+          args: --timeout=10m --config=.golangci.yml ./pkg/... ./cmd/... ./test/specifications/...
 
       - name: Run unit test
         run: |

--- a/.github/workflows/on-main.yml
+++ b/.github/workflows/on-main.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
-          go-version: '1.19.0'
+          go-version: '1.20'
           cache: true
 
       - name: Install dependencies

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -140,9 +140,7 @@ tasks:
   test:unit:
     desc: Run unit tests
     cmds:
-      - task vendor
-      - go test `go list ./... | grep -v /kwil-db\/test/` -count=1
-      - task vendor:clean
+      - go test $(go list ./... | grep -v /kwil-db\/test/) -count=1
 
   test:it:
     desc: Run integration tests


### PR DESCRIPTION
The build cache seems to be too big, and uncached lint taking too long. This attempts to improve that by targeting only:
- ./pkg/...
- ./cmd/...
- ./test/specifications/... Notably that leaves out the a bunch of integ/accept test drivers.