### PR TITLE
[WIP] Feature/kwil cli config change

### DIFF
--- a/cmd/kwil-cli/cmds/common/roundtripper.go
+++ b/cmd/kwil-cli/cmds/common/roundtripper.go
@@ -58,7 +58,7 @@ func DialClient(ctx context.Context, flags uint8, fn RoundTripper) error {
 			// here create http client to config cookie
 			// put cookie options in core/client/client.go seems not a good idea
 			cookie := ConvertToHttpCookie(kgwAuthInfo.Cookie)
-			hc, err := httpRPC.DialOptions(conf.GrpcURL, httpRPC.WithCookie(cookie))
+			hc, err := httpRPC.DialOptions(conf.Provider, httpRPC.WithCookie(cookie))
 			if err != nil {
 				return err
 			}
@@ -66,13 +66,13 @@ func DialClient(ctx context.Context, flags uint8, fn RoundTripper) error {
 		}
 	}
 
-	if conf.GrpcURL == "" {
+	if conf.Provider == "" {
 		// the grpc url is required
 		// this is somewhat redundant since the config marks it as required, but in case the config is changed
 		return fmt.Errorf("kwil grpc url is required")
 	}
 
-	clt, err := client.Dial(ctx, conf.GrpcURL, options...)
+	clt, err := client.Dial(ctx, conf.Provider, options...)
 	if err != nil {
 		return err
 	}

--- a/cmd/kwil-cli/cmds/configure/configure.go
+++ b/cmd/kwil-cli/cmds/configure/configure.go
@@ -52,15 +52,15 @@ func runErrs(conf *config.KwilCliConfig, fns ...func(*config.KwilCliConfig) erro
 
 func promptGRPCURL(conf *config.KwilCliConfig) error {
 	prompt := &common.Prompter{
-		Label:   "Kwil RPC URL",
-		Default: conf.GrpcURL,
+		Label:   "Kwil RPC provider URL",
+		Default: conf.Provider,
 	}
 	res, err := prompt.Run()
 	if err != nil {
 		return err
 	}
 
-	conf.GrpcURL = res
+	conf.Provider = res
 
 	return nil
 }

--- a/cmd/kwil-cli/cmds/utils/auth.go
+++ b/cmd/kwil-cli/cmds/utils/auth.go
@@ -35,7 +35,7 @@ func kgwAuthnCmd() *cobra.Command {
 					}
 
 					signer := auth.EthPersonalSigner{Key: *cfg.PrivateKey}
-					if cfg.GrpcURL == "" {
+					if cfg.Provider == "" {
 						return fmt.Errorf("provider url not provided")
 					}
 

--- a/cmd/kwil-cli/cmds/utils/message_test.go
+++ b/cmd/kwil-cli/cmds/utils/message_test.go
@@ -188,13 +188,13 @@ func Example_respKwilCliConfig_text() {
 		cfg: &config.KwilCliConfig{
 			PrivateKey:  pk,
 			ChainID:     "chainid123",
-			GrpcURL:     "localhost:9090",
+			Provider:    "http://localhost:8080",
 			TLSCertFile: "",
 		},
 	}, nil, "text")
 	// Output:
 	// PrivateKey: ***
-	// GrpcURL: localhost:9090
+	// Provider: http://localhost:8080
 	// ChainID: chainid123
 	// TLSCertFile:
 }
@@ -209,7 +209,7 @@ func Example_respKwilCliConfig_json() {
 		cfg: &config.KwilCliConfig{
 			PrivateKey:  pk,
 			ChainID:     "chainid123",
-			GrpcURL:     "localhost:9090",
+			Provider:    "http://localhost:8080",
 			TLSCertFile: "",
 		},
 	}, nil, "json")
@@ -217,7 +217,7 @@ func Example_respKwilCliConfig_json() {
 	// {
 	//   "result": {
 	//     "private_key": "***",
-	//     "grpc_url": "localhost:9090",
+	//     "provider": "http://localhost:8080",
 	//     "chain_id": "chainid123",
 	//     "tls_cert_file": ""
 	//   },

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -18,18 +18,14 @@ const (
 
 	// NOTE: these flags below are also used as viper key names
 	globalPrivateKeyFlag = "private-key"
-	// globalProviderFlag historically there was a chain-provider flag,
-	// we could/should change this flag to `provider`
-	// also since the config file is using `grpc_url`, should change too
-	// TODO: this is a breaking change
-	globalProviderFlag = "kwil-provider"
-	globalChainIDFlag  = "chain-id"
-	globalOutputFlag   = "output"
-	globalTlsCertFlag  = "tls-cert-file"
+	globalProviderFlag   = "provider"
+	globalChainIDFlag    = "chain-id"
+	globalOutputFlag     = "output"
+	globalTlsCertFlag    = "tls-cert-file"
 	// NOTE: viper key name are used for viper related operations
 	// here they are same `mapstructure` names defined in the config struct
 	viperPrivateKeyName = "private_key"
-	viperProviderName   = "grpc_url"
+	viperProviderName   = "provider"
 	viperChainID        = "chain_id"
 	viperTlsCertName    = "tls_cert_file"
 	viperOutputName     = "output"
@@ -85,7 +81,7 @@ var outputFormat = DefaultOutputFormat
 func BindGlobalFlags(fs *pflag.FlagSet) {
 	// Bind flags to environment variables
 	fs.String(globalPrivateKeyFlag, cliCfg.PrivateKey, "The private key of the wallet that will be used for signing")
-	fs.String(globalProviderFlag, cliCfg.GrpcURL, "The Kwil provider endpoint")
+	fs.String(globalProviderFlag, cliCfg.Provider, "The Kwil provider endpoint")
 	fs.String(globalChainIDFlag, cliCfg.ChainID, "The expected/intended Kwil Chain ID")
 	fs.String(globalTlsCertFlag, cliCfg.TLSCertFile, "The path to the TLS certificate, this is required if the kwil provider endpoint is using TLS")
 	fs.Var(&outputFormat, globalOutputFlag, "the format for command output, either 'text' or 'json'")

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -47,7 +47,7 @@ func NewKwilCliDriver(cliBin, adminBin, rpcUrl, privKey, chainID string, identit
 }
 
 func (d *KwilCliDriver) newKwilCliCmd(args ...string) *exec.Cmd {
-	args = append(args, "--kwil-provider", d.rpcUrl)
+	args = append(args, "--provider", d.rpcUrl)
 	args = append(args, "--private-key", d.privKey)
 	args = append(args, "--chain-id", d.chainID)
 	args = append(args, "--output", "json")


### PR DESCRIPTION
This is  **breaking changes**

Since kwil-cli now support http&grpc, and use http by default, the config field `grpc_url` need to be changed:
- change `grpc_url` to `provider`
- change cli flag `kwil-provider` to `provider`

todo:
- remove `tls_cert_file` field?  not sure if it is still needed
- change default configuration folder from `kwil_cli` to `kwil-cli`, to be consistent to other binaries