### PR TITLE
undo invalid auto-init docker image

### DIFF
--- a/scripts/publish/dockerhub
+++ b/scripts/publish/dockerhub
@@ -7,4 +7,4 @@ set -eu
 
 echo Building kwild for multiarch and pushing to dockerhub, tag: ${TAG}
 
-docker buildx build --platform linux/amd64,linux/arm64/v8 -t kwildb/kwil:${TAG} --push -f ./build/package/docker/kwild.auto-init.dockerfile .
+docker buildx build --platform linux/amd64,linux/arm64/v8 -t kwildb/kwil:${TAG} --push -f ./build/package/docker/kwild.shell.dockerfile .


### PR DESCRIPTION
This was incorrectly cherry-picked from the idos pre-release branch.  Build and publish a docker image on main.