### PR TITLE
Validate transactions against local mempool state

### DIFF
--- a/internal/controller/grpc/txsvc/v1/pricing.go
+++ b/internal/controller/grpc/txsvc/v1/pricing.go
@@ -89,13 +89,13 @@ func (s *Service) priceAction(ctx context.Context, txBody *txpb.Transaction_Body
 
 // TODO: Later to be moved to validator module (or) manager
 func (s *Service) priceValidatorJoin(ctx context.Context, txBody *txpb.Transaction_Body) (*big.Int, error) {
-	return big.NewInt(10000000000000), nil
+	return s.vstore.PriceJoin(ctx)
 }
 
 func (s *Service) priceValidatorLeave(ctx context.Context, txBody *txpb.Transaction_Body) (*big.Int, error) {
-	return big.NewInt(10000000000000), nil
+	return s.vstore.PriceLeave(ctx)
 }
 
 func (s *Service) priceValidatorApprove(ctx context.Context, txBody *txpb.Transaction_Body) (*big.Int, error) {
-	return big.NewInt(10000000000000), nil
+	return s.vstore.PriceApprove(ctx)
 }

--- a/internal/controller/grpc/txsvc/v1/service.go
+++ b/internal/controller/grpc/txsvc/v1/service.go
@@ -65,4 +65,7 @@ type ValidatorReader interface {
 	CurrentValidators(ctx context.Context) ([]*validators.Validator, error)
 	ActiveVotes(ctx context.Context) ([]*validators.JoinRequest, error)
 	// JoinStatus(ctx context.Context, joiner []byte) ([]*JoinRequest, error)
+	PriceJoin(ctx context.Context) (*big.Int, error)
+	PriceLeave(ctx context.Context) (*big.Int, error)
+	PriceApprove(ctx context.Context) (*big.Int, error)
 }

--- a/pkg/abci/interfaces.go
+++ b/pkg/abci/interfaces.go
@@ -2,10 +2,12 @@ package abci
 
 import (
 	"context"
+	"math/big"
 
 	modDataset "github.com/kwilteam/kwil-db/pkg/modules/datasets"
 	modVal "github.com/kwilteam/kwil-db/pkg/modules/validators"
 
+	"github.com/kwilteam/kwil-db/pkg/balances"
 	"github.com/kwilteam/kwil-db/pkg/engine/types"
 	"github.com/kwilteam/kwil-db/pkg/snapshots"
 	"github.com/kwilteam/kwil-db/pkg/transactions"
@@ -16,6 +18,10 @@ type DatasetsModule interface {
 	Deploy(ctx context.Context, schema *types.Schema, tx *transactions.Transaction) (*modDataset.ExecutionResponse, error)
 	Drop(ctx context.Context, dbid string, tx *transactions.Transaction) (*modDataset.ExecutionResponse, error)
 	Execute(ctx context.Context, dbid string, action string, args [][]any, tx *transactions.Transaction) (*modDataset.ExecutionResponse, error)
+
+	PriceDeploy(ctx context.Context, schema *types.Schema) (*big.Int, error)
+	PriceDrop(ctx context.Context, dbid string) (*big.Int, error)
+	PriceExecute(ctx context.Context, dbid string, action string, args [][]any) (*big.Int, error)
 }
 
 // ValidatorModule handles the processing of validator approve/join/leave
@@ -56,6 +62,15 @@ type ValidatorModule interface {
 
 	// Updates block height stored by the validator manager. Called in the abci Commit
 	UpdateBlockHeight(ctx context.Context, blockHeight int64)
+
+	// PriceJoin returns the price of a join transaction.
+	PriceJoin(ctx context.Context) (*big.Int, error)
+
+	// PriceApprove returns the price of an approve transaction.
+	PriceApprove(ctx context.Context) (*big.Int, error)
+
+	// PriceLeave returns the price of a leave transaction.
+	PriceLeave(ctx context.Context) (*big.Int, error)
 }
 
 // AtomicCommitter is an interface for a struct that implements atomic commits across multiple stores
@@ -98,4 +113,8 @@ type DBBootstrapModule interface {
 
 	// Signifies the end of the db restoration
 	IsDBRestored() bool
+}
+
+type AccountsModule interface {
+	GetAccount(ctx context.Context, pubKey []byte) (*balances.Account, error)
 }

--- a/pkg/abci/mempool.go
+++ b/pkg/abci/mempool.go
@@ -1,0 +1,115 @@
+package abci
+
+import (
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"sync"
+
+	"github.com/kwilteam/kwil-db/pkg/transactions"
+)
+
+// mempoolState maintains in-memory account state to validate the transactions against.
+type mempool struct {
+	accountStore AccountsModule
+	// nonceTracker tracks the last valid nonce for each account. nonce is
+	// unconfirmed if the value is greater than the nonce in the account store.
+	// Key: sender's public key, Value: last valid nonce
+	nonceTracker map[string]uint64
+
+	// in-memory account state to validate transactions against, purged at the end of commit.
+	accounts map[string]*userAccount
+	mu       sync.Mutex
+}
+
+type userAccount struct {
+	nonce   int64
+	balance *big.Int
+}
+
+// accountInfo retrieves the account info from the mempool state or the account store.
+// If the account is not found, it returns a dummy account with nonce 0 and balance 0.
+func (m *mempool) accountInfo(ctx context.Context, pubKey []byte) (*userAccount, error) {
+	if acctInfo, ok := m.accounts[string(pubKey)]; ok {
+		return acctInfo, nil // there is an unconfirmed tx for this account
+	}
+
+	// get account from account store
+	acct, err := m.accountStore.GetAccount(ctx, pubKey)
+	if err != nil {
+		return nil, err
+	}
+
+	acctInfo := &userAccount{
+		nonce:   acct.Nonce,
+		balance: acct.Balance,
+	}
+	m.accounts[string(pubKey)] = acctInfo
+
+	return acctInfo, nil
+}
+
+// applyTransaction validates account specific info and applies valid transactions to the mempool state.
+func (m *mempool) applyTransaction(ctx context.Context, tx *transactions.Transaction) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	// get account info from mempool state or account store
+	acct, err := m.accountInfo(context.Background(), tx.Sender)
+	if err != nil {
+		return err
+	}
+
+	hexKey := hex.EncodeToString(tx.Sender)
+
+	//  It is normally permissible to accept a transaction with the same nonce
+	//	as a tx already in mempool (but not in a block), however without gas
+	//	we would not want to allow that since there is no criteria
+	//  for selecting the one to mine (normally higher fee).
+	if tx.Body.Nonce != uint64(acct.nonce)+1 {
+		return fmt.Errorf("invalid nonce for account %s: got %d, expected %d", hexKey, tx.Body.Nonce, acct.nonce+1)
+	}
+
+	m.updateAccount(tx.Sender, tx.Body.Nonce)
+	return nil
+}
+
+// updateAccount is called post-transaction validation, so that the effects of
+// the transaction is reflected in the mempool's view of the account state.
+// This ensures that the subsequent transactions are validated against this
+// updated view of the account state, rather than the one from the account store.
+func (m *mempool) updateAccount(pubKey []byte, txNonce uint64) {
+	publicKey := string(pubKey)
+
+	m.accounts[publicKey].nonce++
+	//acct.balance.Sub(acct.balance, fee)
+
+	if txNonce > m.nonceTracker[publicKey] {
+		m.nonceTracker[publicKey] = txNonce
+	}
+}
+
+// reset clears the in-memory unconfirmed account states.
+// This should be done at the end of block commit.
+func (m *mempool) reset() {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	m.accounts = make(map[string]*userAccount)
+}
+
+// groupTransactions groups the transactions by sender.
+func groupTxsBySender(txns [][]byte) (map[string][]*transactions.Transaction, error) {
+	grouped := make(map[string][]*transactions.Transaction)
+	for _, tx := range txns {
+		t := &transactions.Transaction{}
+		err := t.UnmarshalBinary(tx)
+		if err != nil {
+			return nil, err
+		}
+		key := string(t.Sender)
+		grouped[key] = append(grouped[key], t)
+	}
+	return grouped, nil
+}

--- a/pkg/abci/txcode.go
+++ b/pkg/abci/txcode.go
@@ -11,9 +11,12 @@ var (
 type TxCode uint32
 
 const (
-	CodeOk            TxCode = 0
-	CodeEncodingError TxCode = 1
-	CodeUnknownError  TxCode = 2 // for now it's for all non-encoding error
+	CodeOk               TxCode = 0
+	CodeEncodingError    TxCode = 1
+	CodeInvalidTxType    TxCode = 2
+	CodeInvalidSignature TxCode = 3
+	CodeInvalidNonce     TxCode = 4
+	CodeUnknownError     TxCode = 5 // for now it's for all non-encoding error
 )
 
 func (c TxCode) Uint32() uint32 {

--- a/pkg/balances/accounts.go
+++ b/pkg/balances/accounts.go
@@ -44,9 +44,9 @@ func (ac *Committable) ID(ctx context.Context) ([]byte, error) {
 
 // Wrapper around the Cancel method on the base Committable.
 // This reset the updates recorded in the account store within a commit session.
-func (ac *Committable) Cancel(ctx context.Context) {
+func (ac *Committable) Cancel(ctx context.Context) error {
 	ac.resetDBHash()
-	ac.Committable.Cancel(ctx)
+	return ac.Committable.Cancel(ctx)
 }
 
 func NewAccountStore(ctx context.Context, datastore Datastore, opts ...AccountStoreOpts) (*AccountStore, error) {

--- a/pkg/kv/atomic/committer.go
+++ b/pkg/kv/atomic/committer.go
@@ -167,7 +167,7 @@ func (k *AtomicKV) EndApply(ctx context.Context) error {
 	return nil
 }
 
-func (k *AtomicKV) Cancel(ctx context.Context) {
+func (k *AtomicKV) Cancel(ctx context.Context) error {
 	k.mu.Lock()
 	defer k.mu.Unlock()
 
@@ -178,6 +178,7 @@ func (k *AtomicKV) Cancel(ctx context.Context) {
 	k.currentTx = nil
 	k.inSession = false
 	k.uncommittedData = make([]*keyValue, 0)
+	return nil
 }
 
 func (k *AtomicKV) ID(ctx context.Context) ([]byte, error) {

--- a/pkg/modules/validators/interfaces.go
+++ b/pkg/modules/validators/interfaces.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"context"
+	"math/big"
 
 	"github.com/kwilteam/kwil-db/pkg/balances"
 	"github.com/kwilteam/kwil-db/pkg/validators"
@@ -20,4 +21,8 @@ type ValidatorMgr interface {
 	Approve(ctx context.Context, joiner, approver []byte) error
 	Finalize(ctx context.Context) []*validators.Validator // end of block processing requires providing list of updates to the node's consensus client
 	UpdateBlockHeight(blockHeight int64)
+
+	PriceJoin(ctx context.Context) (*big.Int, error)
+	PriceApprove(ctx context.Context) (*big.Int, error)
+	PriceLeave(ctx context.Context) (*big.Int, error)
 }

--- a/pkg/modules/validators/transactions.go
+++ b/pkg/modules/validators/transactions.go
@@ -2,6 +2,7 @@ package validators
 
 import (
 	"context"
+	"fmt"
 	"math/big"
 
 	"github.com/kwilteam/kwil-db/pkg/balances"
@@ -12,6 +13,13 @@ type ExecutionResponse struct {
 	// Fee is the amount of tokens spent on the execution
 	Fee     *big.Int
 	GasUsed int64
+}
+
+func resp(fee *big.Int) *ExecutionResponse {
+	return &ExecutionResponse{
+		Fee:     fee,
+		GasUsed: 0,
+	}
 }
 
 // Join/Leave/Approve required a spend. There is currently no pricing associated
@@ -29,8 +37,16 @@ func (vm *ValidatorModule) spend(ctx context.Context, acctPubKey []byte,
 // Join creates a join request for a prospective validator.
 func (vm *ValidatorModule) Join(ctx context.Context, joiner []byte, power int64,
 	txn *transactions.Transaction) (*ExecutionResponse, error) {
+	price, err := vm.PriceJoin(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	err := vm.spend(ctx, joiner, txn.Body.Fee, txn.Body.Nonce)
+	if txn.Body.Fee.Cmp(price) < 0 {
+		return nil, fmt.Errorf("insufficient fee: %d < %d", txn.Body.Fee, price)
+	}
+
+	err = vm.spend(ctx, joiner, txn.Body.Fee, txn.Body.Nonce)
 	if err != nil {
 		return nil, err
 	}
@@ -39,17 +55,22 @@ func (vm *ValidatorModule) Join(ctx context.Context, joiner []byte, power int64,
 		return nil, err
 	}
 
-	return &ExecutionResponse{
-		Fee:     txn.Body.Fee,
-		GasUsed: 0,
-	}, nil
+	return resp(txn.Body.Fee), nil
 }
 
 // Leave creates a leave request for a current validator.
 func (vm *ValidatorModule) Leave(ctx context.Context, leaver []byte,
 	txn *transactions.Transaction) (*ExecutionResponse, error) {
+	price, err := vm.PriceLeave(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	err := vm.spend(ctx, leaver, txn.Body.Fee, txn.Body.Nonce)
+	if txn.Body.Fee.Cmp(price) < 0 {
+		return nil, fmt.Errorf("insufficient fee: %d < %d", txn.Body.Fee, price)
+	}
+
+	err = vm.spend(ctx, leaver, txn.Body.Fee, txn.Body.Nonce)
 	if err != nil {
 		return nil, err
 	}
@@ -58,18 +79,23 @@ func (vm *ValidatorModule) Leave(ctx context.Context, leaver []byte,
 		return nil, err
 	}
 
-	return &ExecutionResponse{
-		Fee:     txn.Body.Fee,
-		GasUsed: 0,
-	}, nil
+	return resp(txn.Body.Fee), nil
 }
 
 // Approve records an approval transaction from a current validator..
 func (vm *ValidatorModule) Approve(ctx context.Context, joiner []byte,
 	txn *transactions.Transaction) (*ExecutionResponse, error) {
 	approver := txn.Sender
+	price, err := vm.PriceApprove(ctx)
+	if err != nil {
+		return nil, err
+	}
 
-	err := vm.spend(ctx, approver, txn.Body.Fee, txn.Body.Nonce)
+	if txn.Body.Fee.Cmp(price) < 0 {
+		return nil, fmt.Errorf("insufficient fee: %d < %d", txn.Body.Fee, price)
+	}
+
+	err = vm.spend(ctx, approver, txn.Body.Fee, txn.Body.Nonce)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/modules/validators/validators.go
+++ b/pkg/modules/validators/validators.go
@@ -2,7 +2,12 @@
 // blockchain application using a pluggable validator manager and account store.
 package validators
 
-import "github.com/kwilteam/kwil-db/pkg/log"
+import (
+	"context"
+	"math/big"
+
+	"github.com/kwilteam/kwil-db/pkg/log"
+)
 
 // NOTE: currently there is no pricing. Any fee is accepted (nonce update only)
 // if their account has the sufficient balance.
@@ -41,4 +46,16 @@ func WithLogger(logger log.Logger) ValidatorModuleOpt {
 	return func(u *ValidatorModule) {
 		u.log = logger
 	}
+}
+
+func (v *ValidatorModule) PriceJoin(ctx context.Context) (*big.Int, error) {
+	return v.mgr.PriceJoin(ctx)
+}
+
+func (v *ValidatorModule) PriceLeave(ctx context.Context) (*big.Int, error) {
+	return v.mgr.PriceLeave(ctx)
+}
+
+func (v *ValidatorModule) PriceApprove(ctx context.Context) (*big.Int, error) {
+	return v.mgr.PriceApprove(ctx)
 }

--- a/pkg/sessions/errors.go
+++ b/pkg/sessions/errors.go
@@ -18,6 +18,7 @@ var (
 	ErrAlreadyRegistered   = errors.New("committable already registered")
 	ErrUnknownCommittable  = errors.New("unknown committable")
 	ErrClosed              = errors.New("session closed")
+	ErrCancel              = errors.New("error cancelling committer")
 )
 
 // wrapError wraps an error with a message.

--- a/pkg/sessions/interfaces.go
+++ b/pkg/sessions/interfaces.go
@@ -37,7 +37,7 @@ type Committable interface {
 	EndApply(ctx context.Context) error
 
 	// Cancel is used to cancel a session.
-	Cancel(ctx context.Context)
+	Cancel(ctx context.Context) error
 
 	// ID returns a unique ID representative of the state changes that have occurred so far for this committable.
 	// It should be deterministic, and should change if and only if the committable has changed.

--- a/pkg/sessions/mock_test.go
+++ b/pkg/sessions/mock_test.go
@@ -191,13 +191,14 @@ func (m *mockCommittable) EndApply(ctx context.Context) error {
 	return nil
 }
 
-func (m *mockCommittable) Cancel(ctx context.Context) {
+func (m *mockCommittable) Cancel(ctx context.Context) error {
 	m.isInCommit = false
 	m.isInApply = false
 
 	m.appliedData = map[string]any{}
 
 	m.canceled = true
+	return nil
 }
 
 func (m *mockCommittable) ID(ctx context.Context) ([]byte, error) {

--- a/pkg/validators/mgr.go
+++ b/pkg/validators/mgr.go
@@ -67,6 +67,9 @@ type ValidatorMgr struct {
 	// opts
 	joinExpiry int64
 	log        log.Logger
+
+	// pricing
+	feeMultiplier int64
 }
 
 // NOTE: The SQLite validator/approval store is local and transparent to the

--- a/pkg/validators/opts.go
+++ b/pkg/validators/opts.go
@@ -16,3 +16,9 @@ func WithJoinExpiry(joinExpiry int64) ValidatorMgrOpt {
 		v.joinExpiry = joinExpiry
 	}
 }
+
+func WithFeeMultiplier(multiplier int64) ValidatorMgrOpt {
+	return func(v *ValidatorMgr) {
+		v.feeMultiplier = multiplier
+	}
+}

--- a/pkg/validators/pricing.go
+++ b/pkg/validators/pricing.go
@@ -1,0 +1,32 @@
+package validators
+
+import (
+	"context"
+	"math/big"
+)
+
+var (
+	defaultJoinPrice    = big.NewInt(10000000000000)
+	defaultLeavePrice   = big.NewInt(10000000000000)
+	defaultApprovePrice = big.NewInt(10000000000000)
+)
+
+// applyFeeMultiplier applies the fee multiplier to the price.
+func (mgr *ValidatorMgr) applyFeeMultiplier(price *big.Int) *big.Int {
+	return big.NewInt(0).Mul(price, big.NewInt(mgr.feeMultiplier))
+}
+
+// PriceJoin returns the price of issuing a join request.
+func (mgr *ValidatorMgr) PriceJoin(ctx context.Context) (price *big.Int, err error) {
+	return mgr.applyFeeMultiplier(defaultJoinPrice), nil
+}
+
+// PriceLeave returns the price of issuing a leave request.
+func (mgr *ValidatorMgr) PriceLeave(ctx context.Context) (price *big.Int, err error) {
+	return mgr.applyFeeMultiplier(defaultLeavePrice), nil
+}
+
+// PriceApprove returns the price of approving a join request.
+func (mgr *ValidatorMgr) PriceApprove(ctx context.Context) (price *big.Int, err error) {
+	return mgr.applyFeeMultiplier(defaultApprovePrice), nil
+}


### PR DESCRIPTION
List of changes:
1.  ABCI App depends on the account store and accepts configurations such as WithoutGasCosts
2. ABCI maintains mempool state which gets reset per block. All transactions are validated against this mempool state. This weeds out any invalid txns at the mempool level and protects them from getting picked into the block
3. P2P hardening using `CheckTx`: Validates Tx payload, gas costs, nonces wrt local mempool state
4. `ProcessProposal()` checks for nonce ordering, gaps, duplicates, and continuity.
5.  Fixed the error propagation by the `Cancel()` calls of Committer types
6. gas costs for validator operations is now managed by the Validator pkg

Gonna add integration tests, once the nonce override [PR](https://github.com/kwilteam/kwil-db/pull/337) is pushed to the main. 