### PR TITLE
feat(sqlparser): remove identifier surrounding tokens

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,7 @@ require (
 	github.com/kwilteam/go-sqlite v0.0.0-20230606000142-c7eaa7111421
 	github.com/kwilteam/kuneiform v0.5.0-alpha.0.20230904052536-cb47bf390d18
 	github.com/kwilteam/kwil-extensions v0.0.0-20230710163303-bfa03f64ff82
-	github.com/kwilteam/sql-grammar-go v0.0.2
+	github.com/kwilteam/sql-grammar-go v0.0.3-0.20230925230724-00685e1bac32
 	github.com/manifoldco/promptui v0.9.0
 	github.com/olekukonko/tablewriter v0.0.5
 	github.com/spf13/cobra v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -575,8 +575,8 @@ github.com/kwilteam/kuneiform v0.5.0-alpha.0.20230904052536-cb47bf390d18 h1:7dWH
 github.com/kwilteam/kuneiform v0.5.0-alpha.0.20230904052536-cb47bf390d18/go.mod h1:brcnYttEhcbfuyFZSaEOYDmvIVx78hxiR+c3ZsJYwTE=
 github.com/kwilteam/kwil-extensions v0.0.0-20230710163303-bfa03f64ff82 h1:pA0ya2WrncGSxxXB0g3dVq1jZZSm1HO6Qp0/yYn4qks=
 github.com/kwilteam/kwil-extensions v0.0.0-20230710163303-bfa03f64ff82/go.mod h1:+BrFrV+3qcdYIfptqjwatE5gT19azuRHJzw77wMPY8c=
-github.com/kwilteam/sql-grammar-go v0.0.2 h1:Tg8xo/Pzd72QsO19wwNvFrpw2muuBaERP7XTv21U4Iw=
-github.com/kwilteam/sql-grammar-go v0.0.2/go.mod h1:OqmGyCwHfBZvYv/sYPrQ5Ih290dhlD5AcKOHDlUSS0Y=
+github.com/kwilteam/sql-grammar-go v0.0.3-0.20230925230724-00685e1bac32 h1:NDMw+6BKSqLxFyfpbbCJNx8EOLB3+ugCUEnMpomXBeQ=
+github.com/kwilteam/sql-grammar-go v0.0.3-0.20230925230724-00685e1bac32/go.mod h1:OqmGyCwHfBZvYv/sYPrQ5Ih290dhlD5AcKOHDlUSS0Y=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v0.0.0-20150723085316-0dad96c0b94f/go.mod h1:5WUZQaWbwv1U+lTReE5YruASi9Al49XbQIvNi/34Woo=

--- a/pkg/engine/sqlparser/visitor_test.go
+++ b/pkg/engine/sqlparser/visitor_test.go
@@ -1,0 +1,28 @@
+package sqlparser
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func Test_extractIdentifierValue(t *testing.T) {
+	tests := []struct {
+		name string
+		args string
+		want string
+	}{
+		{"empty", "", ""},
+		{"asymmetric quotes with double quotes", `"a`, `"a`},
+		{"asymmetric quotes with bracket quote", `[a`, `[a`},
+		{"asymmetric quotes with back tick quote", "`a", "`a"},
+		{"double quotes", `"a"`, `a`},
+		{"bracket quotes", `[a]`, `a`},
+		{"back tick quotes", "`a`", `a`},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equalf(t, tt.want, extractSQLName(tt.args), "extractSQLName(%v)", tt.args)
+		})
+	}
+}

--- a/test/acceptance/test-data/test_db.kf
+++ b/test/acceptance/test-data/test_db.kf
@@ -25,18 +25,18 @@ table posts {
 }
 
 action create_user($id, $username, $age) public {
-    INSERT INTO users (id, username, age, wallet)
+    INSERT INTO "users" (id, username, age, wallet)
     VALUES ($id, $username, $age, @caller);
 }
 
 action update_user($id, $username, $age) public {
-    UPDATE users
+    UPDATE [users]
     SET id = $id, username = $username, age = $age
     WHERE wallet = @caller;
 }
 
 action update_username($username) public {
-    UPDATE users
+    UPDATE `users`
     SET username = $username
     WHERE wallet = @caller;
 }
@@ -47,9 +47,10 @@ action delete_user() public {
 }
 
 action delete_user_by_id ($id) public owner {
-    DELETE FROM users
-    WHERE id = $id;
+    DELETE FROM "users"
+    WHERE id = $id AND public_key(wallet) = public_key(@caller);
 }
+
 
 action create_post($id, $title, $content) public {
     INSERT INTO posts (id, user_id, title, content)
@@ -102,7 +103,7 @@ action get_post_authenticated($id) public view mustsign {
 
 action get_post_unauthenticated($id) public view {
     SELECT *
-    FROM posts
+    FROM "posts"
     WHERE id = $id;
 }
 

--- a/test/integration/test-data/test_db.kf
+++ b/test/integration/test-data/test_db.kf
@@ -12,7 +12,7 @@ table users {
     id int primary notnull,
     username text default('sds'),
     age int min(0),
-    wallet text unique
+    wallet blob unique
 }
 
 table posts {
@@ -25,36 +25,36 @@ table posts {
 }
 
 action create_user($id, $username, $age) public {
-    INSERT INTO users (id, username, age, wallet)
-    VALUES ($id, $username, $age, public_key(@caller, 'hex'));
+    INSERT INTO "users" (id, username, age, wallet)
+    VALUES ($id, $username, $age, @caller);
 }
 
 action update_user($id, $username, $age) public {
-    UPDATE users
+    UPDATE [users]
     SET id = $id, username = $username, age = $age
-    WHERE wallet = public_key(@caller, 'hex');
+    WHERE wallet = @caller;
 }
 
 action update_username($username) public {
-    UPDATE users
+    UPDATE `users`
     SET username = $username
-    WHERE wallet = public_key(@caller, 'hex');
+    WHERE wallet = @caller;
 }
 
 action delete_user() public {
     DELETE FROM users
-    WHERE wallet = public_key(@caller, 'hex');
+    WHERE public_key(wallet) = public_key(@caller);
 }
 
 action delete_user_by_id ($id) public owner {
-    DELETE FROM users
-    WHERE id = $id;
+    DELETE FROM "users"
+    WHERE id = $id AND public_key(wallet) = public_key(@caller);
 }
 
 action create_post($id, $title, $content) public {
     INSERT INTO posts (id, user_id, title, content)
     VALUES ($id, (
-        SELECT id FROM users WHERE wallet = public_key(@caller, 'hex')
+        SELECT id FROM users WHERE wallet = @caller
     ), $title, $content);
 }
 
@@ -63,7 +63,7 @@ action delete_post($id) public {
     WHERE id = $id AND user_id = (
         SELECT id
         FROM users
-        WHERE wallet = public_key(@caller, 'hex')
+        WHERE wallet = @caller
     );
 }
 
@@ -102,7 +102,7 @@ action get_post_authenticated($id) public view mustsign {
 
 action get_post_unauthenticated($id) public view {
     SELECT *
-    FROM posts
+    FROM "posts"
     WHERE id = $id;
 }
 
@@ -118,6 +118,6 @@ action divide($numerator, $denominator) public view {
     select $up AS upper_value, $down AS lower_value;
 }
 
-action owner_only() public owner view {
+action owner_only() public owner view mustsign {
     select 'owner only';
 }


### PR DESCRIPTION
resolves #255 

This pr reformats following names in sqlparser, by removing the surrounding tokens:
- table name
- table name alias
- column name
- column name alias
- function name
- collation name 
- index name 