### PR TITLE
 decouple apphash generation of accounts and masterdb from sql implementation

### DIFF
--- a/internal/app/kwild/server/utils.go
+++ b/internal/app/kwild/server/utils.go
@@ -258,7 +258,7 @@ func (s *sqlCommittableRegister) Unregister(ctx context.Context, name string) er
 // registerSQL is a helper function to register a SQL committable to the atomic committer.
 func registerSQL(ctx context.Context, ac *sessions.AtomicCommitter, db sql.Database, name string, logger log.Logger) error {
 	return ac.Register(ctx, name,
-		sqlSessions.NewSqlCommitable(db,
+		sqlSessions.NewSqlCommittable(db,
 			sqlSessions.WithLogger(*logger.Named(name + "-committable")),
 		),
 	)

--- a/pkg/abci/abci.go
+++ b/pkg/abci/abci.go
@@ -449,6 +449,12 @@ func (a *AbciApp) Commit() abciTypes.ResponseCommit {
 		panic(newFatalError("Commit", nil, fmt.Sprintf("failed to get commit id: %v", err)))
 	}
 
+	err = a.committer.Commit(ctx)
+	if err != nil {
+		panic(newFatalError("Commit", nil, fmt.Sprintf("failed to commit atomic commit: %v", err)))
+	}
+
+	// Update AppHash and Block Height in metadata store.
 	appHash, err := a.createNewAppHash(ctx, id)
 	if err != nil {
 		panic(newFatalError("Commit", nil, fmt.Sprintf("failed to create new app hash: %v", err)))
@@ -457,11 +463,6 @@ func (a *AbciApp) Commit() abciTypes.ResponseCommit {
 	err = a.metadataStore.IncrementBlockHeight(ctx)
 	if err != nil {
 		panic(newFatalError("Commit", nil, fmt.Sprintf("failed to increment block height: %v", err)))
-	}
-
-	err = a.committer.Commit(ctx)
-	if err != nil {
-		panic(newFatalError("Commit", nil, fmt.Sprintf("failed to commit atomic commit: %v", err)))
 	}
 
 	// Update the validator address=>pubkey map used by Penalize.

--- a/pkg/balances/accounts.go
+++ b/pkg/balances/accounts.go
@@ -2,11 +2,16 @@ package balances
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/binary"
 	"fmt"
+	"hash"
 	"math/big"
 	"sync"
 
 	"github.com/kwilteam/kwil-db/pkg/log"
+	"github.com/kwilteam/kwil-db/pkg/sessions"
+	sqlSessions "github.com/kwilteam/kwil-db/pkg/sessions/sql-session"
 )
 
 type AccountStore struct {
@@ -16,6 +21,32 @@ type AccountStore struct {
 	gasEnabled    bool
 	noncesEnabled bool
 	stmts         *preparedStatements
+
+	blockHasher hash.Hash
+}
+
+// Wrapper around the sql session committable that allows us to
+// define module specific logic on how to capture the state of the
+// account store independent of the SQL specifics.
+type Committable struct {
+	sessions.Committable
+
+	dbHash      func() ([]byte, error)
+	resetDBHash func()
+}
+
+// ID overrides the base Committable. We do this so that we can have the
+// persistence of the state be part of the 2pc process, but have the ID reflect
+// the actual state free from SQL specifics.
+func (ac *Committable) ID(ctx context.Context) ([]byte, error) {
+	return ac.dbHash()
+}
+
+// Wrapper around the Cancel method on the base Committable.
+// This reset the updates recorded in the account store within a commit session.
+func (ac *Committable) Cancel(ctx context.Context) {
+	ac.resetDBHash()
+	ac.Committable.Cancel(ctx)
 }
 
 func NewAccountStore(ctx context.Context, datastore Datastore, opts ...AccountStoreOpts) (*AccountStore, error) {
@@ -38,13 +69,50 @@ func NewAccountStore(ctx context.Context, datastore Datastore, opts ...AccountSt
 		return nil, fmt.Errorf("failed to prepare statements: %w", err)
 	}
 
+	ar.blockHasher = sha256.New()
 	return ar, nil
 }
+
+func (a *AccountStore) Close() error {
+	// Close prepared statements
+	if a.stmts != nil {
+		if err := a.stmts.Close(); err != nil {
+			return fmt.Errorf("failed to close prepared statements: %w", err)
+		}
+	}
+	return nil
+}
+
 func (a *AccountStore) GetAccount(ctx context.Context, pubKey []byte) (*Account, error) {
 	a.rw.RLock()
 	defer a.rw.RUnlock()
 
 	return a.getAccountReadOnly(ctx, pubKey)
+}
+
+// WrapCommittable wraps a sql session committable with the account store specific logic
+func (a *AccountStore) WrapCommittable(committable *sqlSessions.SqlCommitable) *Committable {
+	return &Committable{
+		Committable: committable,
+		dbHash:      a.dbHash,
+		resetDBHash: a.resetBlockHasher,
+	}
+}
+
+// dbHash captures the hash of the updates received by the account store
+// within a commit session.
+// Each update includes: [accountPubKey, amount, nonce]
+func (a *AccountStore) dbHash() ([]byte, error) {
+	hash := a.blockHasher.Sum(nil)
+	a.blockHasher.Reset()
+	return hash, nil
+}
+
+// resetBlockHasher resets the block hasher to its initial state.
+// This is called when a commit session is cancelled.
+func (a *AccountStore) resetBlockHasher() {
+	a.log.Debug("resetting accounts block hasher")
+	a.blockHasher.Reset()
 }
 
 type Spend struct {
@@ -68,7 +136,19 @@ func (a *AccountStore) Spend(ctx context.Context, spend *Spend) error {
 		return fmt.Errorf("failed to update account: %w", err)
 	}
 
+	a.registerSpend(ctx, spend.AccountPubKey, balance, nonce)
 	return nil
+}
+
+// AccountStore can get really large with many accounts.
+// Therefore, computing the apphash of the entire account store can be expensive,
+// and would involve a full scan of the db on write connection to get updated account information.
+// Instead, we compute the apphash based on the updates to the account store per block.
+// registerSpend: Hashes the user account info [pubkey, balance, nonce] after spending.
+func (a *AccountStore) registerSpend(ctx context.Context, pubKey []byte, balance *big.Int, nonce int64) {
+	a.blockHasher.Write(pubKey)
+	a.blockHasher.Write(balance.Bytes())
+	binary.Write(a.blockHasher, binary.LittleEndian, nonce)
 }
 
 // checkSpend checks that a spend is valid.  If gas costs are enabled, it checks that the account has enough gas to pay for the spend.

--- a/pkg/sessions/sql-session/session.go
+++ b/pkg/sessions/sql-session/session.go
@@ -25,7 +25,7 @@ type SqlCommitable struct {
 var _ sessions.Committable = (*SqlCommitable)(nil)
 
 // NewSqlCommitable creates a new SqlCommitable.
-func NewSqlCommitable(db SqlDB, opts ...SqlCommittableOpt) *SqlCommitable {
+func NewSqlCommittable(db SqlDB, opts ...SqlCommittableOpt) *SqlCommitable {
 	s := &SqlCommitable{
 		db:  db,
 		log: log.NewNoOp(),

--- a/pkg/sql/client/session.go
+++ b/pkg/sql/client/session.go
@@ -53,7 +53,7 @@ func (c *Changeset) Close() error {
 }
 
 /*
-ID generates a determinstic ID for the changeset.
+ID generates a deterministic ID for the changeset.
 It does this by:
 1. ordering each record by primary key
 if there are multiple primary keys, it will concatenate them alphabetically


### PR DESCRIPTION
This PR unties appHashes generation logic from sqlite constructs. 

Updated the appHash generation for
- MasterDB: hash of DBIDs
- AccountStore: hash of spend(pubkey, nonce, balance) from all transactions in a block
- KVStore:  no-op 