### PR TITLE
add --nonce override flag to kwil-cli database commands

### DIFF
--- a/cmd/kwil-cli/cmds/common/prompt/prompt.go
+++ b/cmd/kwil-cli/cmds/common/prompt/prompt.go
@@ -5,7 +5,6 @@ import (
 	"strings"
 
 	"github.com/manifoldco/promptui"
-	"github.com/spf13/cobra"
 )
 
 type Prompter struct {
@@ -49,14 +48,4 @@ func (p Prompter) Run() (string, error) {
 	}
 
 	return prompt.Run()
-}
-
-func ConfirmPrompt() bool {
-	prompt := promptui.Select{
-		Label: "Are you sure?",
-		Items: []string{"Apply", "Abort"},
-	}
-	_, result, err := prompt.Run()
-	cobra.CheckErr(err)
-	return result == "Apply"
 }

--- a/cmd/kwil-cli/cmds/database/batch.go
+++ b/cmd/kwil-cli/cmds/database/batch.go
@@ -36,7 +36,7 @@ The execution is treated as a single transaction, and will either succeed or fai
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resp []byte
 
-			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, client *client.Client, conf *config.KwilCliConfig) error {
+			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, cl *client.Client, conf *config.KwilCliConfig) error {
 				dbid, err := getSelectedDbid(cmd, conf)
 				if err != nil {
 					return err
@@ -61,7 +61,7 @@ The execution is treated as a single transaction, and will either succeed or fai
 					return fmt.Errorf("error building inputs: %w", err)
 				}
 
-				actionStructure, err := getAction(ctx, client, dbid, action)
+				actionStructure, err := getAction(ctx, cl, dbid, action)
 				if err != nil {
 					return fmt.Errorf("error getting action: %w", err)
 				}
@@ -71,7 +71,7 @@ The execution is treated as a single transaction, and will either succeed or fai
 					return fmt.Errorf("error creating action inputs: %w", err)
 				}
 
-				resp, err = client.ExecuteAction(ctx, dbid, strings.ToLower(action), tuples...)
+				resp, err = cl.ExecuteAction(ctx, dbid, strings.ToLower(action), tuples, client.WithNonce(nonceOverride))
 				if err != nil {
 					return fmt.Errorf("error executing action: %w", err)
 				}

--- a/cmd/kwil-cli/cmds/database/cmd.go
+++ b/cmd/kwil-cli/cmds/database/cmd.go
@@ -5,25 +5,40 @@ import (
 )
 
 var (
-	rootCmd = &cobra.Command{
+	dbCmd = &cobra.Command{
 		Use:     "database",
 		Aliases: []string{"db"},
 		Short:   "manage databases",
 		Long:    "Database is a command that contains subcommands for interacting with databases",
 	}
+
+	nonceOverride int64
 )
 
 func NewCmdDatabase() *cobra.Command {
-	rootCmd.AddCommand(
+	// readOnlyCmds do not create a transaction.
+	readOnlyCmds := []*cobra.Command{
+		listCmd(),
+		readSchemaCmd(),
+		queryCmd(),
+		callCmd(), // no tx, but may required key for signature, for now
+	}
+	dbCmd.AddCommand(readOnlyCmds...)
+
+	// writeCmds create a transactions, requiring a private key for signing/
+	writeCmds := []*cobra.Command{
 		deployCmd(),
 		dropCmd(),
-		readSchemaCmd(),
 		executeCmd(),
-		listCmd(),
 		batchCmd(),
-		queryCmd(),
-		callCmd(),
-	)
+	}
+	dbCmd.AddCommand(writeCmds...)
 
-	return rootCmd
+	// The write commands may also specify a nonce to use instead of asking the
+	// node for the latest confirmed nonce.
+	for _, cmd := range writeCmds {
+		cmd.Flags().Int64VarP(&nonceOverride, "nonce", "N", -1, "nonce override (-1 means request from server)")
+	}
+
+	return dbCmd
 }

--- a/cmd/kwil-cli/cmds/database/deploy.go
+++ b/cmd/kwil-cli/cmds/database/deploy.go
@@ -29,7 +29,7 @@ func deployCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var txHash []byte
 
-			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, client *client.Client, conf *config.KwilCliConfig) error {
+			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, cl *client.Client, conf *config.KwilCliConfig) error {
 				// read in the file
 				file, err := os.Open(filePath)
 				if err != nil {
@@ -49,7 +49,7 @@ func deployCmd() *cobra.Command {
 					return fmt.Errorf("failed to unmarshal file: %w", err)
 				}
 
-				txHash, err = client.DeployDatabase(ctx, db)
+				txHash, err = cl.DeployDatabase(ctx, db, client.WithNonce(nonceOverride))
 				return err
 			})
 

