### PR TITLE
pkg/validators: compute db hash with binary encodings

### DIFF
--- a/pkg/abci/abci.go
+++ b/pkg/abci/abci.go
@@ -694,6 +694,10 @@ func (a *AbciApp) createNewAppHash(ctx context.Context, addition []byte) ([]byte
 	return newHash, err
 }
 
+// TODO: here should probably be other apphash computations such as the genesis
+// config digest. The internal/app/kwild/config package should probably not
+// contain consensus-critical computations.
+
 // convertArgs converts the string args to type any.
 func convertArgs(args [][]string) [][]any {
 	converted := make([][]any, len(args))


### PR DESCRIPTION
This tweaks the validator managers state hash computation to use strict binary encodings rather than a string formatting.  Pursuant to https://github.com/kwilteam/kwil-db/pull/318#discussion_r1339286610

I didn't want to drag out #318 so decided to follow up quick on this.  Of course, this changes the appHash computation (again), so if anyone had a node running from last night, it'll be broken with this.