### PR TITLE
purify config pkgs of comet

### DIFF
--- a/cmd/kwild/main.go
+++ b/cmd/kwild/main.go
@@ -47,7 +47,8 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to load kwild config: %w", err)
 		}
 
-		if err := kwildCfg.InitPrivateKeyAndGenesis(); err != nil {
+		nodeKey, genesisConfig, err := kwildCfg.InitPrivateKeyAndGenesis()
+		if err != nil {
 			return fmt.Errorf("failed to initialize private key and genesis: %w", err)
 		}
 
@@ -60,7 +61,7 @@ var rootCmd = &cobra.Command{
 			cancel()
 		}()
 
-		svr, err := server.New(ctx, kwildCfg)
+		svr, err := server.New(ctx, kwildCfg, genesisConfig, nodeKey)
 		if err != nil {
 			return err
 		}

--- a/internal/app/kwild/config/default_config.toml
+++ b/internal/app/kwild/config/default_config.toml
@@ -1,5 +1,4 @@
-# This is a TOML config file.
-# For more information, see https://github.com/toml-lang/toml
+# The is an example config file for kwild.
 
 # NOTE: Any path below can be absolute (e.g. "/var/myawesomeapp/data") or
 # relative to the root directory (e.g. "data"). The root directory is

--- a/internal/app/kwild/server/cometbft.go
+++ b/internal/app/kwild/server/cometbft.go
@@ -1,7 +1,7 @@
 package server
 
 import (
-	"encoding/hex"
+	"fmt"
 	"path/filepath"
 
 	"github.com/kwilteam/kwil-db/internal/app/kwild/config"
@@ -108,15 +108,12 @@ func extractGenesisDoc(g *config.GenesisConfig) (*cmttypes.GenesisDoc, error) {
 	}
 
 	for _, v := range g.Validators {
-		// Addr in Hex string format, convert back to HexBytes.
-		addr, err := hex.DecodeString(v.Address)
-		if err != nil {
-			return nil, err
+		if len(v.PubKey) != cmtEd.PubKeySize {
+			return nil, fmt.Errorf("pubkey is incorrect size: %v", v.PubKey.String())
 		}
-
 		pubKey := cmtEd.PubKey(v.PubKey)
 		genDoc.Validators = append(genDoc.Validators, cmttypes.GenesisValidator{
-			Address: addr,
+			Address: pubKey.Address(),
 			PubKey:  pubKey,
 			Power:   v.Power,
 			Name:    v.Name,

--- a/pkg/abci/cometbft/genesis.go
+++ b/pkg/abci/cometbft/genesis.go
@@ -2,8 +2,6 @@ package cometbft
 
 import (
 	"path/filepath"
-
-	cmtrand "github.com/cometbft/cometbft/libs/rand"
 )
 
 // NOTE: we will soon be passing the genesis doc in memory rather than file.
@@ -29,8 +27,4 @@ func GenesisPath(chainRootDir string) string {
 func AddrBookPath(chainRootDir string) string {
 	abciCfgDir := filepath.Join(chainRootDir, ConfigDir)
 	return filepath.Join(abciCfgDir, AddrBookFileName)
-}
-
-func GenerateChainID(prefix string) string {
-	return prefix + cmtrand.Str(6)
 }

--- a/pkg/nodecfg/toml.go
+++ b/pkg/nodecfg/toml.go
@@ -10,8 +10,6 @@ import (
 	"github.com/kwilteam/kwil-db/internal/app/kwild/config"
 )
 
-const defaultDirPerm = 0755
-
 var configTemplate *template.Template
 
 func init() {
@@ -33,15 +31,15 @@ func arrayFormatter(items []string) string {
 	return "[" + strings.Join(formattedStrings, ", ") + "]"
 }
 
-// kwildTemplateConfig
-func writeConfigFile(configFilePath string, cfg *config.KwildConfig) {
+// writeConfigFile writes the config to a file.
+func writeConfigFile(configFilePath string, cfg *config.KwildConfig) error {
 	var buffer bytes.Buffer
 
 	if err := configTemplate.Execute(&buffer, cfg); err != nil {
-		panic(err)
+		return err
 	}
 
-	os.WriteFile(configFilePath, buffer.Bytes(), defaultDirPerm)
+	return os.WriteFile(configFilePath, buffer.Bytes(), nodeDirPerm)
 }
 
 const defaultConfigTemplate = `

--- a/pkg/sql/sqlite/connection.go
+++ b/pkg/sql/sqlite/connection.go
@@ -302,7 +302,6 @@ func (c *Connection) Query(ctx context.Context, statement string, options ...Exe
 
 	results, err := c.query(ctx, statement, removeNilVals(options)...)
 	if err != nil {
-		c.log.Error("failed to execute query", zap.Error(err))
 		return nil, err
 	}
 

--- a/pkg/sql/sqlite/savepoint.go
+++ b/pkg/sql/sqlite/savepoint.go
@@ -50,24 +50,9 @@ func (sp *Savepoint) Rollback() error {
 	return sp.conn.Execute("RELEASE " + sp.saveName)
 }
 
-var letterRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
-var alphanumericRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
-
-var rnd = random.New()
-
 func randomSavepointName(length int) string {
 	if length < 2 {
 		panic("Length must be at least 2 to generate a valid savepoint name.")
 	}
-
-	result := make([]rune, length)
-	// First character must be a letter
-	result[0] = letterRunes[rnd.Intn(len(letterRunes))]
-
-	// Rest of the characters can be alphanumeric
-	for i := 1; i < length; i++ {
-		result[i] = alphanumericRunes[rnd.Intn(len(alphanumericRunes))]
-	}
-
-	return string(result)
+	return random.String(length)
 }

--- a/pkg/utils/random/crypto.go
+++ b/pkg/utils/random/crypto.go
@@ -36,3 +36,5 @@ var _ rand.Source64 = &Source
 func New() *rand.Rand {
 	return rand.New(Source)
 }
+
+var rng = rand.New(Source)

--- a/pkg/utils/random/string.go
+++ b/pkg/utils/random/string.go
@@ -1,0 +1,22 @@
+package random
+
+var (
+	letterRunes       = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz")
+	alphanumericRunes = []rune("ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789")
+)
+
+// String returns a random string of alphanumeric characters. The first
+// character will be a letter. If you need the first character to include
+// digits, generate a longer string and trim the first character.
+func String(length int) string {
+	result := make([]rune, length)
+	// First character must be a letter
+	result[0] = letterRunes[rng.Intn(len(letterRunes))]
+
+	// Rest of the characters can be alphanumeric
+	for i := 1; i < length; i++ {
+		result[i] = alphanumericRunes[rng.Intn(len(alphanumericRunes))]
+	}
+
+	return string(result)
+}

--- a/pkg/validators/sql.go
+++ b/pkg/validators/sql.go
@@ -84,7 +84,7 @@ const (
 		version INT NOT NULL
     );` // Do we still need WITHOUT ROWID and STRICT? It's just a single row table
 
-	sqlSetVersion = "INSERT INTO schema_version (version) VALUES ($version);"
+	sqlInitVersionRow = "INSERT INTO schema_version (version) VALUES ($version);"
 
 	//sqlUpdateVersion = "UPDATE schema_version SET version = $version;"
 
@@ -104,7 +104,7 @@ func (vs *validatorStore) initSchemaVersion(ctx context.Context) error {
 		return fmt.Errorf("failed to initialize schema version table: %w", err)
 	}
 
-	err := vs.db.Execute(ctx, sqlSetVersion, map[string]any{
+	err := vs.db.Execute(ctx, sqlInitVersionRow, map[string]any{
 		"$version": valStoreVersion,
 	})
 	if err != nil {

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -274,7 +274,7 @@ func (r *IntHelper) WaitForSignals(t *testing.T) {
 }
 
 func (r *IntHelper) ExtractPrivateKeys() {
-	regexPath := filepath.Join(r.home, "*/private_key")
+	regexPath := filepath.Join(r.home, "*", "private_key")
 
 	files, err := filepath.Glob(regexPath)
 	require.NoError(r.t, err, "failed to get private key files")


### PR DESCRIPTION
```
config: revise genesis validator format, minor fixes

This change remove address field from genesis.json because it is
redundant, and use HexBytes for the pubkey. This is a breaking
change, and prior genesis.json files will be be readable.

Remove convenience fields from KwildConfig that were not from
the config.toml or cli flags. They are passed directly to the
kwild Server constructor.

Other minor changes:

Make our own pkg/utils/random.String function, which is based
on the random savepoint generator, so this is reused in a
couple spots now. Also avoids using comet's rand package.

In pkg/nodecfg.GenerateNodeConfig do not update any existing
genesis file.

Make sure `--autogen` will create the root directory if it does
not exist.

Disable the sqlite.Connection's logging of Query errors because
it returns the error to the caller.  That's an antipattern that
makes logs that the higher levels of the application cannot
silence, and which are likely to be duplicated.
```