--- a/cmd/kwil-cli/cmds/database/drop.go
+++ b/cmd/kwil-cli/cmds/database/drop.go
@@ -20,9 +20,9 @@ func dropCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resp []byte
 
-			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, client *client.Client, conf *config.KwilCliConfig) error {
+			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, cl *client.Client, conf *config.KwilCliConfig) error {
 				var _err error
-				resp, _err = client.DropDatabase(ctx, args[0])
+				resp, _err = cl.DropDatabase(ctx, args[0], client.WithNonce(nonceOverride))
 				if _err != nil {
 					return fmt.Errorf("error dropping database: %w", _err)
 				}

--- a/cmd/kwil-cli/cmds/database/execute.go
+++ b/cmd/kwil-cli/cmds/database/execute.go
@@ -43,7 +43,7 @@ OR
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var resp []byte
 
-			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, client *client.Client, conf *config.KwilCliConfig) error {
+			err := common.DialClient(cmd.Context(), 0, func(ctx context.Context, cl *client.Client, conf *config.KwilCliConfig) error {
 				dbId, err := getSelectedDbid(cmd, conf)
 				if err != nil {
 					return fmt.Errorf("target database not properly specified: %w", err)
@@ -51,7 +51,7 @@ OR
 
 				lowerName := strings.ToLower(actionName)
 
-				actionStructure, err := getAction(ctx, client, dbId, lowerName)
+				actionStructure, err := getAction(ctx, cl, dbId, lowerName)
 				if err != nil {
 					return fmt.Errorf("error getting action: %w", err)
 				}
@@ -61,7 +61,9 @@ OR
 					return fmt.Errorf("error getting inputs: %w", err)
 				}
 
-				resp, err = client.ExecuteAction(ctx, dbId, lowerName, inputs...)
+				// Could actually just directly pass nonce to the client method,
+				// but those methods don't need tx details in the inputs.
+				resp, err = cl.ExecuteAction(ctx, dbId, lowerName, inputs, client.WithNonce(nonceOverride))
 				if err != nil {
 					return fmt.Errorf("error executing database: %w", err)
 				}

--- a/internal/controller/grpc/txsvc/v1/account.go
+++ b/internal/controller/grpc/txsvc/v1/account.go
@@ -14,7 +14,7 @@ func (s *Service) GetAccount(ctx context.Context, req *txpb.GetAccountRequest) (
 
 	return &txpb.GetAccountResponse{
 		Account: &txpb.Account{
-			PublicKey: acc.PublicKey,
+			PublicKey: acc.PublicKey, // nil for non-existent account
 			Nonce:     acc.Nonce,
 			Balance:   acc.Balance.String(),
 		},

--- a/pkg/balances/account.go
+++ b/pkg/balances/account.go
@@ -8,7 +8,7 @@ import (
 // emptyAccount returns an empty account with a balance of 0 and a nonce of 0.
 func emptyAccount() *Account {
 	return &Account{
-		PublicKey: nil,
+		PublicKey: nil, // do not change unless callers are updated
 		Balance:   big.NewInt(0),
 		Nonce:     0,
 	}

--- a/pkg/balances/sql.go
+++ b/pkg/balances/sql.go
@@ -71,8 +71,9 @@ func (a *AccountStore) createAccount(ctx context.Context, pubKey []byte) error {
 	})
 }
 
-// getAccountReadOnly gets an account using a read-only connection.
-// it will not show uncommitted changes.
+// getAccountReadOnly gets an account using a read-only connection. it will not
+// show uncommitted changes. If the account does not exist, no error is
+// returned, but an account with a nil pubkey is returned.
 func (a *AccountStore) getAccountReadOnly(ctx context.Context, pubKey []byte) (*Account, error) {
 	results, err := a.db.Query(ctx, sqlGetAccount, map[string]interface{}{
 		"$public_key": pubKey,

--- a/pkg/client/opts.go
+++ b/pkg/client/opts.go
@@ -51,3 +51,15 @@ func Authenticated(shouldSign bool) CallOpt {
 		o.forceAuthenticated = &copied
 	}
 }
+
+type txOptions struct {
+	nonce int64
+}
+
+type TxOpt func(*txOptions)
+
+func WithNonce(nonce int64) TxOpt {
+	return func(o *txOptions) {
+		o.nonce = nonce
+	}
+}

--- a/pkg/client/tx.go
+++ b/pkg/client/tx.go
@@ -3,26 +3,37 @@ package client
 import (
 	"context"
 	"fmt"
-	"math/big"
 
-	"github.com/kwilteam/kwil-db/pkg/balances"
 	"github.com/kwilteam/kwil-db/pkg/transactions"
 )
 
 // newTx creates a new Transaction signed by the Client's Signer
-func (c *Client) newTx(ctx context.Context, data transactions.Payload) (*transactions.Transaction, error) {
-	// get nonce from address
-	acc, err := c.transportClient.GetAccount(ctx, c.Signer.PublicKey())
-	if err != nil {
-		acc = &balances.Account{
-			PublicKey: c.Signer.PublicKey(),
-			Nonce:     0,
-			Balance:   big.NewInt(0),
+func (c *Client) newTx(ctx context.Context, data transactions.Payload, opts ...TxOpt) (*transactions.Transaction, error) {
+	txOpts := &txOptions{}
+	for _, opt := range opts {
+		opt(txOpts)
+	}
+
+	var nonce uint64
+	if txOpts.nonce > 0 {
+		nonce = uint64(txOpts.nonce)
+	} else {
+		// Get the latest nonce for the account, if it exists.
+		acc, err := c.transportClient.GetAccount(ctx, c.Signer.PublicKey())
+		if err != nil {
+			return nil, err
+		}
+		// NOTE: an error type would be more robust signalling of a non-existent
+		// account, but presently a nil pubkey is set by pkg/balances.
+		if len(acc.PublicKey) > 0 {
+			nonce = uint64(acc.Nonce + 1)
+		} else {
+			nonce = 1
 		}
 	}
 
 	// build transaction
-	tx, err := transactions.CreateTransaction(data, uint64(acc.Nonce+1))
+	tx, err := transactions.CreateTransaction(data, nonce)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create transaction: %w", err)
 	}

--- a/test/driver/client_driver.go
+++ b/test/driver/client_driver.go
@@ -113,7 +113,7 @@ func (d *KwildClientDriver) DatabaseExists(ctx context.Context, dbid string) err
 }
 
 func (d *KwildClientDriver) ExecuteAction(ctx context.Context, dbid string, actionName string, actionInputs ...[]any) ([]byte, error) {
-	rec, err := d.clt.ExecuteAction(ctx, dbid, actionName, actionInputs...)
+	rec, err := d.clt.ExecuteAction(ctx, dbid, actionName, actionInputs)
 	if err != nil {
 		return nil, fmt.Errorf("error executing query: %w", err)
 	}


### PR DESCRIPTION
```
kwil-cli,pkg/client: add --nonce override flag to database cmds
This adds the ability to set a nonce when making a transaction.

Rather than giving every method a nonce input arg, I've added a
WithNonceFunc option to pkg/client.Client. This is perhaps a
little strange but the cascade from a new argument was rather
large, and it seemed a little out of place as the other arguments
pertain to the action rather than the transaction containing it.
Can be switched if we'd prefer.
```

See my review for notes about the pkg/client change.  Very happy to change it.