### PR TITLE
ci: add staticcheck to linters list

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -22,6 +22,7 @@ linters:
     - nosprintfhostport
     - reassign
     - rowserrcheck
+    - staticcheck
     - sqlclosecheck
     - tparallel
     - typecheck

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -55,7 +55,6 @@ tasks:
 
   lint:
     desc: Lint with golangci-lint
-    deps: [pb:compile:v1]
     cmds:
         - golangci-lint run -c .golangci.yml --skip-dirs ./api/protobuf
 


### PR DESCRIPTION
This adds staticcheck to the list of linters run by golangci-lint.  This linter is one of the golangci-lint defaults, but we had it disabled.  This would have caught the infinite recursive call that is being fixed in https://github.com/kwilteam/kwil-db/pull/259