### PR TITLE
cli: remove chainClientRPCURL and fix privkey

### DIFF
--- a/cmd/kwil-cli/cmds/utils/printConfig.go
+++ b/cmd/kwil-cli/cmds/utils/printConfig.go
@@ -20,7 +20,7 @@ func printConfigCmd() *cobra.Command {
 				return err
 			}
 
-			printStruct(cfg.ToPeristedConfig())
+			printStruct(cfg.ToPersistedConfig())
 			return nil
 		},
 	}

--- a/cmd/kwil-cli/config/config.go
+++ b/cmd/kwil-cli/config/config.go
@@ -12,16 +12,18 @@ import (
 )
 
 type KwilCliConfig struct {
-	PrivateKey        crypto.PrivateKey
-	GrpcURL           string
-	ClientChainRPCURL string
+	PrivateKey crypto.PrivateKey
+	GrpcURL    string
 }
 
-func (c *KwilCliConfig) ToPeristedConfig() *kwilCliPersistedConfig {
+func (c *KwilCliConfig) ToPersistedConfig() *kwilCliPersistedConfig {
+	var privKeyHex string
+	if c.PrivateKey != nil {
+		privKeyHex = c.PrivateKey.Hex()
+	}
 	return &kwilCliPersistedConfig{
-		PrivateKey:        c.PrivateKey.Hex(),
-		GrpcURL:           c.GrpcURL,
-		ClientChainRPCURL: c.ClientChainRPCURL,
+		PrivateKey: privKeyHex,
+		GrpcURL:    c.GrpcURL,
 	}
 }
 
@@ -30,15 +32,13 @@ func (c *KwilCliConfig) Store() error {
 }
 
 type kwilCliPersistedConfig struct {
-	PrivateKey        string `json:"private_key"`
-	GrpcURL           string `json:"grpc_url"`
-	ClientChainRPCURL string `json:"client_chain_rpc_url"`
+	PrivateKey string `json:"private_key"`
+	GrpcURL    string `json:"grpc_url"`
 }
 
 func (c *kwilCliPersistedConfig) toKwilCliConfig() (*KwilCliConfig, error) {
 	kwilConfig := &KwilCliConfig{
-		GrpcURL:           c.GrpcURL,
-		ClientChainRPCURL: c.ClientChainRPCURL,
+		GrpcURL: c.GrpcURL,
 	}
 
 	privateKey, err := crypto.Secp256k1PrivateKeyFromHex(c.PrivateKey)
@@ -52,7 +52,7 @@ func (c *kwilCliPersistedConfig) toKwilCliConfig() (*KwilCliConfig, error) {
 }
 
 func PersistConfig(conf *KwilCliConfig) error {
-	persistable := conf.ToPeristedConfig()
+	persistable := conf.ToPersistedConfig()
 
 	jsonBytes, err := json.Marshal(persistable)
 	if err != nil {
@@ -108,9 +108,8 @@ func LoadCliConfig() (*KwilCliConfig, error) {
 	}
 
 	innerConf := &kwilCliPersistedConfig{
-		PrivateKey:        viper.GetString("private_key"),
-		GrpcURL:           viper.GetString("grpc_url"),
-		ClientChainRPCURL: viper.GetString("client_chain_rpc_url"),
+		PrivateKey: viper.GetString("private_key"),
+		GrpcURL:    viper.GetString("grpc_url"),
 	}
 	return innerConf.toKwilCliConfig()
 }

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -33,22 +33,18 @@ func init() {
 }
 
 const (
-	privateKeyFlag  = "private-key"
-	grpcURLFlag     = "kwil-provider"
-	clientChainFlag = "client-chain-rpc-url"
+	privateKeyFlag = "private-key"
+	grpcURLFlag    = "kwil-provider"
 
-	privateKeyEnv  = "private_key"
-	grpcURLEnv     = "grpc_url"
-	clientChainEnv = "client_chain_rpc_url"
+	privateKeyEnv = "private_key"
+	grpcURLEnv    = "grpc_url"
 )
 
 func BindGlobalFlags(fs *pflag.FlagSet) {
 	// Bind flags to environment variables
 	fs.String(privateKeyFlag, "", "The private key of the wallet that will be used for signing")
 	fs.String(grpcURLFlag, "", "The kwil provider endpoint")
-	fs.String(clientChainFlag, "", "The client chain RPC URL")
 
 	viper.BindPFlag(privateKeyEnv, fs.Lookup(privateKeyFlag))
 	viper.BindPFlag(grpcURLEnv, fs.Lookup(grpcURLFlag))
-	viper.BindPFlag(clientChainEnv, fs.Lookup(clientChainFlag))
 }


### PR DESCRIPTION
First a question: is the `.kwil-cli/config.json` going away or changing with the upcoming kwild TOML work? @charithabandi Or do we need to fix these issues as in this PR? 

This fixes some issues with kwil-cli's `configure` and `utils print-config` (sub)commands:

- remove `conf.ClientChainRPCURL`, which as of https://github.com/kwilteam/kwil-db/pull/167 does not appear to have a use
- fix handling of unsete private key to avoid panics

Working like this with `utils print-config` and `configure`:

```
$ ./kwil-cli utils print-config
Config file not found. Using default values and/or flags.  To create a config file, run 'kwil-cli configure'
PrivateKey: 
GrpcURL: 
```

```
$ ./kwil-cli configure
✔ Kwil RPC URL tcp://127.0.0.1:50051
Private Key: 91a5ad3a26dcfbf6b3214ac169fd1f9abdd9969de7fd9215ad6ecc5a85db38█
invalid private key: invalid length, need 256 bits
✔ Would you like to enter another? (y/n) y
✔ Private Key 91a5ad3a26dcfbf6b3214ac169fd1f9abdd9969de7fd9215ad6ecc5a85db38da
```

```
$ ./kwil-cli utils print-config
PrivateKey: 91a5ad3a26dcfbf6b3214ac169fd1f9abdd9969de7fd9215ad6ecc5a85db38da
GrpcURL: tcp://127.0.0.1:50051
```

These panicked before.