### PR TITLE
ci: trigger workflow for non-draft pr

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    types: [ opened, synchronize, reopened ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
   workflow_dispatch:
   push:
     branches:
@@ -12,6 +12,7 @@ on:
 jobs:
   unit-test:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }} # only run on non-draft PRs
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -71,6 +72,7 @@ jobs:
 
   acceptance-test:
     runs-on: ubuntu-latest
+    if: ${{ !github.event.pull_request.draft }} # only run on non-draft PRs
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/on-main.yml
+++ b/.github/workflows/on-main.yml
@@ -9,6 +9,7 @@ on:
 jobs:
   build-push-image:
     name: Build & push image
+    if: false # temporary disable
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -8,8 +8,8 @@ on:
 jobs:
   build-push-image:
     name: Build & push image
+    if: false # temporary disable
     runs-on: ubuntu-latest
-
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
resolve #262

Also this PR disables `main` and `release` workflow since we're not using them. 