### PR TITLE
pkg/engine: drop 3rd party errors lib

### DIFF
--- a/cmd/kwil-cli/cmds/system/version.go
+++ b/cmd/kwil-cli/cmds/system/version.go
@@ -1,13 +1,13 @@
 package system
 
 import (
+	"fmt"
 	"html/template"
 	"os"
 	"runtime"
 	"text/tabwriter"
 
 	"github.com/kwilteam/kwil-db/internal/pkg/build"
-	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/tonistiigi/go-rosetta"
 )
@@ -44,7 +44,7 @@ func NewVersionCmd() *cobra.Command {
 		Short: "Show the kwil-cli version information",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return runVesrion(&opts)
+			return runVersion(&opts)
 		},
 	}
 
@@ -62,12 +62,12 @@ func arch() string {
 	return arch
 }
 
-func runVesrion(opts *versionOptions) error {
+func runVersion(opts *versionOptions) error {
 	tmpl := template.New("version")
 	// load different template according to the opts.format
 	tmpl, err := tmpl.Parse(versionTemplate)
 	if err != nil {
-		return errors.Wrap(err, "template parsing error")
+		return fmt.Errorf("template parsing error: %w", err)
 	}
 
 	vd := versionInfo{

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,6 @@ require (
 	github.com/kwilteam/kwil-extensions v0.0.0-20230710163303-bfa03f64ff82
 	github.com/kwilteam/sql-grammar-go v0.0.2
 	github.com/manifoldco/promptui v0.9.0
-	github.com/pkg/errors v0.9.1
 	github.com/spf13/cobra v1.7.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.14.0
@@ -173,6 +172,7 @@ require (
 	github.com/pelletier/go-toml v1.9.5 // indirect
 	github.com/pelletier/go-toml/v2 v2.0.5 // indirect
 	github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect
+	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.14.0 // indirect
 	github.com/prometheus/client_model v0.3.0 // indirect

--- a/pkg/engine/dataset/actparser/parser.go
+++ b/pkg/engine/dataset/actparser/parser.go
@@ -39,7 +39,7 @@ func ParseActionStmt(stmt string, errorListener *sqlparser.ErrorListener, trace 
 		}
 
 		if err != nil {
-			errorListener.Add(err.Error())
+			errorListener.AddError(err)
 		}
 
 		err = errorListener.Err()

--- a/pkg/engine/sqlparser/parser.go
+++ b/pkg/engine/sqlparser/parser.go
@@ -39,7 +39,7 @@ func ParseSql(sql string, currentLine int, errorListener *ErrorListener, trace b
 		}
 
 		if err != nil {
-			errorListener.Add(err.Error())
+			errorListener.AddError(err)
 		}
 
 		err = errorListener.Err()

--- a/pkg/engine/sqlparser/parser_test.go
+++ b/pkg/engine/sqlparser/parser_test.go
@@ -1,6 +1,7 @@
 package sqlparser
 
 import (
+	"errors"
 	"flag"
 	"fmt"
 	"strings"
@@ -2267,8 +2268,8 @@ func TestParseRawSQL_syntax_invalid(t *testing.T) {
 			_, err := ParseSql(tt.input, 1, nil, *trace)
 			assert.Errorf(t, err, "Parser should complain abould invalid syntax")
 
-			if err == nil || !strings.Contains(err.Error(), ErrInvalidSyntax.Error()) {
-				t.Errorf("ParseRawSQL() expected error: %s, got %s", ErrInvalidSyntax, err)
+			if !errors.Is(err, ErrInvalidSyntax) {
+				t.Fatalf("ParseRawSQL() expected error: %s, got %s", ErrInvalidSyntax, err)
 			}
 
 			//if el.symbol != tt.causeSymbol {


### PR DESCRIPTION
This drops the unnecessary dependency on "github.com/pkg/errors" since the standard library has support for wrapping, unwrapping, and type checking errors (also not string matching).