### PR TITLE
feat: separate default signer from private key

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -40,7 +40,7 @@ tasks:
   git:advance:
     desc: Advance git submodules to latest main revision
     cmds:
-      - git submodule update --remote
+      - git submodule update
 
   init:
     desc: Initialize the project
@@ -57,7 +57,7 @@ tasks:
     desc: Lint with golangci-lint
     deps: [pb:compile:v1]
     cmds:
-        - golangci-lint run -c .golangci.yml 
+        - golangci-lint run -c .golangci.yml --skip-dirs ./api/protobuf
 
   build:
     desc: Build cli & kwild
@@ -153,7 +153,7 @@ tasks:
         - task vendor
         - go test `go list ./... | grep -v /kwil-db\/test/` -count=1 -race
         - task vendor:clean
-  
+
   test:it:
     desc: Run integration tests
     deps:

--- a/cmd/kwil-cli/cmds/common/roundtripper.go
+++ b/cmd/kwil-cli/cmds/common/roundtripper.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
 	"github.com/kwilteam/kwil-db/pkg/client"
+	"github.com/kwilteam/kwil-db/pkg/crypto"
 )
 
 const (
@@ -30,7 +31,8 @@ func DialClient(ctx context.Context, flags uint8, fn RoundTripper) error {
 			return fmt.Errorf("private key not provided")
 		}
 
-		options = append(options, client.WithSigner(conf.PrivateKey.Signer()))
+		signer := crypto.DefaultSigner(conf.PrivateKey)
+		options = append(options, client.WithSigner(signer))
 	}
 
 	if conf.GrpcURL == "" {

--- a/pkg/crypto/README.md
+++ b/pkg/crypto/README.md
@@ -1,0 +1,45 @@
+This package contains cryptographic functions and types used in Kwil.
+
+Users of this package are expected to use:
+- `Signer` to sign message
+- `Signature` to verify message
+
+## Signer
+
+A concrete `Signer` knows how to sign the original message according to the signing schema.
+
+Currently, Kwil supports the following signing schemas:
+- `ComebftSecp256k1Signer`, cometbft secp256k1 signing schema
+- `EthPersonalSecp256k1Signer`, ethereum secp256k1 personal_sign signing schema
+- `StdEd25519Signer`, standard ed25519 signing schema
+
+## Signature
+
+A `Signature` is structure that contains the signature and the signing schema type.
+
+Currently, Kwil supports the following signing schemas:
+- `secp256k1_ct`, cometbft secp256k1 signing schema
+- `secp256k1_ep`, ethereum secp256k1 personal_sign signing schema
+- `ed25519`, standard ed25519 signing schema
+
+## Usage
+
+Here we use ed25519 as example:
+
+```go
+// sign message
+pk, err := Ed25519PrivateKeyFromHex(pvKeyHex)
+// err handling ..
+
+edSigner := &StdEd25519Signer{
+    key: pk,
+}
+
+sig, err := edSigner.SignMsg(msg)
+// err handling ..
+
+
+// verify signature
+err = sig.Verify(pk.PubKey(), msg)
+// err handling ..
+```

--- a/pkg/crypto/ed25519.go
+++ b/pkg/crypto/ed25519.go
@@ -28,26 +28,9 @@ func (pv *Ed25519PrivateKey) Hex() string {
 	return hex.EncodeToString(pv.Bytes())
 }
 
-// SignMsg signs the given message(not hashed). ed25519 is kind special that hashing is took care already.
-// Implements the Signer interface.
-func (pv *Ed25519PrivateKey) SignMsg(msg []byte) (*Signature, error) {
-	sig, err := pv.Sign(msg)
-	if err != nil {
-		return nil, err
-	}
-	return &Signature{
-		Signature: sig,
-		Type:      SIGNATURE_TYPE_ED25519,
-	}, nil
-}
-
-// Sign signs the given message(not hashed). This is only to keep the interface consistent.
+// Sign signs the given message(not hashed). This returns a standard ed25519 signature, 64 bytes long.
 func (pv *Ed25519PrivateKey) Sign(msg []byte) ([]byte, error) {
 	return ed25519.Sign(pv.key, msg), nil
-}
-
-func (pv *Ed25519PrivateKey) Signer() Signer {
-	return pv
 }
 
 func (pv *Ed25519PrivateKey) Type() KeyType {
@@ -71,6 +54,7 @@ func (pub *Ed25519PublicKey) Type() KeyType {
 }
 
 // Verify verifies the given signature against the given message(not hashed).
+// This expects a standard ed25519 signature, 64 bytes long.
 func (pub *Ed25519PublicKey) Verify(sig []byte, msg []byte) error {
 	if len(sig) != ed25519.SignatureSize {
 		return errInvalidSignature

--- a/pkg/crypto/ed25519_test.go
+++ b/pkg/crypto/ed25519_test.go
@@ -23,27 +23,6 @@ func TestEd25519PrivateKey_Sign(t *testing.T) {
 	assert.Equal(t, expectSignature, hex.EncodeToString(sig), "unexpect signature")
 }
 
-func TestEd25519PrivateKey_SignMsg(t *testing.T) {
-	key := "7c67e60fce0c403ff40193a3128e5f3d8c2139aed36d76d7b5f1e70ec19c43f00aa611bf555596912bc6f9a9f169f8785918e7bab9924001895798ff13f05842"
-	pk, err := crypto.Ed25519PrivateKeyFromHex(key)
-	require.NoError(t, err, "error parse private key")
-
-	msg := []byte("foo")
-
-	sig, err := pk.SignMsg(msg)
-	require.NoError(t, err, "error sign")
-
-	expectSignature := "59b2db2d1e4ce6f8771453cfc78d1f943723528f00fa14adf574600f15c601d591fa2ba29c94d9ed694db324f9e8671bdfbcba4b8e10f6a8733682fa3d115f0c"
-	expectSignatureBytes, _ := hex.DecodeString(expectSignature)
-
-	expectSig := &crypto.Signature{
-		Signature: expectSignatureBytes,
-		Type:      crypto.SIGNATURE_TYPE_ED25519,
-	}
-
-	assert.EqualValues(t, expectSig, sig, "unexpect signature")
-}
-
 func TestEd25519PublicKey_Verify(t *testing.T) {
 	key := "0aa611bf555596912bc6f9a9f169f8785918e7bab9924001895798ff13f05842"
 	keyBytes, err := hex.DecodeString(key)

--- a/pkg/crypto/keys.go
+++ b/pkg/crypto/keys.go
@@ -11,7 +11,6 @@ type PrivateKey interface {
 	Sign(data []byte) ([]byte, error)
 	PubKey() PublicKey
 	Hex() string
-	Signer() Signer
 }
 
 type PublicKey interface {

--- a/pkg/crypto/secp256k1_test.go
+++ b/pkg/crypto/secp256k1_test.go
@@ -8,6 +8,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// Note: all the tests below are using same key pair and message
+
 func TestSecp256k1PrivateKey_Sign(t *testing.T) {
 	key := "f1aa5a7966c3863ccde3047f6a1e266cdc0c76b399e256b8fede92b1c69e4f4e"
 	pk, err := Secp256k1PrivateKeyFromHex(key)
@@ -20,29 +22,8 @@ func TestSecp256k1PrivateKey_Sign(t *testing.T) {
 	require.NoError(t, err, "error sign")
 
 	expectSig := "19a4aced02d5b9142b4f622b06442b1904445e16bd25409e6b0ff357ccc021d001d0e7824654b695b4b6e0991cb7507f487b82be4b2ed713d1e3e2cbc3d2518d01"
-	require.Equal(t, SIGNATURE_SECP256K1_PERSONAL_LENGTH, len(sig), "invalid signature length")
+	require.Equal(t, 65, len(sig), "invalid signature length")
 	require.EqualValues(t, hex.EncodeToString(sig), expectSig, "invalid signature")
-}
-
-func TestSecp256k1PrivateKey_SignMsg(t *testing.T) {
-	key := "f1aa5a7966c3863ccde3047f6a1e266cdc0c76b399e256b8fede92b1c69e4f4e"
-	pk, err := Secp256k1PrivateKeyFromHex(key)
-	require.NoError(t, err, "error parse private key")
-
-	msg := []byte("foo")
-
-	sig, err := pk.SignMsg(msg)
-	require.NoError(t, err, "error sign msg")
-
-	expectSignature := "cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e253475800"
-	expectSignatureBytes, _ := hex.DecodeString(expectSignature)
-
-	expectSig := &Signature{
-		Signature: expectSignatureBytes,
-		Type:      SIGNATURE_TYPE_SECP256K1_PERSONAL,
-	}
-
-	assert.EqualValues(t, expectSig, sig, "unexpect signature")
 }
 
 func TestSecp256k1PublicKey_Verify(t *testing.T) {
@@ -58,7 +39,7 @@ func TestSecp256k1PublicKey_Verify(t *testing.T) {
 
 	sig := "19a4aced02d5b9142b4f622b06442b1904445e16bd25409e6b0ff357ccc021d001d0e7824654b695b4b6e0991cb7507f487b82be4b2ed713d1e3e2cbc3d2518d01"
 	sigBytes, _ := hex.DecodeString(sig)
-	require.Equal(t, SIGNATURE_SECP256K1_PERSONAL_LENGTH, len(sigBytes), "invalid signature length")
+	require.Equal(t, 65, len(sigBytes), "invalid signature length")
 
 	tests := []struct {
 		name     string
@@ -66,14 +47,14 @@ func TestSecp256k1PublicKey_Verify(t *testing.T) {
 		wantErr  error
 	}{
 		{
-			name:     "verify success",
-			sigBytes: sigBytes[:len(sigBytes)-1],
+			name:     "verify success with 65 bytes signature",
+			sigBytes: sigBytes[:],
 			wantErr:  nil,
 		},
 		{
-			name:     "invalid signature length",
-			sigBytes: sigBytes,
-			wantErr:  errInvalidSignature,
+			name:     "verify success with 64 bytes signature(no recovery ID 'v')",
+			sigBytes: sigBytes[:len(sigBytes)-1],
+			wantErr:  nil,
 		},
 		{
 			name:     "wrong signature",

--- a/pkg/crypto/signer.go
+++ b/pkg/crypto/signer.go
@@ -1,19 +1,60 @@
 package crypto
 
+import (
+	"fmt"
+
+	ethAccount "github.com/ethereum/go-ethereum/accounts"
+)
+
+// Signer represents an interface that signs (raw) message.
+// You're supposed to use `Signature` to verify the signature.
 type Signer interface {
 	SignMsg(msg []byte) (*Signature, error)
 	PubKey() PublicKey
 }
 
-type ComebftSecp256k1Signer struct {
+// trivialSigner is a signer that does nothing, you cannot use it to sign messages.
+// This serves as a placeholder for the signer in the case that the private key is not supported.
+type trivialSigner struct {
+	key PrivateKey
+}
+
+func NewTrivialSigner(key PrivateKey) *trivialSigner {
+	return &trivialSigner{
+		key: key,
+	}
+}
+
+// SignMsg just complains.
+func (t *trivialSigner) SignMsg(msg []byte) (*Signature, error) {
+	// We can also return a signature with invalid signature type, but caller won't notice this until the signature hit
+	// the chain, which is not ideal.
+	return nil, fmt.Errorf("you got a trivial signer from unsupported private key, it cannot sign messages")
+}
+
+func (t *trivialSigner) PubKey() PublicKey {
+	return t.key.PubKey()
+}
+
+// CometbftSecp256k1Signer is a signer that signs messages using the secp256k1 curve, using cometbft's signature scheme.
+type CometbftSecp256k1Signer struct {
 	key *Secp256k1PrivateKey
 }
 
-func (c *ComebftSecp256k1Signer) PublicKey() PublicKey {
+func NewCometbftSecp256k1Signer(key *Secp256k1PrivateKey) *CometbftSecp256k1Signer {
+	return &CometbftSecp256k1Signer{
+		key: key,
+	}
+}
+
+func (c *CometbftSecp256k1Signer) PubKey() PublicKey {
 	return c.key.PubKey()
 }
 
-func (c *ComebftSecp256k1Signer) SignMsg(msg []byte) (*Signature, error) {
+// SignMsg signs the given message(not hashed) according to cometbft's signature scheme.
+// It use sha256 to hash the message.
+// The signature is in [R || S] format, 64 bytes.
+func (c *CometbftSecp256k1Signer) SignMsg(msg []byte) (*Signature, error) {
 	hash := Sha256(msg)
 	sig, err := c.key.Sign(hash)
 	if err != nil {
@@ -23,4 +64,77 @@ func (c *ComebftSecp256k1Signer) SignMsg(msg []byte) (*Signature, error) {
 		Signature: sig[:len(sig)-1],
 		Type:      SIGNATURE_TYPE_SECP256K1_COMETBFT,
 	}, nil
+}
+
+// EthPersonalSecp256k1Signer is a signer that signs messages using the secp256k1 curve, using ethereum's
+// personal_sign signature scheme.
+type EthPersonalSecp256k1Signer struct {
+	key *Secp256k1PrivateKey
+}
+
+func NewEthPersonalSecp256k1Signer(key *Secp256k1PrivateKey) *EthPersonalSecp256k1Signer {
+	return &EthPersonalSecp256k1Signer{
+		key: key,
+	}
+}
+
+func (e *EthPersonalSecp256k1Signer) PubKey() PublicKey {
+	return e.key.PubKey()
+}
+
+// SignMsg signs the given message(not hashed) according to EIP-191 personal_sign.
+// It prefix the message with "\x19Ethereum Signed Message:\n" and the message length,
+// then hash the message with keccak256.
+// The signature is in [R || S || V] format, 65 bytes.
+// This is default signature type for sec256k1.
+func (e *EthPersonalSecp256k1Signer) SignMsg(msg []byte) (*Signature, error) {
+	hash := ethAccount.TextHash(msg)
+	sig, err := e.key.Sign(hash)
+	if err != nil {
+		return nil, err
+	}
+	return &Signature{
+		Signature: sig,
+		Type:      SIGNATURE_TYPE_SECP256K1_PERSONAL,
+	}, nil
+}
+
+// StdEd25519Signer is a signer that signs messages using the ed25519 curve. Vanilla implementation.
+type StdEd25519Signer struct {
+	key *Ed25519PrivateKey
+}
+
+func NewStdEd25519Signer(key *Ed25519PrivateKey) *StdEd25519Signer {
+	return &StdEd25519Signer{
+		key: key,
+	}
+}
+
+func (e *StdEd25519Signer) PubKey() PublicKey {
+	return e.key.PubKey()
+}
+
+// SignMsg signs the given message(not hashed).
+// ed25519 is kind special that it's also an EdDSA signing schema, which require sha512 as hashing algorithm.
+func (e *StdEd25519Signer) SignMsg(msg []byte) (*Signature, error) {
+	sig, err := e.key.Sign(msg)
+	if err != nil {
+		return nil, err
+	}
+	return &Signature{
+		Signature: sig,
+		Type:      SIGNATURE_TYPE_ED25519,
+	}, nil
+}
+
+// DefaultSigner returns a default signer for the given private key.
+func DefaultSigner(key PrivateKey) Signer {
+	switch key.Type() {
+	case Secp256k1:
+		return NewEthPersonalSecp256k1Signer(key.(*Secp256k1PrivateKey))
+	case Ed25519:
+		return NewStdEd25519Signer(key.(*Ed25519PrivateKey))
+	default:
+		return NewTrivialSigner(key)
+	}
 }

--- a/pkg/crypto/signer_test.go
+++ b/pkg/crypto/signer_test.go
@@ -4,28 +4,93 @@ import (
 	"encoding/hex"
 	"testing"
 
+	"github.com/stretchr/testify/require"
+
 	"github.com/cometbft/cometbft/crypto/secp256k1"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestComebftSecp256k1Signer_SignMsg(t *testing.T) {
 	msg := []byte("foo")
-
 	pvKeyHex := "f1aa5a7966c3863ccde3047f6a1e266cdc0c76b399e256b8fede92b1c69e4f4e"
-	sigHex := "19a4aced02d5b9142b4f622b06442b1904445e16bd25409e6b0ff357ccc021d001d0e7824654b695b4b6e0991cb7507f487b82be4b2ed713d1e3e2cbc3d2518d"
+	expectSignatureHex := "19a4aced02d5b9142b4f622b06442b1904445e16bd25409e6b0ff357ccc021d001d0e7824654b695b4b6e0991cb7507f487b82be4b2ed713d1e3e2cbc3d2518d"
+	expectSignatureBytes, _ := hex.DecodeString(expectSignatureHex)
+	expectSig := &Signature{
+		Signature: expectSignatureBytes,
+		Type:      SIGNATURE_TYPE_SECP256K1_COMETBFT,
+	}
+	require.Equal(t, SIGNATURE_SECP256K1_COMETBFT_LENGTH, len(expectSignatureBytes), "invalid signature length")
 
+	// comebft secp256k1 private key, and signature
 	pvKeyBytes, _ := hex.DecodeString(pvKeyHex)
 	cometBftSecp256k1Key := secp256k1.PrivKey(pvKeyBytes)
-	cometBfgSecp256k1Sig, err := cometBftSecp256k1Key.Sign(msg)
+	cometBfgSecp256k1Sig, err := cometBftSecp256k1Key.Sign(msg) // sha256 is done in `Sign`
 	assert.NoError(t, err, "error signing message")
-	assert.Equal(t, sigHex, hex.EncodeToString(cometBfgSecp256k1Sig), "signature mismatch")
+	assert.Equal(t, expectSignatureHex, hex.EncodeToString(cometBfgSecp256k1Sig), "signature mismatch")
 
-	// use the cometbft signer to sign the message
-	kwilCometBftKey, _ := Secp256k1PrivateKeyFromHex(pvKeyHex)
-	cometBfgSigner := &ComebftSecp256k1Signer{
-		key: kwilCometBftKey,
-	}
-	kwilCometBftKeySig, err := cometBfgSigner.SignMsg(msg)
+	// use the kwil secp256k1 private key and cometbft signer to sign the message
+	kwilCometBftKey, err := Secp256k1PrivateKeyFromHex(pvKeyHex)
+	require.NoError(t, err, "error parse private pvKeyHex")
+
+	cometBfgSigner := NewCometbftSecp256k1Signer(kwilCometBftKey)
+	sig, err := cometBfgSigner.SignMsg(msg)
 	assert.NoError(t, err, "error signing message")
-	assert.Equal(t, sigHex, hex.EncodeToString(kwilCometBftKeySig.Signature), "signature mismatch")
+	require.EqualValues(t, expectSig, sig, "signature mismatch")
+
+	err = sig.Verify(kwilCometBftKey.PubKey(), msg)
+	assert.NoError(t, err, "error verifying signature")
+}
+
+func TestEthPersonalSecp256k1Signer_SignMsg(t *testing.T) {
+	msg := []byte("foo")
+	pvKeyHex := "f1aa5a7966c3863ccde3047f6a1e266cdc0c76b399e256b8fede92b1c69e4f4e"
+	expectSignatureHex := "cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e253475800"
+	expectSignatureBytes, _ := hex.DecodeString(expectSignatureHex)
+	expectSig := &Signature{
+		Signature: expectSignatureBytes,
+		Type:      SIGNATURE_TYPE_SECP256K1_PERSONAL,
+	}
+	require.Equal(t, SIGNATURE_SECP256K1_PERSONAL_LENGTH, len(expectSignatureBytes), "invalid signature length")
+
+	pk, err := Secp256k1PrivateKeyFromHex(pvKeyHex)
+	require.NoError(t, err, "error parse private pvKeyHex")
+
+	ethSigner := NewEthPersonalSecp256k1Signer(pk)
+
+	sig, err := ethSigner.SignMsg(msg)
+	require.NoError(t, err, "error signing msg")
+	assert.EqualValues(t, expectSig, sig, "signature mismatch")
+
+	err = sig.Verify(pk.PubKey(), msg)
+	assert.NoError(t, err, "error verifying signature")
+}
+
+func TestStdEd25519Signer_SignMsg(t *testing.T) {
+	msg := []byte("foo")
+	pvKeyHex := "7c67e60fce0c403ff40193a3128e5f3d8c2139aed36d76d7b5f1e70ec19c43f00aa611bf555596912bc6f9a9f169f8785918e7bab9924001895798ff13f05842"
+	expectSignature := "59b2db2d1e4ce6f8771453cfc78d1f943723528f00fa14adf574600f15c601d591fa2ba29c94d9ed694db324f9e8671bdfbcba4b8e10f6a8733682fa3d115f0c"
+	expectSignatureBytes, _ := hex.DecodeString(expectSignature)
+	expectSig := &Signature{
+		Signature: expectSignatureBytes,
+		Type:      SIGNATURE_TYPE_ED25519,
+	}
+	require.Equal(t, SIGNATURE_ED25519_LENGTH, len(expectSignatureBytes), "invalid signature length")
+
+	pk, err := Ed25519PrivateKeyFromHex(pvKeyHex)
+	require.NoError(t, err, "error parse private key")
+
+	edSigner := NewStdEd25519Signer(pk)
+
+	sig, err := edSigner.SignMsg(msg)
+	require.NoError(t, err, "error sign")
+	assert.EqualValues(t, expectSig, sig, "signature mismatch")
+
+	err = sig.Verify(pk.PubKey(), msg)
+	assert.NoError(t, err, "error verifying signature")
+}
+
+func TestTrivialSigner_SignMsg(t *testing.T) {
+	signer := NewTrivialSigner(nil)
+	_, err := signer.SignMsg([]byte("foo"))
+	require.Error(t, err, "suppose to error")
 }

--- a/test/acceptance/helper.go
+++ b/test/acceptance/helper.go
@@ -105,17 +105,15 @@ func (r *ActHelper) LoadConfig() {
 		DockerComposeFile: runner.GetEnv("KACT_DOCKER_COMPOSE_FILE", "./docker-compose.yml"),
 	}
 
-	var err error
-	cfg.AlicePK, err = crypto.Secp256k1PrivateKeyFromHex(cfg.AliceRawPK)
+	alicePk, err := crypto.Secp256k1PrivateKeyFromHex(cfg.AliceRawPK)
 	require.NoError(r.t, err, "invalid alice private key")
-	//if err != nil {
-	//	return nil, fmt.Errorf("invalid alice private key: %v", err)
-	//}
+	cfg.AlicePK = crypto.DefaultSigner(alicePk)
 
-	cfg.BobPk, err = crypto.Secp256k1PrivateKeyFromHex(cfg.BobRawPK)
+	bobPk, err := crypto.Secp256k1PrivateKeyFromHex(cfg.BobRawPK)
 	require.NoError(r.t, err, "invalid bob private key")
-	r.cfg = cfg
+	cfg.BobPk = crypto.DefaultSigner(bobPk)
 
+	r.cfg = cfg
 	cfg.DumpToEnv()
 }
 

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -90,13 +90,15 @@ func (r *IntHelper) LoadConfig() {
 	cfg.NValidator, err = strconv.Atoi(nodeNum)
 	require.NoError(r.t, err, "invalid node number")
 
-	cfg.AlicePK, err = crypto.Secp256k1PrivateKeyFromHex(cfg.AliceRawPK)
+	alicePk, err := crypto.Secp256k1PrivateKeyFromHex(cfg.AliceRawPK)
 	require.NoError(r.t, err, "invalid alice private key")
+	cfg.AlicePK = crypto.DefaultSigner(alicePk)
 
-	cfg.BobPk, err = crypto.Secp256k1PrivateKeyFromHex(cfg.BobRawPK)
+	bobPk, err := crypto.Secp256k1PrivateKeyFromHex(cfg.BobRawPK)
 	require.NoError(r.t, err, "invalid bob private key")
-	r.cfg = cfg
+	cfg.BobPk = crypto.DefaultSigner(bobPk)
 
+	r.cfg = cfg
 	cfg.DumpToEnv()
 }
 


### PR DESCRIPTION
Make default Signer separate from private key, eliminate the confusion. 
Provided a `DefaultSigner` which accept a private key and return default Siginer