### PR TITLE
client: add WaitTx method for fully-synchronous TxQuery

### DIFF
--- a/cmd/kwild/server/utils.go
+++ b/cmd/kwild/server/utils.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/kwilteam/kwil-db/core/log"
@@ -193,7 +194,7 @@ func (wc *wrappedCometBFTClient) TxQuery(ctx context.Context, hash []byte, prove
 		return res, nil
 	}
 	// The transaction could be in mempool.
-	limit := -1
+	limit := math.MaxInt // cmt is bugged, -1 doesn't work
 	unconf, err := wc.cl.UnconfirmedTxs(ctx, &limit)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This adds a `WaitTx` method to the `client.Client` that is essentially `TxQuery` in a loop.  I'm pulling this out of another branch and putting it up somewhat unpolished because there seems to be a bug whereby you do broadcast->txquery and quite often it will say "not found" even though our broadcast uses "sync" meaning it should have passed into cometbft's mempool.  This seems like a cometbft bug.