### PR TITLE
Validator Join expiry 

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -59,7 +59,7 @@ tasks:
         - golangci-lint run -c .golangci.yml --skip-dirs ./api/protobuf
 
   build:
-    desc: Build cli & kwild
+    desc: Build cli, admin & kwild
     cmds:
       - task: build:cli
       - task: build:kwild

--- a/cmd/kwil-admin/main.go
+++ b/cmd/kwil-admin/main.go
@@ -21,10 +21,10 @@ const (
 )
 
 type args struct {
-	Key   *KeyCmd        `arg:"subcommand:key"`
-	Setup *SetupCmd      `arg:"subcommand:setup"`
-	Vals  *ValidatorsCmd `arg:"subcommand:validators"`
-	Node  *NodeCmd       `arg:"subcommand:node"`
+	Key   *KeyCmd        `arg:"subcommand:key" help:"commands for managing node private keys"`
+	Setup *SetupCmd      `arg:"subcommand:setup" help:"commands for setting up a standalone node or testnet configuration"`
+	Vals  *ValidatorsCmd `arg:"subcommand:validators" help:"commands for managing validators"`
+	Node  *NodeCmd       `arg:"subcommand:node" help:"commands for controlling a running node on the authenticated RPC service"`
 
 	Help *HelpCmd `arg:"subcommand:help"`
 	Ver  *VerCmd  `arg:"subcommand:version"`

--- a/cmd/kwil-admin/setup.go
+++ b/cmd/kwil-admin/setup.go
@@ -31,7 +31,10 @@ func (cc *SetupCmd) run(ctx context.Context) error {
 	switch {
 	case cc.Init != nil:
 		genCfg := &nodecfg.NodeGenerateConfig{
-			OutputDir: cc.Init.OutputDir,
+			OutputDir:       cc.Init.OutputDir,
+			JoinExpiry:      cc.Init.JoinExpiry,
+			WithoutGasCosts: cc.Init.WithoutGasCosts,
+			WithoutNonces:   cc.Init.WithoutNonces,
 		}
 		return nodecfg.GenerateNodeConfig(genCfg)
 	case cc.Testnet != nil:
@@ -56,7 +59,10 @@ func (cc *SetupCmd) run(ctx context.Context) error {
 }
 
 type SetupInitCmd struct {
-	OutputDir string `arg:"-o,--output-dir" default:".testnet" help:"parent directory for all of generated node folders" placeholder:"DIR"`
+	OutputDir       string `arg:"-o,--output-dir" default:".testnet" help:"parent directory for all of generated node folders" placeholder:"DIR"`
+	JoinExpiry      int64  `arg:"--join-expiry" default:"86400" help:"number of blocks before a join request expires"`
+	WithoutGasCosts bool   `arg:"--without-gas-costs" help:"disable gas costs"`
+	WithoutNonces   bool   `arg:"--without-nonces" help:"disable nonces"`
 }
 
 type SetupTestnetCmd struct {
@@ -71,6 +77,9 @@ type SetupTestnetCmd struct {
 	StartingIPAddress       string   `arg:"--starting-ip" help:"starting IP address of the first network node" placeholder:"IP"`
 	Hostnames               []string `arg:"--hostname" help:"override all hostnames of the nodes"`
 	P2pPort                 int      `arg:"-p,--p2p-port" help:"P2P port" placeholder:"PORT"`
+	JoinExpiry              int64    `arg:"--join-expiry" default:"86400" help:"number of blocks before a join request expires"`
+	WithoutGasCosts         bool     `arg:"--without-gas-costs" help:"disable gas costs"`
+	WithoutNonces           bool     `arg:"--without-nonces" help:"disable nonces"`
 	// InitialHeight           int64    `arg:"--initial-height" default:"true" help:"initial height of the first block"`
 }
 

--- a/cmd/kwild/flags.go
+++ b/cmd/kwild/flags.go
@@ -23,8 +23,6 @@ func addKwildFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 	flagSet.StringVar(&cfg.AppCfg.HTTPListenAddress, "app.http_listen_addr", cfg.AppCfg.HTTPListenAddress, "Kwild app HTTP listen address")
 	flagSet.StringVar(&cfg.AppCfg.AdminListenAddress, "app.admin_listen_addr", cfg.AppCfg.AdminListenAddress, "Kwild app gRPC listen address")
 	flagSet.StringVar(&cfg.AppCfg.SqliteFilePath, "app.sqlite_file_path", cfg.AppCfg.SqliteFilePath, "Kwild app sqlite file path")
-	flagSet.BoolVar(&cfg.AppCfg.WithoutGasCosts, "app.without_gas_costs", cfg.AppCfg.WithoutGasCosts, "Kwild app without gas costs")
-	flagSet.BoolVar(&cfg.AppCfg.WithoutNonces, "app.without_nonces", cfg.AppCfg.WithoutNonces, "Kwild app without nonces")
 	flagSet.StringVar(&cfg.AppCfg.TLSCertFile, "app.tls_cert_file", cfg.AppCfg.TLSCertFile, "TLS certificate file path for RPC Server")
 	flagSet.StringVar(&cfg.AppCfg.TLSKeyFile, "app.tls_key_file", cfg.AppCfg.TLSKeyFile, "TLS key file path for RPC Server")
 	flagSet.BoolVar(&cfg.AppCfg.EnableRPCTLS, "app.rpctls", cfg.AppCfg.EnableRPCTLS, "Kwild app without nonces")
@@ -33,47 +31,48 @@ func addKwildFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 	// Extension endpoints flags
 	flagSet.StringSliceVar(&cfg.AppCfg.ExtensionEndpoints, "app.extension_endpoints", cfg.AppCfg.ExtensionEndpoints, "Kwild app extension endpoints")
 
-	// Snapshot Config flags
-	flagSet.BoolVar(&cfg.AppCfg.SnapshotConfig.Enabled, "app.snapshots.enabled", cfg.AppCfg.SnapshotConfig.Enabled, "Enable snapshots")
-	flagSet.Uint64Var(&cfg.AppCfg.SnapshotConfig.RecurringHeight, "app.snapshots.recurring_height", cfg.AppCfg.SnapshotConfig.RecurringHeight, "Recurring snapshot height")
-	flagSet.Uint64Var(&cfg.AppCfg.SnapshotConfig.MaxSnapshots, "app.snapshots.max_snapshots", cfg.AppCfg.SnapshotConfig.MaxSnapshots, "Maximum snapshots")
-	flagSet.StringVar(&cfg.AppCfg.SnapshotConfig.SnapshotDir, "app.snapshots.snapshot_dir", cfg.AppCfg.SnapshotConfig.SnapshotDir, "Snapshot directory path")
+	// TODO: Snapshots are not supported yet
+	// // Snapshot Config flags
+	// flagSet.BoolVar(&cfg.AppCfg.SnapshotConfig.Enabled, "app.snapshots.enabled", cfg.AppCfg.SnapshotConfig.Enabled, "Enable snapshots")
+	// flagSet.Uint64Var(&cfg.AppCfg.SnapshotConfig.RecurringHeight, "app.snapshots.recurring_height", cfg.AppCfg.SnapshotConfig.RecurringHeight, "Recurring snapshot height")
+	// flagSet.Uint64Var(&cfg.AppCfg.SnapshotConfig.MaxSnapshots, "app.snapshots.max_snapshots", cfg.AppCfg.SnapshotConfig.MaxSnapshots, "Maximum snapshots")
+	// flagSet.StringVar(&cfg.AppCfg.SnapshotConfig.SnapshotDir, "app.snapshots.snapshot_dir", cfg.AppCfg.SnapshotConfig.SnapshotDir, "Snapshot directory path")
 
 	// Basic Chain Config flags
 	flagSet.StringVar(&cfg.ChainCfg.Moniker, "chain.moniker", cfg.ChainCfg.Moniker, "Node moniker")
 	// flagSet.StringVar(&cfg.ChainCfg.DBPath, "chain.db_dir", cfg.ChainCfg.DBPath, "Chain database directory path") // rm?
 
 	// Chain RPC flags
-	flagSet.StringVar(&cfg.ChainCfg.RPC.ListenAddress, "chain.rpc.laddr", cfg.ChainCfg.RPC.ListenAddress, "Chain RPC listen address")
-	flagSet.DurationVar(&cfg.ChainCfg.RPC.TimeoutBroadcastTxCommit, "chain.rpc.timeout_broadcast_tx_commit", cfg.ChainCfg.RPC.TimeoutBroadcastTxCommit, "chain timeout broadcast tx commit")
+	flagSet.StringVar(&cfg.ChainCfg.RPC.ListenAddress, "chain.rpc.listen_addr", cfg.ChainCfg.RPC.ListenAddress, "Chain RPC listen address")
 
 	// Chain P2P flags
-	flagSet.StringVar(&cfg.ChainCfg.P2P.ListenAddress, "chain.p2p.laddr", cfg.ChainCfg.P2P.ListenAddress, "chain P2P listen address")
-	flagSet.StringVar(&cfg.ChainCfg.P2P.ExternalAddress, "chain.p2p.external_address", cfg.ChainCfg.P2P.ExternalAddress, "chain P2P external address")
-	flagSet.StringVar(&cfg.ChainCfg.P2P.PersistentPeers, "chain.p2p.persistent_peers", cfg.ChainCfg.P2P.PersistentPeers, "chain P2P persistent peers")
-	flagSet.BoolVar(&cfg.ChainCfg.P2P.AddrBookStrict, "chain.p2p.addr_book_strict", cfg.ChainCfg.P2P.AddrBookStrict, "chain P2P address book strict")
-	flagSet.StringVar(&cfg.ChainCfg.P2P.UnconditionalPeerIDs, "chain.p2p.unconditional_peer_ids", cfg.ChainCfg.P2P.UnconditionalPeerIDs, "chain P2P unconditional peer IDs")
-	flagSet.IntVar(&cfg.ChainCfg.P2P.MaxNumInboundPeers, "chain.p2p.max_num_inbound_peers", cfg.ChainCfg.P2P.MaxNumInboundPeers, "chain P2P maximum number of inbound peers")
-	flagSet.IntVar(&cfg.ChainCfg.P2P.MaxNumOutboundPeers, "chain.p2p.max_num_outbound_peers", cfg.ChainCfg.P2P.MaxNumOutboundPeers, "chain P2P maximum number of outbound peers")
-	flagSet.BoolVar(&cfg.ChainCfg.P2P.AllowDuplicateIP, "chain.p2p.allow_duplicate_ip", cfg.ChainCfg.P2P.AllowDuplicateIP, "chain P2P allow duplicate IP")
+	flagSet.StringVar(&cfg.ChainCfg.P2P.ListenAddress, "chain.p2p.listen_addr", cfg.ChainCfg.P2P.ListenAddress, "Chain P2P listen address")
+	flagSet.StringVar(&cfg.ChainCfg.P2P.ExternalAddress, "chain.p2p.external_address", cfg.ChainCfg.P2P.ExternalAddress, "Chain P2P external address")
+	flagSet.StringVar(&cfg.ChainCfg.P2P.PersistentPeers, "chain.p2p.persistent_peers", cfg.ChainCfg.P2P.PersistentPeers, "Chain P2P persistent peers")
+	flagSet.BoolVar(&cfg.ChainCfg.P2P.AddrBookStrict, "chain.p2p.addr_book_strict", cfg.ChainCfg.P2P.AddrBookStrict, "Chain P2P address book strict")
+	flagSet.StringVar(&cfg.ChainCfg.P2P.UnconditionalPeerIDs, "chain.p2p.unconditional_peer_ids", cfg.ChainCfg.P2P.UnconditionalPeerIDs, "Chain P2P unconditional peer IDs")
+	flagSet.IntVar(&cfg.ChainCfg.P2P.MaxNumInboundPeers, "chain.p2p.max_num_inbound_peers", cfg.ChainCfg.P2P.MaxNumInboundPeers, "Chain P2P maximum number of inbound peers")
+	flagSet.IntVar(&cfg.ChainCfg.P2P.MaxNumOutboundPeers, "chain.p2p.max_num_outbound_peers", cfg.ChainCfg.P2P.MaxNumOutboundPeers, "Chain P2P maximum number of outbound peers")
+	flagSet.BoolVar(&cfg.ChainCfg.P2P.AllowDuplicateIP, "chain.p2p.allow_duplicate_ip", cfg.ChainCfg.P2P.AllowDuplicateIP, "Chain P2P allow duplicate IP")
 
 	// Chain Mempool flags
-	flagSet.IntVar(&cfg.ChainCfg.Mempool.Size, "chain.mempool.size", cfg.ChainCfg.Mempool.Size, "chain mempool size")
-	flagSet.IntVar(&cfg.ChainCfg.Mempool.CacheSize, "chain.mempool.cache_size", cfg.ChainCfg.Mempool.CacheSize, "chain mempool cache size")
+	flagSet.IntVar(&cfg.ChainCfg.Mempool.Size, "chain.mempool.size", cfg.ChainCfg.Mempool.Size, "Chain mempool size")
+	flagSet.IntVar(&cfg.ChainCfg.Mempool.CacheSize, "chain.mempool.cache_size", cfg.ChainCfg.Mempool.CacheSize, "Chain mempool cache size")
 	// flagSet.Int64Var(&cfg.ChainCfg.Mempool.MaxTxsBytes, "chain.mempool.max_txs_bytes", cfg.ChainCfg.Mempool.MaxTxsBytes, "chain mempool maximum transactions bytes")
 
 	// Chain Consensus flags
-	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutPropose, "chain.consensus.timeout_propose", cfg.ChainCfg.Consensus.TimeoutPropose, "chain consensus timeout propose")
-	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutPrevote, "chain.consensus.timeout_prevote", cfg.ChainCfg.Consensus.TimeoutPrevote, "chain consensus timeout prevote")
-	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutPrecommit, "chain.consensus.timeout_precommit", cfg.ChainCfg.Consensus.TimeoutPrecommit, "chain consensus timeout precommit")
-	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutCommit, "chain.consensus.timeout_commit", cfg.ChainCfg.Consensus.TimeoutCommit, "chain consensus timeout commit")
+	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutPropose, "chain.consensus.timeout_propose", cfg.ChainCfg.Consensus.TimeoutPropose, "Chain consensus timeout propose")
+	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutPrevote, "chain.consensus.timeout_prevote", cfg.ChainCfg.Consensus.TimeoutPrevote, "Chain consensus timeout prevote")
+	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutPrecommit, "chain.consensus.timeout_precommit", cfg.ChainCfg.Consensus.TimeoutPrecommit, "Chain consensus timeout precommit")
+	flagSet.DurationVar(&cfg.ChainCfg.Consensus.TimeoutCommit, "chain.consensus.timeout_commit", cfg.ChainCfg.Consensus.TimeoutCommit, "Chain consensus timeout commit")
 
 	// State Sync flags
