### PR TITLE
fix buildkit typo in docker build script, add ignores

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,3 +7,17 @@ build/package/docker/
 .gitattributes
 .gitignore
 .DS_Store
+test/
+proto/
+deployments/
+.editorconfig
+.gitmodules
+.golangci.yml
+.goreleaser.yaml
+.local_env
+cmd/kwild/kwild
+cmd/kwil-admin/kwil-admin
+cmd/kwil-cli/kwil-cli
+**/__debug_bin.exe
+**/__debug_bin*
+**/_*

--- a/build/package/docker/kwild.dockerfile
+++ b/build/package/docker/kwild.dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine AS stage
+FROM golang:alpine AS build
 
 ARG version
 ARG build_time
@@ -13,9 +13,9 @@ RUN test -f go.work && rm go.work || true
 RUN GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" ./scripts/build/binary kwild
 RUN chmod +x /app/dist/kwild-*
 
-FROM scratch
+FROM scratch AS assemble
 WORKDIR /app
-COPY --from=stage /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
-COPY --from=stage /app/dist/kwild-* ./kwild
+COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
+COPY --from=build /app/dist/kwild-* ./kwild
 EXPOSE 50051 8080 26656 26657
 ENTRYPOINT ["/app/kwild"]

--- a/scripts/build/docker
+++ b/scripts/build/docker
@@ -20,6 +20,6 @@ BUILD_ARGS="${BUILD_ARGS} --build-arg version=${GIT_VERSION}"
 BUILD_ARGS="${BUILD_ARGS} --build-arg git_commit=${GIT_COMMIT}"
 BUILD_ARGS="${BUILD_ARGS} --build-arg build_time=${BUILD_TIME}"
 
-export DOCKDER_BUILDKIT=1
+export DOCKER_BUILDKIT=1
 
-docker build .  -t "${IMAGE}:${GIT_VERSION}" -t "${IMAGE}:latest" ${BUILD_ARGS} -f "./build/package/docker/${DOCKER_FILE}" --progress=plain
+docker build .  -t "${IMAGE}:${GIT_VERSION}" -t "${IMAGE}:latest" ${BUILD_ARGS} -f "./build/package/docker/${DOCKER_FILE}" --progress=auto


### PR DESCRIPTION
I just noticed a typo in an environment variable name that is intended for docker to recognize, but this also tweaks some things that could make the image build faster.