### PR TITLE
make abci Commit guarantee state is committed

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -66,7 +66,6 @@ tasks:
 
   build:cli:
     desc: Build kwil-cli
-    deps: [pb:compile:v1]
     cmds:
       - ./scripts/build/binary kwil-cli #-mod=mod
     generates:
@@ -74,7 +73,6 @@ tasks:
 
   build:kwild:
     desc: Builds kwild server
-    deps: [pb:compile:v1]
     cmds:
       - ./scripts/build/binary kwild #-mod=mod
     generates:
@@ -83,7 +81,6 @@ tasks:
   # ************ docker ************
   build:docker:
     desc: Build the docker image for the kwild
-    deps: [ pb:compile:v1]
     cmds:
       # need to run after protobuf is compiled
       - task: vendor
@@ -93,7 +90,6 @@ tasks:
 
   publish:dockerhub:
     desc: Publish docker image to dockerhub
-    deps: [ pb:compile:v1]
     cmds:
       - task: vendor
       - TAG={{.TAG}} ./scripts/publish/dockerhub

--- a/pkg/abci/interfaces.go
+++ b/pkg/abci/interfaces.go
@@ -60,7 +60,7 @@ type AtomicCommitter interface {
 	ClearWal(ctx context.Context) error
 	Begin(ctx context.Context) error
 	ID(ctx context.Context) ([]byte, error)
-	Commit(ctx context.Context, applyCallback func(error)) error
+	Commit(ctx context.Context) error
 }
 
 // KVStore is an interface for a basic key-value store

--- a/pkg/sessions/sessions_test.go
+++ b/pkg/sessions/sessions_test.go
@@ -156,15 +156,7 @@ func Test_Session(t *testing.T) {
 					return err
 				}
 
-				applyErr := make(chan error)
-				err = committer.Commit(ctx, func(err error) {
-					applyErr <- err
-				})
-				if err != nil {
-					return err
-				}
-
-				err = <-applyErr
+				err = committer.Commit(ctx)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
This resolves an issue caused by the atomic committer not actually applying the changes when Commit returns.  This caused the ABCI application and thus the cometBFT node to be out of sync for a transient period.