### PR TITLE
not using ~ folder when run kwild with ROOT_DIR not set

### DIFF
--- a/internal/app/kwild/config/variables.go
+++ b/internal/app/kwild/config/variables.go
@@ -195,7 +195,13 @@ var (
 		Field:   "RootDir",
 		Setter: func(val any) (any, error) {
 			if val == nil {
-				return filepath.Clean("~/.kwil"), nil
+				home, err := os.UserHomeDir()
+				if err != nil {
+					// if `home` env(depends on OS) is not set, complain
+					// we can use '/tmp/.kwil' or '.kwil' in this case, but it's not a good idea
+					return "", err
+				}
+				return filepath.Join(home, ".kwil"), err
 			}
 
 			str, err := conv.String(val)


### PR DESCRIPTION
If run kwild without any flags or configurations, it will generate a `~` folder in current folder. 

This is kind dangerous, you could potentially delete you home dir (yeah i did once) 