### PR TITLE
server: fix block version reported incorrectly

### DIFF
--- a/internal/app/kwild/server/utils.go
+++ b/internal/app/kwild/server/utils.go
@@ -94,7 +94,7 @@ func convertNodeInfo(ni *p2p.DefaultNodeInfo) *types.NodeInfo {
 		NodeID:          string(ni.ID()),
 		ProtocolVersion: ni.ProtocolVersion.P2P,
 		AppVersion:      ni.ProtocolVersion.App,
-		BlockVersion:    ni.ProtocolVersion.App,
+		BlockVersion:    ni.ProtocolVersion.Block,
 		ListenAddr:      ni.ListenAddr,
 		RPCAddr:         ni.Other.RPCAddress,
 	}


### PR DESCRIPTION
Tiny bug, the block version reported by the `node status` command was reporting the app version instead of the block version, which is presently 11.