### PR TITLE
Move the private key from config.toml to private_key.txt file

### DIFF
--- a/internal/app/kwild/app.go
+++ b/internal/app/kwild/app.go
@@ -21,6 +21,7 @@ var rootCmd = &cobra.Command{
 
 var kwildCfg = config.DefaultConfig()
 var rootDir string
+var autoGen bool // auto generate private key and genesis file
 
 func Execute() error {
 	rootCmd.AddCommand(
@@ -33,6 +34,7 @@ func Execute() error {
 
 func init() {
 	rootCmd.PersistentFlags().StringVar(&rootDir, "root_dir", "~/.kwild", "kwild root directory for config and data")
+	rootCmd.PersistentFlags().BoolVar(&autoGen, "autogen", false, "auto generate private key and genesis file if not exist")
 	rootCmd.PersistentPreRunE = extractKwildConfig
 }
 
@@ -52,10 +54,12 @@ func extractKwildConfig(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	err = kwildCfg.LoadKwildConfig(rootDir)
-	if err != nil {
-		fmt.Println("Failed to load config: ", err)
-		return err
+	if err = kwildCfg.LoadKwildConfig(rootDir); err != nil {
+		return fmt.Errorf("failed to load kwild config: %v", err)
+	}
+
+	if err = kwildCfg.LoadGenesisAndPrivateKey(autoGen); err != nil {
+		return fmt.Errorf("failed to load genesis and private key: %v", err)
 	}
 	return nil
 }

--- a/internal/app/kwild/cmd/server/root.go
+++ b/internal/app/kwild/cmd/server/root.go
@@ -48,7 +48,7 @@ func NewStartCmd(cfg *config.KwildConfig) *cobra.Command {
 
 func AddKwildFlags(cmd *cobra.Command, cfg *config.KwildConfig) {
 	// General APP flags:
-	cmd.Flags().StringVar(&cfg.AppCfg.PrivateKey, "app.private_key", cfg.AppCfg.PrivateKey, "Kwild app's private key")
+	cmd.Flags().StringVar(&cfg.AppCfg.PrivateKeyPath, "app.private_key_path", cfg.AppCfg.PrivateKeyPath, "Path to private key file")
 
 	cmd.Flags().StringVar(&cfg.AppCfg.GrpcListenAddress, "app.grpc_listen_addr", cfg.AppCfg.GrpcListenAddress, "Kwild app gRPC listen address")
 
@@ -86,8 +86,6 @@ func AddKwildFlags(cmd *cobra.Command, cfg *config.KwildConfig) {
 
 	//  Basic Chain Config flags
 	cmd.Flags().StringVar(&cfg.ChainCfg.Moniker, "chain.moniker", cfg.ChainCfg.Moniker, "Chain moniker")
-
-	cmd.Flags().StringVar(&cfg.ChainCfg.Genesis, "chain.genesis", cfg.ChainCfg.Genesis, "Genesis file path")
 
 	cmd.Flags().StringVar(&cfg.ChainCfg.DBPath, "chain.db_dir", cfg.ChainCfg.DBPath, "Chain database directory path")
 	// Chain RPC flags

--- a/internal/pkg/nodecfg/toml.go
+++ b/internal/pkg/nodecfg/toml.go
@@ -51,9 +51,10 @@ const defaultConfigTemplate = `
 # NOTE: Any path below can be absolute (e.g. "/var/myawesomeapp/data") or
 # relative to the home directory (e.g. "data")
 
-# Home Directory Structure:
-# HomeDir/
+# Root Directory Structure:
+# RootDir/
 #   |- config.toml    (app and chain configuration for running the kwild node)
+#   |- private_key.txt   (node's private key)
 #   |- abci/
 #   |   |- config/
 #   |   |   |- genesis.json   (genesis file for the network)
@@ -93,7 +94,7 @@ time_format = "{{ .Logging.TimeEncoding }}"
 
 [app]
 # Node's Private key
-private_key = "{{ .AppCfg.PrivateKey }}"
+private_key_path = "{{ .AppCfg.PrivateKeyPath }}"
 
 # TCP or UNIX socket address for the KWILD App's GRPC server to listen on
 grpc_listen_addr = "{{ .AppCfg.GrpcListenAddress }}"
@@ -157,9 +158,6 @@ snapshot_dir = "{{ .AppCfg.SnapshotConfig.SnapshotDir }}"
 [chain]
 # A custom human readable name for this node
 moniker = "{{ .ChainCfg.Moniker }}"
-
-# Blockchain Genesis file
-genesis_file = "{{ .ChainCfg.Genesis }}"
 
 # Blockchain database directory
 db_dir = "{{ .ChainCfg.DBPath }}"

--- a/pkg/abci/utils.go
+++ b/pkg/abci/utils.go
@@ -55,6 +55,19 @@ func ResetAll(cfg *config.KwildConfig) error {
 		fmt.Println("Error removing all sqlite files", "dir", cfg.AppCfg.SqliteFilePath, "err", err)
 	}
 
+	rcvdSnaps := filepath.Join(cfg.RootDir, "rcvdSnaps")
+	if err := os.RemoveAll(rcvdSnaps); err == nil {
+		fmt.Println("Removed all rcvdSnaps", "dir", rcvdSnaps)
+	} else {
+		fmt.Println("Error removing all rcvdSnaps", "dir", rcvdSnaps, "err", err)
+	}
+
+	if err := os.RemoveAll(cfg.AppCfg.SnapshotConfig.SnapshotDir); err == nil {
+		fmt.Println("Removed all snapshots", "dir", cfg.AppCfg.SnapshotConfig.SnapshotDir)
+	} else {
+		fmt.Println("Error removing all snapshots", "dir", cfg.AppCfg.SnapshotConfig.SnapshotDir, "err", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
This PR deals with moving the private key config to a separate private_key.txt file.

Default Private Key Location:  root_dir/private_key.txt, which can be overwritten by using --app.private_key_path on cmdline or by updating private_key_path field under the app configuration

Introduced a new flag --autogen to autogenerate the pkey and genesis file if not present:

- If private key doesn't exist at the location, we would generate the pkey during the server start
- If genesis file doesn't exist, we would generate genesis file under `root_dir/abci/config/genesis.json` based on the pkey (either generated or read from file)
-If genesis file exists, the file doesn't get updated. In which case, the node would run as a non-validator.

Updated the init and testnet util commands to generate the private key.
