### PR TITLE
utils: clean up and remove stdlib duplication

### DIFF
--- a/cmd/kwil-cli/config/config.go
+++ b/cmd/kwil-cli/config/config.go
@@ -59,7 +59,7 @@ func PersistConfig(conf *KwilCliConfig) error {
 		return fmt.Errorf("failed to marshal config: %w", err)
 	}
 
-	file, err := utils.CreateOrOpenFile(DefaultConfigFile, os.O_CREATE|os.O_RDWR)
+	file, err := utils.CreateOrOpenFile(DefaultConfigFile)
 	if err != nil {
 		return fmt.Errorf("failed to create or open config file: %w", err)
 	}
@@ -78,7 +78,7 @@ func PersistConfig(conf *KwilCliConfig) error {
 }
 
 func LoadPersistedConfig() (*KwilCliConfig, error) {
-	bts, err := utils.ReadOrCreateFile(DefaultConfigFile, os.O_CREATE|os.O_RDWR)
+	bts, err := utils.ReadOrCreateFile(DefaultConfigFile)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create or open config file: %w", err)
 	}

--- a/pkg/snapshots/snapshotter.go
+++ b/pkg/snapshots/snapshotter.go
@@ -200,7 +200,7 @@ func (s *Snapshotter) ListSnapshots() ([]Snapshot, error) {
 // Returns the chunk of index chunkID from snapshot at given height
 func (s *Snapshotter) LoadSnapshotChunk(height uint64, format uint32, chunkID uint32) ([]byte, error) {
 	chunkFile := s.chunkFilePath(chunkID)
-	chunk, err := utils.ReadFile(chunkFile)
+	chunk, err := os.ReadFile(chunkFile)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/snapshots/utils.go
+++ b/pkg/snapshots/utils.go
@@ -21,7 +21,7 @@ func (s *Snapshotter) writeSnapshotFile() error {
 }
 
 func (s *Snapshotter) ReadSnapshotFile(filePath string) (*Snapshot, error) {
-	bts, err := utils.ReadFile(filePath)
+	bts, err := os.ReadFile(filePath)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/utils/files.go
+++ b/pkg/utils/files.go
@@ -11,17 +11,13 @@ func CreateDirIfNeeded(path string) error {
 	return os.MkdirAll(path, 0755)
 }
 
-func DeleteDir(path string) error {
-	return os.RemoveAll(path)
-}
-
-func ReadOrCreateFile(path string, permissions int) ([]byte, error) {
+func ReadOrCreateFile(path string) ([]byte, error) {
 	dir := filepath.Dir(path)
 	if err := CreateDirIfNeeded(dir); err != nil {
 		return nil, err
 	}
 
-	file, err := os.OpenFile(path, permissions, 0644)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return nil, err
 	}
@@ -35,13 +31,13 @@ func ReadOrCreateFile(path string, permissions int) ([]byte, error) {
 	return data, nil
 }
 
-func CreateOrOpenFile(path string, permissions int) (*os.File, error) {
+func CreateOrOpenFile(path string) (*os.File, error) {
 	dir := filepath.Dir(path)
 	if err := CreateDirIfNeeded(dir); err != nil {
 		return nil, err
 	}
 
-	file, err := os.OpenFile(path, permissions, 0644)
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0644)
 	if err != nil {
 		return nil, err
 	}
@@ -49,44 +45,10 @@ func CreateOrOpenFile(path string, permissions int) (*os.File, error) {
 	return file, nil
 }
 
-func OpenFile(path string, permissions int) (*os.File, error) {
-	file, err := os.OpenFile(path, permissions, 0644)
-	if err != nil {
-		return nil, err
-	}
-
-	return file, nil
-}
-
-func ReadFile(path string) ([]byte, error) {
-	file, err := os.Open(path)
-	if err != nil {
-		return nil, err
-	}
-	defer file.Close()
-	data, err := io.ReadAll(file)
-	if err != nil {
-		return nil, err
-	}
-
-	return data, nil
-}
+// NOTE: os.ReadFile requires no wrapper.
 
 func WriteFile(path string, data []byte) error {
-	file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, 0644)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-	_, err = file.Write(data)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-func FileStat(path string) (os.FileInfo, error) {
-	return os.Stat(path)
+	return os.WriteFile(path, data, 0644)
 }
 
 func HashFile(path string) ([]byte, error) {


### PR DESCRIPTION
This cleans up the `pkg/utils` package:

- do _not_ duplicate or trivially-wrap standard library code: `ReadFile`, `DeleteFile`, `OpenFile`, `FileStat` should not exists.  Even `WriteFile`, which now just calls `os.WriteFile` with 0644 permissions, is a bit silly and it's not asking much of the caller to set the desired permissions with the standard library.
- clarify and move the *flags* argument, which (a) is not permissions, and (b) the correct flags were implied by the function e.g. `ReadOrCreateFile` implies `os.O_CREATE|os.O_RDWR` or the function is useless.