-	flagSet.BoolVar(&cfg.ChainCfg.StateSync.Enable, "chain.state_sync.enable", cfg.ChainCfg.StateSync.Enable, "chain state sync enable")
-	flagSet.StringVar(&cfg.ChainCfg.StateSync.TempDir, "chain.state_sync.temp_dir", cfg.ChainCfg.StateSync.TempDir, "chain state sync temp dir")
-	flagSet.StringSliceVar(&cfg.ChainCfg.StateSync.RPCServers, "chain.state_sync.rpc_servers", cfg.ChainCfg.StateSync.RPCServers, "chain state sync rpc servers")
-	flagSet.DurationVar(&cfg.ChainCfg.StateSync.DiscoveryTime, "chain.state_sync.discovery_time", cfg.ChainCfg.StateSync.DiscoveryTime, "chain state sync discovery time")
-	flagSet.DurationVar(&cfg.ChainCfg.StateSync.ChunkRequestTimeout, "chain.state_sync.chunk_request_timeout", cfg.ChainCfg.StateSync.ChunkRequestTimeout, "chain state sync chunk request timeout")
+	// TODO: Bring these flags back when we support state sync
+	// flagSet.BoolVar(&cfg.ChainCfg.StateSync.Enable, "chain.state_sync.enable", cfg.ChainCfg.StateSync.Enable, "Chain state sync enable")
+	// flagSet.StringVar(&cfg.ChainCfg.StateSync.TempDir, "chain.state_sync.temp_dir", cfg.ChainCfg.StateSync.TempDir, "Chain state sync temp dir")
+	// flagSet.StringSliceVar(&cfg.ChainCfg.StateSync.RPCServers, "chain.state_sync.rpc_servers", cfg.ChainCfg.StateSync.RPCServers, "Chain state sync rpc servers")
+	// flagSet.DurationVar(&cfg.ChainCfg.StateSync.DiscoveryTime, "chain.state_sync.discovery_time", cfg.ChainCfg.StateSync.DiscoveryTime, "Chain state sync discovery time")
+	// flagSet.DurationVar(&cfg.ChainCfg.StateSync.ChunkRequestTimeout, "chain.state_sync.chunk_request_timeout", cfg.ChainCfg.StateSync.ChunkRequestTimeout, "Chain state sync chunk request timeout")
 
 	// Block sync can be added later (when they have more version of it)
 }

