### PR TITLE
config: fix config.json path issues

### DIFF
--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -1,8 +1,8 @@
 package config
 
 import (
-	"fmt"
 	"os"
+	"path/filepath"
 
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
@@ -24,9 +24,9 @@ func init() {
 		dirname = "/tmp"
 	}
 
-	configPath := fmt.Sprintf("%s/.kwil_cli/", dirname)
+	configPath := filepath.Join(dirname, ".kwil_cli")
 
-	DefaultConfigFile = fmt.Sprintf("%s/config.json", configPath)
+	DefaultConfigFile = filepath.Join(configPath, "config.json")
 
 	viper.AddConfigPath(configPath)
 	viper.AutomaticEnv()

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -4,10 +4,11 @@ import (
 	"crypto/sha256"
 	"io"
 	"os"
+	"path/filepath"
 )
 
 func CreateDirIfNeeded(path string) error {
-	return os.MkdirAll(path, os.ModePerm)
+	return os.MkdirAll(path, 0755)
 }
 
 func DeleteDir(path string) error {
@@ -15,7 +16,8 @@ func DeleteDir(path string) error {
 }
 
 func ReadOrCreateFile(path string, permissions int) ([]byte, error) {
-	if err := CreateDirIfNeeded(path); err != nil {
+	dir := filepath.Dir(path)
+	if err := CreateDirIfNeeded(dir); err != nil {
 		return nil, err
 	}
 
@@ -34,7 +36,8 @@ func ReadOrCreateFile(path string, permissions int) ([]byte, error) {
 }
 
 func CreateOrOpenFile(path string, permissions int) (*os.File, error) {
-	if err := CreateDirIfNeeded(path); err != nil {
+	dir := filepath.Dir(path)
+	if err := CreateDirIfNeeded(dir); err != nil {
 		return nil, err
 	}
 
@@ -104,8 +107,5 @@ func HashFile(path string) ([]byte, error) {
 
 func FileExists(path string) bool {
 	_, err := os.Stat(path)
-	if err != nil && os.IsNotExist(err) {
-		return false
-	}
-	return true
+	return !os.IsNotExist(err)
 }


### PR DESCRIPTION
With the snappshotter changes merged, kwil-cli now makes the config file incorrectly:

```
Error: failed to create or open config file: open /home/jon/.kwil_cli//config.json: is a directory
```

```
  ll ~/.kwil_cli/
total 20
drwxr-xr-x   3 jon users  4096 Aug 23 14:33 .
drwx------ 106 jon users 12288 Aug 23 14:33 ..
drwxr-xr-x   2 jon users  4096 Aug 23 14:33 config.json
```


`CreateDirIfNeeded` needs a path, not a file name.  Update both `ReadOrCreateFile` and `CreateOrOpenFile` to get the directory component of the full file path before calling `CreateDirIfNeeded`.

This also switches to using `filepath.Join` instead of `fmt.Sprintf` when generating the default config file path.