### PR TITLE
fix logwrapper dropping kv pairs, add tests

### DIFF
--- a/pkg/abci/cometbft/node.go
+++ b/pkg/abci/cometbft/node.go
@@ -83,11 +83,11 @@ func (lw *LogWrapper) With(kvs ...any) cometLog.Logger {
 }
 
 func keyValsToFields(kvs []any) []zap.Field {
-	if len(kvs)%2 != 0 {
+	n := len(kvs)
+	if n%2 != 0 {
 		kvs = append(kvs, errors.New("missing value"))
 	}
-	n := len(kvs) / 2
-	fields := make([]zap.Field, 0, n)
+	fields := make([]zap.Field, 0, n/2)
 	for i := 0; i < n; i += 2 {
 		fields = append(fields, zap.Any(toString(kvs[i]), kvs[i+1]))
 	}

--- a/pkg/abci/cometbft/node_test.go
+++ b/pkg/abci/cometbft/node_test.go
@@ -1,0 +1,104 @@
+package cometbft
+
+import (
+	"math"
+	"testing"
+
+	"go.uber.org/zap/zapcore"
+)
+
+func Test_keyValsToFields(t *testing.T) {
+	tests := []struct {
+		name           string
+		kvs            []any
+		wantKeys       []string
+		wantValTypes   []zapcore.FieldType
+		wantStringVals []string
+		wantIntVals    []int64
+		wantFloatVals  []float64
+	}{
+		{
+			name:           "two with string key",
+			kvs:            []any{"key", "val"},
+			wantKeys:       []string{"key"},
+			wantValTypes:   []zapcore.FieldType{zapcore.StringType},
+			wantStringVals: []string{"val"},
+		},
+		{
+			name:           "missing value",
+			kvs:            []any{"key0", "val0", "key1"},
+			wantKeys:       []string{"key0", "key1"},
+			wantValTypes:   []zapcore.FieldType{zapcore.StringType, zapcore.ErrorType},
+			wantStringVals: []string{"val0"}, // last is an error type
+		},
+		{
+			name:           "four with string keys",
+			kvs:            []any{"key0", "val0", "key1", "val1"},
+			wantKeys:       []string{"key0", "key1"},
+			wantValTypes:   []zapcore.FieldType{zapcore.StringType, zapcore.StringType},
+			wantStringVals: []string{"val0", "val1"},
+		},
+		{
+			name:           "six with mixed type keys",
+			kvs:            []any{"key0", "val0", "key1", "val1", "key2", 222},
+			wantKeys:       []string{"key0", "key1", "key2"},
+			wantValTypes:   []zapcore.FieldType{zapcore.StringType, zapcore.StringType, zapcore.Int64Type},
+			wantStringVals: []string{"val0", "val1", ""},
+			wantIntVals:    []int64{0, 0, 222},
+		},
+		{
+			name:         "int64 value",
+			kvs:          []any{"key", int64(42)},
+			wantKeys:     []string{"key"},
+			wantValTypes: []zapcore.FieldType{zapcore.Int64Type},
+			wantIntVals:  []int64{42},
+		},
+		{
+			name:         "uint32 value",
+			kvs:          []any{"key", uint32(42)},
+			wantKeys:     []string{"key"},
+			wantValTypes: []zapcore.FieldType{zapcore.Uint32Type},
+			wantIntVals:  []int64{42},
+		},
+		{
+			name:          "float64 value",
+			kvs:           []any{"key", 42.42},
+			wantKeys:      []string{"key"},
+			wantValTypes:  []zapcore.FieldType{zapcore.Float64Type},
+			wantFloatVals: []float64{42.42},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotFields := keyValsToFields(tt.kvs)
+			if len(gotFields) != len(tt.wantKeys) {
+				t.Fatalf("got %d fields, wanted %d", len(gotFields), len(tt.wantKeys))
+			}
+			for i, field := range gotFields {
+				if tt.wantKeys[i] != field.Key {
+					t.Errorf("wanted key %q, got %q", tt.wantKeys[i], field.Key)
+				}
+				if tt.wantValTypes[i] != field.Type {
+					t.Errorf("wanted value type %v, got %v", tt.wantValTypes[i], field.Type)
+					continue
+				}
+
+				switch field.Type {
+				case zapcore.StringType, zapcore.StringerType:
+					if field.String != tt.wantStringVals[i] {
+						t.Errorf("wanted string value %v, got %v", tt.wantStringVals[i], field.String)
+					}
+				case zapcore.Int64Type, zapcore.Int32Type, zapcore.Int16Type, zapcore.Int8Type:
+					if field.Integer != tt.wantIntVals[i] {
+						t.Errorf("wanted int value %v, got %v", tt.wantIntVals[i], field.Integer)
+					}
+				case zapcore.Float64Type, zapcore.Float32Type:
+					gotFloat := math.Float64frombits(uint64(field.Integer))
+					if gotFloat != tt.wantFloatVals[i] {
+						t.Errorf("wanted float value %v, got %v", tt.wantFloatVals[i], gotFloat)
+					}
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
I got the range condition wrong and it failed to log some fields (kv pairs) from cometbft.  This fixes that and adds tests.

@charithabandi 