--- a/cmd/kwild/main.go
+++ b/cmd/kwild/main.go
@@ -44,7 +44,11 @@ var rootCmd = &cobra.Command{
 		// command line flags are now (finally) parsed by cobra. Bind env vars,
 		// load the config file, and unmarshal into kwildCfg.
 		if err := kwildCfg.LoadKwildConfig(); err != nil {
-			return fmt.Errorf("Failed to load kwild config: %w", err)
+			return fmt.Errorf("failed to load kwild config: %w", err)
+		}
+
+		if err := kwildCfg.InitPrivateKeyAndGenesis(); err != nil {
+			return fmt.Errorf("failed to initialize private key and genesis: %w", err)
 		}
 
 		signalChan := make(chan os.Signal, 1)

--- a/internal/app/kwild/config/config_test.go
+++ b/internal/app/kwild/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/kwilteam/kwil-db/internal/app/kwild"
 	"github.com/kwilteam/kwil-db/internal/app/kwild/config"
 
 	"github.com/stretchr/testify/assert"
@@ -11,7 +12,7 @@ import (
 
 func Test_Config_Toml(t *testing.T) {
 	cfg := config.DefaultConfig()
-	err := cfg.ParseConfig(filepath.Join("test_data", config.ConfigFileName))
+	err := cfg.ParseConfig(filepath.Join("test_data", kwild.ConfigFileName))
 	assert.NoError(t, err)
 
 	assert.Equal(t, "localhost:50051", cfg.AppCfg.GrpcListenAddress)
@@ -22,6 +23,5 @@ func Test_Config_Toml(t *testing.T) {
 	assert.Equal(t, "localhost:50052", cfg.AppCfg.ExtensionEndpoints[0])
 	assert.Equal(t, "localhost:50053", cfg.AppCfg.ExtensionEndpoints[1])
 
-	assert.Equal(t, true, cfg.AppCfg.WithoutGasCosts)
 	// TODO: Add bunch of other validations for different types
 }

--- a/internal/app/kwild/config/genesis.go
+++ b/internal/app/kwild/config/genesis.go
@@ -1,0 +1,300 @@
+package config
+
+import (
+	"bytes"
+	"crypto/sha256"
+	"encoding/binary"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/kwilteam/kwil-db/pkg/abci/cometbft"
+
+	cmtEd "github.com/cometbft/cometbft/crypto/ed25519"
+	cmtrand "github.com/cometbft/cometbft/libs/rand"
+)
+
+const (
+	ABCIPubKeyTypeEd25519 = "ed25519"
+	chainIDPrefix         = "kwil-chain-"
+)
+
+type GenesisConfig struct {
+	GenesisTime   time.Time `json:"genesis_time"`
+	ChainID       string    `json:"chain_id"`
+	InitialHeight int64     `json:"initial_height"`
+	DataAppHash   []byte    `json:"app_hash"`
+
+	/*
+	 TODO: Can introduce app state later if needed. Used to specify raw initial state such as tokens etc,
+	 abci init will generate a new app hash after applying this state
+	*/
+	// AppState json.RawMessage `json:"app_state"`
+	ConsensusParams *ConsensusParams   `json:"consensus_params,omitempty"`
+	Validators      []GenesisValidator `json:"validators,omitempty"`
+}
+
+type GenesisValidator struct {
+	Address string `json:"address"`
+	PubKey  []byte `json:"pub_key"`
+	Power   int64  `json:"power"`
+	Name    string `json:"name"`
+}
+
+type ConsensusParams struct {
+	Block     BlockParams     `json:"block"`
+	Evidence  EvidenceParams  `json:"evidence"`
+	Version   VersionParams   `json:"version"`
+	Validator ValidatorParams `json:"validator"`
+
+	WithoutNonces   bool `json:"without_nonces"`
+	WithoutGasCosts bool `json:"without_gas_costs"`
+}
+
+type BlockParams struct {
+	MaxBytes int64 `json:"max_bytes"`
+	MaxGas   int64 `json:"max_gas"`
+}
+
+type EvidenceParams struct {
+	MaxAgeNumBlocks int64         `json:"max_age_num_blocks"`
+	MaxAgeDuration  time.Duration `json:"max_age_duration"`
+	MaxBytes        int64         `json:"max_bytes"`
+}
+
+type ValidatorParams struct {
+	PubKeyTypes []string `json:"pub_key_types"`
+
+	// Number of blocks after which the validators join request expires if not approved
+	JoinExpiry int64 `json:"join_expiry"`
+}
+
+type VersionParams struct {
+	App uint64 `json:"app"`
+}
+
+type GenesisParams struct {
+	JoinExpiry      int64
+	WithoutGasCosts bool
+	WithoutNonces   bool
+	ChainIDPrefix   string
+}
+
+func DefaultGenesisParams() *GenesisParams {
+	return &GenesisParams{
+		JoinExpiry:      86400,
+		WithoutGasCosts: true,
+		WithoutNonces:   false,
+		ChainIDPrefix:   "kwil-chain-",
+	}
+}
+
+// Default ConsensusParams
+func defaultConsensusParams() *ConsensusParams {
+	return &ConsensusParams{
+		Block: BlockParams{
+			MaxBytes: 22020096, // 21MB
+			MaxGas:   -1,
+		},
+
+		Evidence: EvidenceParams{
+			MaxAgeNumBlocks: 100000,         // 27.8 hrs at 1block/s
+			MaxAgeDuration:  48 * time.Hour, // 2 days
+			MaxBytes:        1048576,        // 1 MB
+		},
+		Version: VersionParams{
+			App: 0,
+		},
+
+		Validator: ValidatorParams{
+			PubKeyTypes: []string{ABCIPubKeyTypeEd25519},
+			JoinExpiry:  86400, // approx 1 day considering block rate of 1 block/s
+		},
+
+		WithoutNonces:   false,
+		WithoutGasCosts: true,
+	}
+}
+
+// Generate a genesis file with default configuration
+func GenerateGenesisConfig(pkey []cmtEd.PrivKey, genParams *GenesisParams) *GenesisConfig {
+	genVals := make([]GenesisValidator, len(pkey))
+	for idx, key := range pkey {
+		pub := key.PubKey()
+		addr := pub.Address()
+		val := GenesisValidator{
+			Address: hex.EncodeToString(addr),
+			PubKey:  pub.Bytes(),
+			Power:   1,
+			Name:    fmt.Sprint("validator-", idx),
+		}
+		genVals[idx] = val
+	}
+
+	genConf := GenesisConfig{
+		ChainID:         cometbft.GenerateChainID(genParams.ChainIDPrefix),
+		GenesisTime:     genesisTime(),
+		ConsensusParams: defaultConsensusParams(),
+		Validators:      genVals,
+	}
+
+	genConf.ConsensusParams.Validator.JoinExpiry = genParams.JoinExpiry
+	genConf.ConsensusParams.WithoutGasCosts = genParams.WithoutGasCosts
+	genConf.ConsensusParams.WithoutNonces = genParams.WithoutNonces
+
+	return &genConf
+}
+
+// Write a genesis file to disk
+func (genConf *GenesisConfig) SaveAs(file string) error {
+	genDocBytes, err := json.MarshalIndent(genConf, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(file, genDocBytes, 0644)
+}
+
+// Load a genesis file from disk and parse it into a GenesisConfig
+func LoadGenesisConfig(file string) (*GenesisConfig, error) {
+	genConfig := &GenesisConfig{}
+	genDocBytes, err := os.ReadFile(file)
+	if err != nil {
+		return nil, err
+	}
+	err = json.Unmarshal(genDocBytes, genConfig)
+	if err != nil {
+		return nil, err
+	}
+	return genConfig, nil
+}
+
+func generatePrivateKeyFile(keyPath string) (cmtEd.PrivKey, error) {
+	privKey := cmtEd.GenPrivKey()
+	keyHex := hex.EncodeToString(privKey[:])
+	return privKey, os.WriteFile(keyPath, []byte(keyHex), 0600)
+}
+
+func readPrivateKeyFile(keyPath string) (cmtEd.PrivKey, error) {
+	privKeyHexB, err := os.ReadFile(keyPath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading private key file: %v", err)
+	}
+	privKeyHex := string(bytes.TrimSpace(privKeyHexB))
+	privB, err := hex.DecodeString(privKeyHex)
+	if err != nil {
+		return nil, fmt.Errorf("error decoding private key: %v", err)
+	}
+	return cmtEd.PrivKey(privB), nil
+}
+
+func readOrCreatePrivateKeyFile(keyPath string, autogen bool) (privKey cmtEd.PrivKey, newKey bool, err error) {
+	if fileExists(keyPath) {
+		privKey, err = readPrivateKeyFile(keyPath)
+		return
+	}
+	if !autogen {
+		err = fmt.Errorf("private key not found")
+		return
+	}
+
+	privKey, err = generatePrivateKeyFile(keyPath)
+	newKey = true
+	return
+}
+
+// loadGenesisAndPrivateKey generates private key and genesis file if not exist
+//
+//   - If genesis file exists but not private key file, it will generate private
+//     key and start the node as a non-validator.
+//   - Otherwise, the genesis file is generated based on the private key and
+//     starts the node as a validator.
+func LoadGenesisAndPrivateKey(autoGen bool, privKeyPath, chainRootDir string, genParams *GenesisParams) (privKey cmtEd.PrivKey, genesisCfg *GenesisConfig, newKey, newGenesis bool, err error) {
+	// Get private key:
+	//  - if private key file exists, load it.
+	//  - else if in autogen mode, generate private key and write to file.
+	//  - else fail
+
+	privKey, newKey, err = readOrCreatePrivateKeyFile(privKeyPath, autoGen)
+	if err != nil {
+		return
+	}
+
+	abciCfgDir := filepath.Join(chainRootDir, cometbft.ConfigDir)
+	genFile := filepath.Join(abciCfgDir, cometbft.GenesisJSONName) // i.e. <root>/abci/config/genesis.json
+	if fileExists(genFile) {
+		fmt.Printf("Found genesis file %v\n", genFile)
+		genesisCfg, err = LoadGenesisConfig(genFile)
+		if err != nil {
+			err = fmt.Errorf("error loading genesis file %s: %v", genFile, err)
+			return
+		}
+	} else {
+		if !autoGen {
+			err = fmt.Errorf("genesis file not found: %s", genFile)
+			return
+		}
+
+		if err = os.MkdirAll(abciCfgDir, 0755); err != nil {
+			err = fmt.Errorf("error creating abci config dir %s: %v", abciCfgDir, err)
+			return
+		}
+
+		genesisCfg = GenerateGenesisConfig([]cmtEd.PrivKey{privKey}, genParams)
+		err = genesisCfg.SaveAs(genFile)
+		if err != nil {
+			err = fmt.Errorf("unable to write genesis file %s: %v", genFile, err)
+			return
+		}
+		newGenesis = true
+	}
+
+	return
+}
+
+func genesisTime() time.Time {
+	return time.Now().Round(0).UTC()
+}
+
+/*
+AppHash: App hash in the genesis file corresponds to the initial database state.
+
+CometBFT internally hashes specific fields from the ConsensusParams from the Genesis,
+but doesn't automatically validates the rest of the fields.
+
+computeGenesisHash constructs app hash based on the fields introduced by the application
+in the genesis file which aren't monitored by cometBFT for consensus purposes.
+
+This app hash is used by the ABCI application to initialize the blockchain.
+
+Currently includes:
+  - AppHash (Database state)
+  - Join Expiry
+  - Without Gas Costs
+  - Without Nonces
+*/
+func (genConf *GenesisConfig) ComputeGenesisHash() []byte {
+	hasher := sha256.New()
+	hasher.Write(genConf.DataAppHash)
+	binary.Write(hasher, binary.LittleEndian, genConf.ConsensusParams.Validator.JoinExpiry)
+
+	if genConf.ConsensusParams.WithoutGasCosts {
+		hasher.Write([]byte{1})
+	} else {
+		hasher.Write([]byte{0})
+	}
+
+	if genConf.ConsensusParams.WithoutNonces {
+		hasher.Write([]byte{1})
+	} else {
+		hasher.Write([]byte{0})
+	}
+
+	return hasher.Sum(nil)
+}
+
+func GenerateChainID(prefix string) string {
+	return prefix + cmtrand.Str(6)
+}

--- a/internal/app/kwild/folders.go
+++ b/internal/app/kwild/folders.go
@@ -10,5 +10,8 @@ const (
 	ReceivedSnapsDirName = "rcvdSnaps"
 	SigningDirName       = "signing"
 
+	ConfigFileName     = "config.toml"
+	PrivateKeyFileName = "private_key"
+
 	// Note that the sqlLite file path is user-configurable e.g. "data/kwil.db"
 )

--- a/pkg/abci/cometbft/genesis.go
+++ b/pkg/abci/cometbft/genesis.go
@@ -1,16 +1,9 @@
 package cometbft
 
 import (
-	"encoding/hex"
-	"fmt"
-	"os"
 	"path/filepath"
 
-	cmtEd "github.com/cometbft/cometbft/crypto/ed25519"
-	cmtjson "github.com/cometbft/cometbft/libs/json"
-	cmtRand "github.com/cometbft/cometbft/libs/rand"
-	cmtTypes "github.com/cometbft/cometbft/types"
-	cmtTime "github.com/cometbft/cometbft/types/time"
+	cmtrand "github.com/cometbft/cometbft/libs/rand"
 )
 
 // NOTE: we will soon be passing the genesis doc in memory rather than file.
@@ -38,53 +31,6 @@ func AddrBookPath(chainRootDir string) string {
 	return filepath.Join(abciCfgDir, AddrBookFileName)
 }
 
-func GeneratePrivateKeyFile(keyPath string) (cmtEd.PrivKey, error) {
-	privKey := cmtEd.GenPrivKey()
-	keyHex := hex.EncodeToString(privKey[:])
-	return privKey, os.WriteFile(keyPath, []byte(keyHex), 0600)
-}
-
-func GenerateGenesisFile(path string, pkeys []cmtEd.PrivKey, chainIDPrefix string) error {
-	doc := GenesisDoc(pkeys, chainIDPrefix)
-	return doc.SaveAs(path)
-}
-
-func GenesisDocBytes(pkeys []cmtEd.PrivKey, chainIDPrefix string) ([]byte, error) {
-	doc := GenesisDoc(pkeys, chainIDPrefix)
-	return cmtjson.MarshalIndent(doc, "", "  ")
-}
-
-func GenesisDoc(pkeys []cmtEd.PrivKey, chainIDPrefix string) *cmtTypes.GenesisDoc {
-	genVals := make([]cmtTypes.GenesisValidator, len(pkeys))
-	for idx, key := range pkeys {
-		pub := key.PubKey().(cmtEd.PubKey)
-		addr := pub.Address()
-		val := cmtTypes.GenesisValidator{
-			Address: addr,
-			PubKey:  pub,
-			Power:   1,
-			Name:    fmt.Sprint("validator-", idx),
-		}
-		genVals[idx] = val
-	}
-
-	genDoc := cmtTypes.GenesisDoc{
-		ChainID:         chainIDPrefix + cmtRand.Str(6),
-		GenesisTime:     cmtTime.Now(),
-		ConsensusParams: cmtTypes.DefaultConsensusParams(),
-		Validators:      genVals,
-	}
-	return &genDoc
-}
-
-func SetGenesisAppHash(appHash []byte, genesisFile string) error {
-	genesisDoc, err := cmtTypes.GenesisDocFromFile(genesisFile)
-	if err != nil {
-		return fmt.Errorf("failed to load genesis file: %w", err)
-	}
-	genesisDoc.AppHash = appHash
-	if err := genesisDoc.SaveAs(genesisFile); err != nil {
-		return fmt.Errorf("failed to save genesis file: %w", err)
-	}
-	return nil
+func GenerateChainID(prefix string) string {
+	return prefix + cmtrand.Str(6)
 }

--- a/pkg/abci/interfaces.go
+++ b/pkg/abci/interfaces.go
@@ -30,7 +30,7 @@ type DatasetsModule interface {
 type ValidatorModule interface {
 	// GenesisInit configures the initial set of validators for the genesis
 	// block. This is only called once for a new chain.
-	GenesisInit(ctx context.Context, vals []*validators.Validator) error
+	GenesisInit(ctx context.Context, vals []*validators.Validator, blockHeight int64) error
 
 	// CurrentSet returns the current validator set. This is used on app
 	// construction to initialize the addr=>pubkey mapping.
@@ -53,6 +53,9 @@ type ValidatorModule interface {
 	// is not idempotent. The modules working list of updates is reset until
 	// subsequent join/approves are processed for the next block.
 	Finalize(ctx context.Context) []*validators.Validator // end of block processing requires providing list of updates to the node's consensus client
+
+	// Updates block height stored by the validator manager. Called in the abci Commit
+	UpdateBlockHeight(ctx context.Context, blockHeight int64)
 }
 
 // AtomicCommitter is an interface for a struct that implements atomic commits across multiple stores

--- a/pkg/abci/utils.go
+++ b/pkg/abci/utils.go
@@ -13,7 +13,7 @@ import (
 	"path/filepath"
 	"slices"
 
-	"github.com/kwilteam/kwil-db/pkg/abci/cometbft"
+	"github.com/kwilteam/kwil-db/internal/app/kwild/config"
 	"github.com/kwilteam/kwil-db/pkg/snapshots"
 
 	abciTypes "github.com/cometbft/cometbft/abci/types"
@@ -124,7 +124,7 @@ func PatchGenesisAppHash(sqliteDbDir, genesisFile string) ([]byte, error) {
 
 	// Optionally update the app_hash in the genesis file.
 	if genesisFile != "" {
-		err = cometbft.SetGenesisAppHash(genesisHash, genesisFile)
+		err = setGenesisAppHash(genesisHash, genesisFile)
 		if err != nil {
 			return nil, err
 		}
@@ -167,4 +167,17 @@ func ReadKeyFile(keyFile string) ([]byte, error) {
 		return nil, fmt.Errorf("error decoding private key: %v", err)
 	}
 	return privB, nil
+}
+
+func setGenesisAppHash(appHash []byte, genesisFile string) error {
+	genesisConf, err := config.LoadGenesisConfig(genesisFile)
+	if err != nil {
+		return fmt.Errorf("failed to load genesis file: %w", err)
+	}
+
+	genesisConf.DataAppHash = appHash
+	if err := genesisConf.SaveAs(genesisFile); err != nil {
+		return fmt.Errorf("failed to save genesis file: %w", err)
+	}
+	return nil
 }

--- a/pkg/modules/validators/interfaces.go
+++ b/pkg/modules/validators/interfaces.go
@@ -12,11 +12,12 @@ type Spender interface {
 }
 
 type ValidatorMgr interface {
-	GenesisInit(ctx context.Context, vals []*validators.Validator) error
+	GenesisInit(ctx context.Context, vals []*validators.Validator, blockHeight int64) error
 	CurrentSet(ctx context.Context) ([]*validators.Validator, error)
 	Update(ctx context.Context, validator []byte, power int64) error
 	Join(ctx context.Context, joiner []byte, power int64) error
 	Leave(ctx context.Context, joiner []byte) error
 	Approve(ctx context.Context, joiner, approver []byte) error
 	Finalize(ctx context.Context) []*validators.Validator // end of block processing requires providing list of updates to the node's consensus client
+	UpdateBlockHeight(blockHeight int64)
 }

--- a/pkg/modules/validators/status.go
+++ b/pkg/modules/validators/status.go
@@ -10,9 +10,9 @@ import (
 
 // GenesisInit is called at the genesis block to set and initial list of
 // validators.
-func (vm *ValidatorModule) GenesisInit(ctx context.Context, vals []*validators.Validator) error {
+func (vm *ValidatorModule) GenesisInit(ctx context.Context, vals []*validators.Validator, blockHeight int64) error {
 	vm.log.Warn("Resetting validator store with genesis validators.")
-	return vm.mgr.GenesisInit(ctx, vals)
+	return vm.mgr.GenesisInit(ctx, vals, blockHeight)
 }
 
 // CurrentSet returns the current validator list. This may be used on
@@ -35,4 +35,9 @@ func (vm *ValidatorModule) Punish(ctx context.Context, validator []byte, newPowe
 // requires providing list of updates to the node's consensus client
 func (vm *ValidatorModule) Finalize(ctx context.Context) []*validators.Validator {
 	return vm.mgr.Finalize(ctx)
+}
+
+// Updates block height stored by the validator manager. Called in the abci Commit
+func (vm *ValidatorModule) UpdateBlockHeight(ctx context.Context, blockHeight int64) {
+	vm.mgr.UpdateBlockHeight(blockHeight)
 }

--- a/pkg/nodecfg/toml.go
+++ b/pkg/nodecfg/toml.go
@@ -65,9 +65,7 @@ const defaultConfigTemplate = `
 #   |- application/wal
 #   |- data
 #   |   |- kwild.db/
-#   |- snapshots/
 #   |- signing/
-#   |- rcvdSnaps/   (includes the chunks rcvd from the state sync module during db restoration process, its a temp dir)
 
 # Only the config.toml and genesis file are required to run the kwild node
 # The rest of the files & directories are created by the kwild node on startup
@@ -105,12 +103,6 @@ http_listen_addr = "{{ .AppCfg.HTTPListenAddress }}"
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = {{arrayFormatter .AppCfg.ExtensionEndpoints}}
 
-# Toggle to enable gas costs for transactions and queries
-without_gas_costs = {{ .AppCfg.WithoutGasCosts }}
-
-# Toggle to disable nonces for transactions and queries
-without_nonces = {{ .AppCfg.WithoutNonces }}
-
 # KWILD Sqlite database file path
 sqlite_file_path = "{{ .AppCfg.SqliteFilePath }}"
 
@@ -133,26 +125,6 @@ tls_key_file = "{{ .AppCfg.TLSKeyFile }}"
 hostname = ""
 
 #######################################################################
-###                Snapshot store Config Options                    ###
-#######################################################################
-[app.snapshots]
-# Toggle to enable snapshot store
-# This would snapshot the application state at every snapshot_heights blocks
-# and keep max_snapshots number of snapshots in the snapshot_dir
-# Application state includes the databases deployed, accounts and the Validators db
-enabled = {{ .AppCfg.SnapshotConfig.Enabled }}
-
-# The height at which the snapshot is taken
-snapshot_heights = {{ .AppCfg.SnapshotConfig.RecurringHeight }}
-
-# Maximum number of snapshots to be kept in the snapshot_dir.
-# If max limit is reached, the oldest would be deleted and replaced by the latest snapshot
-max_snapshots = {{ .AppCfg.SnapshotConfig.MaxSnapshots}}
-
-# The directory where the snapshots are stored. Can be absolute or relative to the kwild root directory
-snapshot_dir = "{{ .AppCfg.SnapshotConfig.SnapshotDir }}"
-
-#######################################################################
 ###                 Chain  Main Base Config Options                 ###
 #######################################################################
 [chain]
@@ -170,13 +142,7 @@ moniker = "{{ .ChainCfg.Moniker }}"
 [chain.rpc]
 
 # TCP or UNIX socket address for the RPC server to listen on
-laddr = "{{ .ChainCfg.RPC.ListenAddress }}"
-
-# How long to wait for a tx to be committed during /broadcast_tx_commit.
-# WARNING: Using a value larger than 10s will result in increasing the
-# global HTTP write timeout, which applies to all connections and endpoints.
-# See https://github.com/tendermint/tendermint/issues/3435
-timeout_broadcast_tx_commit = "{{ .ChainCfg.RPC.TimeoutBroadcastTxCommit }}"
+listen_addr = "{{ .ChainCfg.RPC.ListenAddress }}"
 
 #######################################################
 ###         Consensus Configuration Options         ###
@@ -203,10 +169,10 @@ timeout_commit = "{{ .ChainCfg.Consensus.TimeoutCommit }}"
 [chain.p2p]
 
 # Address to listen for incoming connections
-laddr = "{{ .ChainCfg.P2P.ListenAddress }}"
+listen_addr = "{{ .ChainCfg.P2P.ListenAddress }}"
 
 # Address to advertise to peers for them to dial
-# If empty, will use the same port as the laddr,
+# If empty, will use the same port as the listening address,
 # and will introspect on the listener or use UPnP
 # to figure out the address. ip and port are required
 # example: 159.89.10.97:26656
@@ -246,34 +212,4 @@ size = {{ .ChainCfg.Mempool.Size }}
 
 # Size of the cache (used to filter transactions we saw earlier) in transactions
 cache_size = {{ .ChainCfg.Mempool.CacheSize }}
-
-#######################################################
-###         State Sync Configuration Options        ###
-#######################################################
-[chain.statesync]
-# State sync rapidly bootstraps a new node by discovering, fetching, and restoring a state machine
-# snapshot from peers instead of fetching and replaying historical blocks. Requires some peers in
-# the network to take and serve state machine snapshots. State sync is not attempted if the node
-# has any local state (LastBlockHeight > 0). The node will have a truncated block history,
-# starting from the height of the snapshot.
-enable = {{ .ChainCfg.StateSync.Enable }}
-
-# RPC servers (comma-separated) for light client verification of the synced state machine and
-# retrieval of state data for node bootstrapping. Also needs a trusted height and corresponding
-# header hash obtained from a trusted source, and a period during which validators can be trusted.
-#
-# For Cosmos SDK-based chains, trust_period should usually be about 2/3 of the unbonding time (~2
-# weeks) during which they can be financially punished (slashed) for misbehavior.
-rpc_servers = {{arrayFormatter .ChainCfg.StateSync.RPCServers }}
-
-# Temporary directory for state sync snapshot chunks, defaults to the OS tempdir (typically /tmp).
-# Will create a new, randomly named directory within, and remove it when done.
-temp_dir = "{{ .ChainCfg.StateSync.TempDir }}"
-
-# Time to spend discovering snapshots before initiating a restore.
-discovery_time = "{{ .ChainCfg.StateSync.DiscoveryTime }}"
-
-# The timeout duration before re-requesting a chunk, possibly from a different
-# peer (default: 1 minute).
-chunk_request_timeout = "{{ .ChainCfg.StateSync.ChunkRequestTimeout }}"
 `

--- a/pkg/nodecfg/toml_test.go
+++ b/pkg/nodecfg/toml_test.go
@@ -31,7 +31,10 @@ func Test_Generate_TOML(t *testing.T) {
 func Test_GenerateNodeCfg(t *testing.T) {
 	genCfg := NodeGenerateConfig{
 		// InitialHeight: 0,
-		OutputDir: "test/trybuild/",
+		OutputDir:       "test/trybuild/",
+		JoinExpiry:      100,
+		WithoutGasCosts: true,
+		WithoutNonces:   false,
 	}
 
 	err := GenerateNodeConfig(&genCfg)

--- a/pkg/validators/mgr.go
+++ b/pkg/validators/mgr.go
@@ -11,6 +11,7 @@ import (
 type joinReq struct {
 	pubkey     []byte
 	power      int64
+	expiresAt  int64
 	validators map[string]bool // pubkey bytes as string for map key
 }
 
@@ -52,13 +53,15 @@ func (jr *joinReq) approve(approver []byte) (repeat, eligible bool) {
 type ValidatorMgr struct {
 	db ValidatorStore
 
+	lastBlockHeight int64
 	// state - these maps are keyed by pubkey, just coerced to string for the map
 	current    map[string]struct{}
 	candidates map[string]*joinReq
 	updates    []*Validator // updates are built in BeginBlock/DeliverTx and cleared in EndBlock
 
 	// opts
-	log log.Logger
+	joinExpiry int64
+	log        log.Logger
 }
 
 // NOTE: The SQLite validator/approval store is local and transparent to the
@@ -72,7 +75,8 @@ type ValidatorStore interface {
 	CurrentValidators(ctx context.Context) ([]*Validator, error)
 	UpdateValidatorPower(ctx context.Context, validator []byte, power int64) error
 	ActiveVotes(ctx context.Context) ([]*JoinRequest, error)
-	StartJoinRequest(ctx context.Context, joiner []byte, approvers [][]byte, power int64) error
+	StartJoinRequest(ctx context.Context, joiner []byte, approvers [][]byte, power int64, expiresAt int64) error
+	DeleteJoinRequest(ctx context.Context, joiner []byte) error
 	AddApproval(ctx context.Context, joiner, approver []byte) error
 	AddValidator(ctx context.Context, joiner []byte, power int64) error
 }
@@ -91,6 +95,7 @@ func NewValidatorMgr(ctx context.Context, datastore Datastore, opts ...Validator
 		current:    make(map[string]struct{}),
 		candidates: make(map[string]*joinReq),
 		log:        log.NewNoOp(),
+		joinExpiry: 86400,
 	}
 	for _, opt := range opts {
 		opt(vm)
@@ -164,7 +169,7 @@ func (vm *ValidatorMgr) ActiveVotes(ctx context.Context) ([]*JoinRequest, error)
 
 // GenesisInit is called at the genesis block to set and initial list of
 // validators.
-func (vm *ValidatorMgr) GenesisInit(ctx context.Context, vals []*Validator) error {
+func (vm *ValidatorMgr) GenesisInit(ctx context.Context, vals []*Validator, blockHeight int64) error {
 	// Initialize the current validator map.
 	vm.current = make(map[string]struct{}, len(vals))
 	for _, vi := range vals {
@@ -172,6 +177,7 @@ func (vm *ValidatorMgr) GenesisInit(ctx context.Context, vals []*Validator) erro
 	}
 	vm.candidates = make(map[string]*joinReq)
 	vm.updates = nil
+	vm.lastBlockHeight = blockHeight
 
 	vm.log.Warn("Resetting validator store with genesis validators.")
 
@@ -222,13 +228,16 @@ func (vm *ValidatorMgr) Join(ctx context.Context, joiner []byte, power int64) er
 		valMap[pk] = false // eligible, but no vote yet
 		approvers = append(approvers, []byte(pk))
 	}
+	expiresAt := vm.lastBlockHeight + vm.joinExpiry
+
 	vm.candidates[string(joiner)] = &joinReq{
 		pubkey:     joiner,
 		power:      power,
 		validators: valMap,
+		expiresAt:  expiresAt,
 	}
 
-	return vm.db.StartJoinRequest(ctx, joiner, approvers, power)
+	return vm.db.StartJoinRequest(ctx, joiner, approvers, power, expiresAt)
 }
 
 // Leave processes a leave request for a current validator.
@@ -273,7 +282,17 @@ func (vm *ValidatorMgr) Finalize(ctx context.Context) []*Validator {
 	// Updates for approved (joining) validators.
 	for candidate, join := range vm.candidates {
 		if join.votes() < join.requiredVotes() {
-			continue // maybe next time
+
+			if vm.lastBlockHeight >= join.expiresAt {
+				// Join request expired
+				delete(vm.candidates, candidate)
+				if err := vm.db.DeleteJoinRequest(ctx, join.pubkey); err != nil {
+					panic(fmt.Sprintf("failed to delete expired join request: %v", err))
+				}
+			}
+
+			continue
+
 		}
 
 		// Candidate is above vote threshold
@@ -307,4 +326,8 @@ func (vm *ValidatorMgr) Finalize(ctx context.Context) []*Validator {
 	vm.updates = nil
 
 	return updates
+}
+
+func (mgr *ValidatorMgr) UpdateBlockHeight(height int64) {
+	mgr.lastBlockHeight = height
 }

--- a/pkg/validators/mgr_updates_test.go
+++ b/pkg/validators/mgr_updates_test.go
@@ -51,14 +51,25 @@ func (vs *stubValStore) ActiveVotes(context.Context) ([]*JoinRequest, error) {
 	return vs.joins, nil
 }
 
-func (vs *stubValStore) StartJoinRequest(_ context.Context, joiner []byte, approvers [][]byte, power int64) error {
+func (vs *stubValStore) StartJoinRequest(_ context.Context, joiner []byte, approvers [][]byte, power int64, expiresAt int64) error {
 	vs.joins = append(vs.joins, &JoinRequest{
 		Candidate: joiner,
 		Power:     power,
 		Board:     approvers,
+		ExpiresAt: expiresAt,
 		Approved:  make([]bool, len(approvers)),
 	})
 	return nil
+}
+
+func (vs *stubValStore) DeleteJoinRequest(_ context.Context, joiner []byte) error {
+	for i, ji := range vs.joins {
+		if bytes.Equal(ji.Candidate, joiner) {
+			vs.joins = append(vs.joins[:i], vs.joins[i+1:]...)
+			return nil
+		}
+	}
+	return errors.New("unknown candidate")
 }
 
 func (vs *stubValStore) AddApproval(_ context.Context, joiner []byte, approver []byte) error {
@@ -96,6 +107,7 @@ func newTestValidatorMgr(t *testing.T, store ValidatorStore) *ValidatorMgr {
 		candidates: make(map[string]*joinReq),
 		log:        log.NewStdOut(log.DebugLevel),
 		db:         store,
+		joinExpiry: 3,
 	}
 	if err := mgr.init(); err != nil {
 		t.Fatal(err)
@@ -131,7 +143,7 @@ func TestValidatorMgr_updates(t *testing.T) {
 	numVals = 3
 	genesisSet := make([]*Validator, numVals)
 	copy(genesisSet, resumeSet)
-	err = mgr.GenesisInit(ctx, genesisSet)
+	err = mgr.GenesisInit(ctx, genesisSet, 1)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/validators/opts.go
+++ b/pkg/validators/opts.go
@@ -10,3 +10,9 @@ func WithLogger(logger log.Logger) ValidatorMgrOpt {
 		v.log = logger
 	}
 }
+
+func WithJoinExpiry(joinExpiry int64) ValidatorMgrOpt {
+	return func(v *ValidatorMgr) {
+		v.joinExpiry = joinExpiry
+	}
+}

--- a/pkg/validators/store.go
+++ b/pkg/validators/store.go
@@ -113,11 +113,11 @@ func (vs *validatorStore) AddValidator(ctx context.Context, joiner []byte, power
 	return vs.addValidator(ctx, joiner, power)
 }
 
-func (vs *validatorStore) StartJoinRequest(ctx context.Context, joiner []byte, approvers [][]byte, power int64) error {
+func (vs *validatorStore) StartJoinRequest(ctx context.Context, joiner []byte, approvers [][]byte, power int64, expiresAt int64) error {
 	vs.rw.Lock()
 	defer vs.rw.Unlock()
 
-	return vs.startJoinRequest(ctx, joiner, approvers, power)
+	return vs.startJoinRequest(ctx, joiner, approvers, power, expiresAt)
 }
 
 // AddApproval records that a certain validator has approved the join request
@@ -127,4 +127,12 @@ func (vs *validatorStore) AddApproval(ctx context.Context, joiner, approver []by
 	defer vs.rw.Unlock()
 
 	return vs.addApproval(ctx, joiner, approver)
+}
+
+// Delete a join request
+func (vs *validatorStore) DeleteJoinRequest(ctx context.Context, joiner []byte) error {
+	vs.rw.Lock()
+	defer vs.rw.Unlock()
+
+	return vs.deleteJoinRequest(ctx, joiner)
 }

--- a/pkg/validators/validator.go
+++ b/pkg/validators/validator.go
@@ -9,7 +9,9 @@
 // engine punishing a validator for some bad behavior.
 package validators
 
-import "fmt"
+import (
+	"fmt"
+)
 
 type Validator struct {
 	PubKey []byte
@@ -23,6 +25,7 @@ func (v *Validator) String() string {
 type JoinRequest struct {
 	Candidate []byte   // pubkey of the candidate validator
 	Power     int64    // the requested power
+	ExpiresAt int64    // the block height at which the join request expires
 	Board     [][]byte // slice of pubkeys of all the eligible voting validators
 	Approved  []bool   // if they approved
 }

--- a/test/acceptance/docker-compose.yml
+++ b/test/acceptance/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       --app.grpc_listen_addr=:50051
       --app.http_listen_addr=:8080
       --chain.p2p.external_address=tcp://0.0.0.0:26656
-      --chain.rpc.laddr=tcp://0.0.0.0:26657
+      --chain.rpc.listen_addr=tcp://0.0.0.0:26657
 
   ext:
     container_name: math_ext

--- a/test/acceptance/helper.go
+++ b/test/acceptance/helper.go
@@ -171,7 +171,10 @@ func (r *ActHelper) generateNodeConfig() {
 
 	err := nodecfg.GenerateNodeConfig(&nodecfg.NodeGenerateConfig{
 		// InitialHeight: 0,
-		OutputDir: tmpPath,
+		OutputDir:       tmpPath,
+		JoinExpiry:      86400,
+		WithoutGasCosts: true,
+		WithoutNonces:   false,
 	})
 	require.NoError(r.t, err, "failed to generate node config")
 

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -72,7 +72,7 @@ func TestKwildAcceptance(t *testing.T) {
 			specifications.DatabaseDropSpecification(ctx, t, creatorDriver)
 
 			// there's one node in the network and we're the validator
-			specifications.NetworkNodeValidatorSetSpecification(ctx, t, creatorDriver, 1)
+			specifications.CurrentValidatorsSpecification(ctx, t, creatorDriver, 1)
 
 			// The other network/validator specs require multiple nodes in a network
 		})

--- a/test/integration/docker-compose.yml
+++ b/test/integration/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       --app.grpc_listen_addr=:50051
       --app.http_listen_addr=:8080
       --chain.p2p.external_address=tcp://0.0.0.0:26656
-      --chain.rpc.laddr=tcp://0.0.0.0:26657
+      --chain.rpc.listen_addr=tcp://0.0.0.0:26657
 
   node1:
     container_name: node1
@@ -56,7 +56,7 @@ services:
       --app.grpc_listen_addr=:50051
       --app.http_listen_addr=:8080
       --chain.p2p.external_address=tcp://0.0.0.0:26656
-      --chain.rpc.laddr=tcp://0.0.0.0:26657
+      --chain.rpc.listen_addr=tcp://0.0.0.0:26657
 
   node2:
     container_name: node2
@@ -84,7 +84,7 @@ services:
       --app.grpc_listen_addr=:50051
       --app.http_listen_addr=:8080
       --chain.p2p.external_address=tcp://0.0.0.0:26656
-      --chain.rpc.laddr=tcp://0.0.0.0:26657
+      --chain.rpc.listen_addr=tcp://0.0.0.0:26657
 
   # This node is used to test the scenario where new node join the network & sync the blocks
   # Removing the ext dependency as test-container docker compose creates a new project everytime we run
@@ -113,7 +113,7 @@ services:
       --app.grpc_listen_addr=:50051
       --app.http_listen_addr=:8080
       --chain.p2p.external_address=tcp://0.0.0.0:26656
-      --chain.rpc.laddr=tcp://0.0.0.0:26657
+      --chain.rpc.listen_addr=tcp://0.0.0.0:26657
 
   # this ext is shared by all nodes
   # we can make a separate ext for each node if we want

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -72,6 +72,7 @@ type IntTestConfig struct {
 
 	NValidator    int
 	NNonValidator int
+	JoinExpiry    int64
 }
 
 type IntHelper struct {
@@ -88,7 +89,9 @@ func NewIntHelper(t *testing.T, opts ...HelperOpt) *IntHelper {
 		t:           t,
 		privateKeys: make(map[string]ed25519.PrivKey),
 		containers:  make(map[string]*testcontainers.DockerContainer),
-		cfg:         &IntTestConfig{},
+		cfg: &IntTestConfig{
+			JoinExpiry: 86400,
+		},
 	}
 
 	helper.LoadConfig()
@@ -111,6 +114,12 @@ func WithValidators(n int) HelperOpt {
 func WithNonValidators(n int) HelperOpt {
 	return func(r *IntHelper) {
 		r.cfg.NNonValidator = n
+	}
+}
+
+func WithJoinExpiry(expiry int64) HelperOpt {
+	return func(r *IntHelper) {
+		r.cfg.JoinExpiry = expiry
 	}
 }
 
@@ -183,6 +192,9 @@ func (r *IntHelper) generateNodeConfig() {
 		HostnameSuffix:          "",
 		StartingIPAddress:       "172.10.100.2",
 		P2pPort:                 26656,
+		JoinExpiry:              r.cfg.JoinExpiry,
+		WithoutGasCosts:         true,
+		WithoutNonces:           true,
 	})
 	require.NoError(r.t, err, "failed to generate testnet config")
 	r.home = tmpPath

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -63,6 +63,7 @@ func TestKwildValidatorUpdatesIntegration(t *testing.T) {
 	opts := []integration.HelperOpt{
 		integration.WithValidators(3),
 		integration.WithNonValidators(1),
+		integration.WithJoinExpiry(15),
 	}
 
 	testDrivers := strings.Split(*drivers, ",")
@@ -85,7 +86,15 @@ func TestKwildValidatorUpdatesIntegration(t *testing.T) {
 			joinerPubKey := joinerPkey.PubKey().Bytes()
 
 			// Start the network with 3 validators & 1 Non-validator
-			specifications.NetworkNodeValidatorSetSpecification(ctx, t, node0Driver, 3)
+			specifications.CurrentValidatorsSpecification(ctx, t, node0Driver, 3)
+
+			/*
+				Join Expiry:
+				- Node3 requests to join
+				- No approval from other nodes
+				- Join request should expire after 15 blocks (15secs)
+			*/
+			specifications.ValidatorJoinExpirySpecification(ctx, t, joinerDriver, joinerPubKey)
 
 			/*
 			 Join Process:
@@ -93,27 +102,27 @@ func TestKwildValidatorUpdatesIntegration(t *testing.T) {
 			 - Requires atleast 2 nodes to approve
 			 - Consensus reached, Node3 is a Validator
 			*/
-			specifications.NetworkNodeJoinSpecification(ctx, t, joinerDriver, joinerPubKey, 3)
+			specifications.ValidatorNodeJoinSpecification(ctx, t, joinerDriver, joinerPubKey, 3)
 			// Node 0,1 approves
-			specifications.NetworkNodeApproveSpecification(ctx, t, node0Driver, joinerPubKey, 3, 3, false)
-			specifications.NetworkNodeApproveSpecification(ctx, t, node1Driver, joinerPubKey, 3, 4, true)
-			specifications.NetworkNodeValidatorSetSpecification(ctx, t, node0Driver, 4)
+			specifications.ValidatorNodeApproveSpecification(ctx, t, node0Driver, joinerPubKey, 3, 3, false)
+			specifications.ValidatorNodeApproveSpecification(ctx, t, node1Driver, joinerPubKey, 3, 4, true)
+			specifications.CurrentValidatorsSpecification(ctx, t, node0Driver, 4)
 
 			/*
 			 Leave Process:
 			 - node3 issues a leave request -> removes it from the validator list
 			 - Validatorset count should be reduced by 1
 			*/
-			specifications.NetworkNodeLeaveSpecification(ctx, t, joinerDriver)
+			specifications.ValidatorNodeLeaveSpecification(ctx, t, joinerDriver)
 
 			/*
 			 Rejoin: (same as join process)
 			*/
-			specifications.NetworkNodeJoinSpecification(ctx, t, joinerDriver, joinerPubKey, 3)
+			specifications.ValidatorNodeJoinSpecification(ctx, t, joinerDriver, joinerPubKey, 3)
 			// Node 0, 1 approves
-			specifications.NetworkNodeApproveSpecification(ctx, t, node0Driver, joinerPubKey, 3, 3, false)
-			specifications.NetworkNodeApproveSpecification(ctx, t, node1Driver, joinerPubKey, 3, 4, true)
-			specifications.NetworkNodeValidatorSetSpecification(ctx, t, node0Driver, 4)
+			specifications.ValidatorNodeApproveSpecification(ctx, t, node0Driver, joinerPubKey, 3, 3, false)
+			specifications.ValidatorNodeApproveSpecification(ctx, t, node1Driver, joinerPubKey, 3, 4, true)
+			specifications.CurrentValidatorsSpecification(ctx, t, node0Driver, 4)
 		})
 	}
 }

--- a/test/specifications/validator_ops.go
+++ b/test/specifications/validator_ops.go
@@ -2,34 +2,40 @@ package specifications
 
 import (
 	"context"
+	"errors"
 	"testing"
+	"time"
 
 	"github.com/kwilteam/kwil-db/pkg/validators"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
-func NetworkNodeValidatorSetSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, count int) {
+func CurrentValidatorsSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, count int) {
 	t.Log("Executing network node validator set specification")
 	vals, err := netops.ValidatorsList(ctx)
 	require.NoError(t, err)
 	require.Equal(t, count, len(vals))
 }
 
-func NetworkNodeJoinSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, joiner []byte, valCount int) {
+func ValidatorNodeJoinSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, joiner []byte, valCount int) {
 	t.Log("Executing network node join specification")
 	// ValidatorSet count doesn't change just by issuing a Join request. Pre and Post cnt should be the same.
 	vals, err := netops.ValidatorsList(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, valCount, len(vals))
 
+	// Validator issues a Join request
 	rec, err := netops.ValidatorNodeJoin(ctx)
 	assert.NoError(t, err)
 
 	// Ensure that the Tx is mined.
 	expectTxSuccess(t, netops, ctx, rec, defaultTxQueryTimeout)()
 
-	// Get Request status, #approvals = 0
+	// Get Request status, #approvals = 0, #board = valCount
 	joinStatus, err := netops.ValidatorJoinStatus(ctx, joiner)
 	assert.NoError(t, err)
 	assert.Equal(t, valCount, len(joinStatus.Board))
@@ -41,13 +47,15 @@ func NetworkNodeJoinSpecification(ctx context.Context, t *testing.T, netops Vali
 	assert.Equal(t, valCount, len(vals))
 }
 
-func NetworkNodeApproveSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, joiner []byte, preCnt int, postCnt int, approved bool) {
+func ValidatorNodeApproveSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, joiner []byte, preCnt int, postCnt int, approved bool) {
 	t.Log("Executing network node approve specification")
-	// Pre approval verification
+
+	// Get current validator count, should be equal to preCnt
 	vals, err := netops.ValidatorsList(ctx)
 	assert.NoError(t, err)
 	assert.Equal(t, preCnt, len(vals))
 
+	// Get Join Request status, #board = preCnt
 	joinStatus, err := netops.ValidatorJoinStatus(ctx, joiner)
 	assert.NoError(t, err)
 	assert.Equal(t, preCnt, len(joinStatus.Board))
@@ -60,7 +68,11 @@ func NetworkNodeApproveSpecification(ctx context.Context, t *testing.T, netops V
 	// Ensure that the Tx is mined.
 	expectTxSuccess(t, netops, ctx, rec, defaultTxQueryTimeout)()
 
-	// Check Join Request Status to ensure that the vote is included
+	/*
+		Check Join Request Status:
+		- If Join request approved (2/3rd majority), Join request should be removed
+		- If not approved, ensure that the vote is included, i.e #approvals = preApprovalCnt + 1
+	*/
 	joinStatus, err = netops.ValidatorJoinStatus(ctx, joiner)
 	if approved {
 		assert.Error(t, err)
@@ -77,19 +89,22 @@ func NetworkNodeApproveSpecification(ctx context.Context, t *testing.T, netops V
 	assert.Equal(t, postCnt, len(vals))
 }
 
-func NetworkNodeLeaveSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl) {
+func ValidatorNodeLeaveSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl) {
 	t.Log("Executing network node leave specification")
 
+	// Get current validator count
 	vals, err := netops.ValidatorsList(ctx)
 	assert.NoError(t, err)
 	preCnt := len(vals)
 
+	// Validator issues a Leave request
 	rec, err := netops.ValidatorNodeLeave(ctx)
 	assert.NoError(t, err)
 
-	// Ensure that the Tx is mined.
+	// Ensure that the Validator Leave Tx is mined.
 	expectTxSuccess(t, netops, ctx, rec, defaultTxQueryTimeout)()
 
+	// ValidatorSet count should be reduced by 1
 	vals, err = netops.ValidatorsList(ctx)
 	assert.NoError(t, err)
 	postCnt := len(vals)
@@ -104,4 +119,28 @@ func approvalCount(joinStatus *validators.JoinRequest) int {
 		}
 	}
 	return cnt
+}
+
+func ValidatorJoinExpirySpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, joiner []byte) {
+	t.Log("Executing validator join expiry specification")
+
+	// Issue a join request
+	rec, err := netops.ValidatorNodeJoin(ctx)
+	assert.NoError(t, err)
+
+	// Ensure that the Tx is mined.
+	expectTxSuccess(t, netops, ctx, rec, defaultTxQueryTimeout)()
+
+	// Get Request status, #approvals = 0
+	joinStatus, err := netops.ValidatorJoinStatus(ctx, joiner)
+	assert.NoError(t, err)
+	assert.Equal(t, 0, approvalCount(joinStatus))
+
+	// Wait for 15 blocks aka 15 secs for the join request to expire
+	time.Sleep(30 * time.Second)
+
+	// join request should be expired and removed
+	joinStatus, err = netops.ValidatorJoinStatus(ctx, joiner)
+	errors.Is(err, status.Error(codes.NotFound, "no active join request"))
+	assert.Nil(t, joinStatus)
 }


### PR DESCRIPTION
- Validator module is height aware, and Join expiry is handled using the block heights. If approval quota is not met within a configured number of blocks, the request will expire
- Added Integration tests for join expiry
- Added JoinExpiry under Validator ConsensusParams in Genesis File
- Moved WithoutGasCosts and WithoutNonces to the Genesis File's ConsensusParams
- admin tools are updated to add these fields. 

- Chain will be initialized with the hash generated from the genesisHash, joinExpiry, nonces and gasCosts config.  Cometbft takes care of ensuring consensus on the other config, so the genesisHash that we generate from the app side would include only the config used by kwildb

Haven't addressed schema migration yet, will look into it in other PR.