### PR TITLE
test: use a fixed chain ID in act/integ tests

### DIFF
--- a/test/acceptance/helper.go
+++ b/test/acceptance/helper.go
@@ -32,6 +32,8 @@ var (
 	envFile = getEnv("KACT_ENV_FILE", "./.env")
 )
 
+const testChainID = "kwil-test-chain"
+
 // ActTestCfg is the config for acceptance test
 type ActTestCfg struct {
 	GWEndpoint    string // gateway endpoint
@@ -171,6 +173,7 @@ func (r *ActHelper) generateNodeConfig() {
 	r.t.Logf("create test temp directory: %s", tmpPath)
 
 	err := nodecfg.GenerateNodeConfig(&nodecfg.NodeGenerateConfig{
+		ChainID: testChainID,
 		// InitialHeight: 0,
 		OutputDir:       tmpPath,
 		JoinExpiry:      86400,
@@ -275,7 +278,7 @@ func (r *ActHelper) GetDriver(driveType string, user string) KwilAcceptanceDrive
 func (r *ActHelper) getClientDriver(signer auth.Signer) KwilAcceptanceDriver {
 	logger := log.New(log.Config{Level: r.cfg.LogLevel})
 
-	options := []client.Option{client.WithSigner(signer, ""),
+	options := []client.Option{client.WithSigner(signer, testChainID),
 		client.WithLogger(logger),
 		client.WithTLSCert("")} // TODO: handle cert
 	kwilClt, err := client.Dial(context.TODO(), r.cfg.GrpcEndpoint, options...)

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -51,7 +51,10 @@ var defaultWaitStrategies = map[string]string{
 	"node3": "Starting Node service",
 }
 
-const ExtContainer = "ext1"
+const (
+	ExtContainer = "ext1"
+	testChainID  = "kwil-test-chain"
+)
 
 // IntTestConfig is the config for integration test
 // This is totally separate from acceptance test
@@ -184,6 +187,7 @@ func (r *IntHelper) generateNodeConfig() {
 	r.t.Logf("create test temp directory: %s", tmpPath)
 
 	err := nodecfg.GenerateTestnetConfig(&nodecfg.TestnetGenerateConfig{
+		ChainID: testChainID,
 		// InitialHeight:           0,
 		NValidators:             r.cfg.NValidator,
 		NNonValidators:          r.cfg.NNonValidator,
@@ -364,7 +368,7 @@ func (r *IntHelper) GetOperatorDriver(ctx context.Context, name string, driverTy
 func (r *IntHelper) getClientDriver(signer auth.Signer) KwilIntDriver {
 	logger := log.New(log.Config{Level: r.cfg.LogLevel})
 
-	options := []client.Option{client.WithSigner(signer, ""),
+	options := []client.Option{client.WithSigner(signer, testChainID),
 		client.WithLogger(logger),
 		client.WithTLSCert("")} // TODO: handle cert
 	kwilClt, err := client.Dial(context.TODO(), r.cfg.GrpcEndpoint, options...)


### PR DESCRIPTION
This uses a fixed chain ID (`kwil-test-chain`) in the acceptance and integration test helpers.  This applies to the `task dev:up` as well.