### PR TITLE
pkg/serialize: fix decode error omitting code

### DIFF
--- a/pkg/serialize/encode.go
+++ b/pkg/serialize/encode.go
@@ -47,7 +47,7 @@ func Decode[T any](bts SerializedData) (*T, error) {
 	case encodingTypeRLP:
 		return decodeRLP[T](val)
 	default:
-		return nil, fmt.Errorf("invalid encoding type: %d", val)
+		return nil, fmt.Errorf("invalid encoding type: %d", encType)
 	}
 }
 
@@ -160,6 +160,6 @@ func DecodeInto(bts []byte, v any) error {
 	case encodingTypeRLP:
 		return rlp.DecodeBytes(val, v)
 	default:
-		return fmt.Errorf("invalid encoding type: %d", val)
+		return fmt.Errorf("invalid encoding type: %d", encType)
 	}
 }


### PR DESCRIPTION
The decode errors when an unrecognized encoding type was detected were supposed to include the erroneous encoding type, not the entire serialized data. The errors now do what Encode does and print the type, not the data.

We saw this from Fractal:

```
panic while building kwild: failed to open engine: invalid encoding type: [4 140 36 41 67 226 173 26 124 254 85 200 86 86 194 142 1 118 201 171 56 196 160 181 175 240 33 172 173 53 116 38 81 83 103 6 192 230 115 39 95 184 92 187 252 211 119 178 10 101 69 179 104 108 102 240 221 240 203 49 238 228 216 109 244]
```