### PR TITLE
added near signer and verifier

### DIFF
--- a/pkg/crypto/signature_test.go
+++ b/pkg/crypto/signature_test.go
@@ -29,6 +29,10 @@ func TestSignature_Verify(t *testing.T) {
 	ed25519Sig := "59b2db2d1e4ce6f8771453cfc78d1f943723528f00fa14adf574600f15c601d591fa2ba29c94d9ed694db324f9e8671bdfbcba4b8e10f6a8733682fa3d115f0c"
 	ed25519SigBytes, _ := hex.DecodeString(ed25519Sig)
 
+	// ed25519 near
+	ed25519NearSigHex := "089bcf52220dad77abc2cfcb1639bcb2944fdf64e0b173f40cd0d144bdbf7808f4eff3716eb3e98ed40be3ab126e1449d5f57efbe5626673059edc90e9cd9801"
+	ed25519NearSigBytes, _ := hex.DecodeString(ed25519NearSigHex)
+
 	type fields struct {
 		Signature []byte
 		Type      SignatureType
@@ -149,6 +153,30 @@ func TestSignature_Verify(t *testing.T) {
 			args: args{
 				publicKey: ed25519PublicKey,
 				msg:       anotherMsg,
+			},
+			wantErr: errVerifySignatureFailed,
+		},
+		{
+			name: "ed25519 near valid signature",
+			fields: fields{
+				Signature: ed25519NearSigBytes,
+				Type:      SignatureTypeEd25519Near,
+			},
+			args: args{
+				publicKey: ed25519PublicKey,
+				msg:       msg,
+			},
+			wantErr: nil,
+		},
+		{
+			name: "ed25519 near invalid signature",
+			fields: fields{
+				Signature: ed25519SigBytes,
+				Type:      SignatureTypeEd25519Near,
+			},
+			args: args{
+				publicKey: ed25519PublicKey,
+				msg:       msg,
 			},
 			wantErr: errVerifySignatureFailed,
 		},

--- a/pkg/crypto/signer.go
+++ b/pkg/crypto/signer.go
@@ -1,6 +1,7 @@
 package crypto
 
 import (
+	"crypto/sha256"
 	"fmt"
 
 	ethAccount "github.com/ethereum/go-ethereum/accounts"
@@ -127,7 +128,35 @@ func (e *StdEd25519Signer) SignMsg(msg []byte) (*Signature, error) {
 	}, nil
 }
 
+func NewNearSigner(key *Ed25519PrivateKey) *NearEd25519Signer {
+	return &NearEd25519Signer{
+		key: key,
+	}
+}
+
+type NearEd25519Signer struct {
+	key *Ed25519PrivateKey
+}
+
 // DefaultSigner returns a default signer for the given private key.
+
+func (n *NearEd25519Signer) PubKey() PublicKey {
+	return n.key.PubKey()
+}
+
+func (n *NearEd25519Signer) SignMsg(msg []byte) (*Signature, error) {
+	hash := sha256.Sum256(msg)
+
+	sig, err := n.key.Sign(hash[:])
+	if err != nil {
+		return nil, err
+	}
+
+	return &Signature{
+		Signature: sig,
+		Type:      SignatureTypeEd25519Near,
+	}, nil
+}
 func DefaultSigner(key PrivateKey) Signer {
 	switch key.Type() {
 	case Secp256k1:


### PR DESCRIPTION
added near signer.  It sha256 hashes the message before applying an ed25519 signature.  Hard to test without official NEAR tooling, but it does match up with what is done here: https://github.com/textileio/near-api-go