### PR TITLE
kwil-cli: add utils chain-info command

### DIFF
--- a/cmd/kwil-cli/cmds/utils/chain_id.go
+++ b/cmd/kwil-cli/cmds/utils/chain_id.go
@@ -1,0 +1,32 @@
+package utils
+
+import (
+	"context"
+
+	"github.com/kwilteam/kwil-db/cmd/internal/display"
+	"github.com/kwilteam/kwil-db/cmd/kwil-cli/cmds/common"
+	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
+	"github.com/kwilteam/kwil-db/core/client"
+	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/spf13/cobra"
+)
+
+func chainInfoCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:   "chain-info",
+		Short: "Ping is used to ping the kwil provider endpoint",
+		Long:  "",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var chainInfo *types.ChainInfo
+			err := common.DialClient(cmd.Context(), common.WithoutPrivateKey, func(ctx context.Context, client *client.Client, cfg *config.KwilCliConfig) error {
+				var err error
+				chainInfo, err = client.ChainInfo(ctx)
+				return err
+			})
+
+			return display.Print(&respChainInfo{chainInfo}, err, config.GetOutputFormat())
+		},
+	}
+
+	return cmd
+}

--- a/cmd/kwil-cli/cmds/utils/message.go
+++ b/cmd/kwil-cli/cmds/utils/message.go
@@ -8,6 +8,7 @@ import (
 	"reflect"
 
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
+	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 )
 
@@ -24,6 +25,35 @@ func (s respStr) MarshalJSON() ([]byte, error) {
 
 func (s respStr) MarshalText() ([]byte, error) {
 	return []byte(s), nil
+}
+
+type respChainInfo struct {
+	Info *types.ChainInfo
+}
+
+func (r *respChainInfo) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		ChainID     string `json:"chain_id"`
+		BlockHeight uint64 `json:"block_height"`
+		BlockHash   string `json:"block_hash"`
+	}{
+		ChainID:     r.Info.ChainID,
+		BlockHeight: r.Info.BlockHeight,
+		BlockHash:   r.Info.BlockHash,
+	})
+}
+
+func (r *respChainInfo) MarshalText() ([]byte, error) {
+	msg := fmt.Sprintf(`Chain ID: %s
+Height: %d
+Hash: %s
+`,
+		r.Info.ChainID,
+		r.Info.BlockHeight,
+		r.Info.BlockHash,
+	)
+
+	return []byte(msg), nil
 }
 
 // respTxQuery is used to represent a transaction response in cli

--- a/cmd/kwil-cli/cmds/utils/message_test.go
+++ b/cmd/kwil-cli/cmds/utils/message_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 
 	"github.com/stretchr/testify/assert"
@@ -25,6 +26,39 @@ func Test_respStr(t *testing.T) {
 	sb, err := s.MarshalJSON()
 	assert.NoError(t, err)
 	assert.Equal(t, `{"message":"pong"}`, string(sb))
+}
+
+func Example_respChainInfo_text() {
+	display.Print(&respChainInfo{
+		&types.ChainInfo{
+			ChainID:     "kwil-chain",
+			BlockHeight: 100,
+			BlockHash:   "00000beefbeefbeef",
+		},
+	}, nil, "text")
+	// Output:
+	// Chain ID: kwil-chain
+	// Height: 100
+	// Hash: 00000beefbeefbeef
+}
+
+func Example_respChainInfo_json() {
+	display.Print(&respChainInfo{
+		&types.ChainInfo{
+			ChainID:     "kwil-chain",
+			BlockHeight: 100,
+			BlockHash:   "00000beefbeefbeef",
+		},
+	}, nil, "json")
+	// Output:
+	// {
+	//   "result": {
+	//     "chain_id": "kwil-chain",
+	//     "block_height": 100,
+	//     "block_hash": "00000beefbeefbeef"
+	//   },
+	//   "error": ""
+	// }
 }
 
 func Example_respStr_text() {

--- a/cmd/kwil-cli/cmds/utils/utils.go
+++ b/cmd/kwil-cli/cmds/utils/utils.go
@@ -16,6 +16,7 @@ func NewCmdUtils() *cobra.Command {
 		pingCmd(),
 		printConfigCmd(),
 		txQueryCmd(),
+		chainInfoCmd(),
 	)
 
 	return cmd


### PR DESCRIPTION
Resolves https://github.com/kwilteam/kwil-db/pull/367

```
$ ./kwil-cli utils chain-info --output json
{
  "result": {
    "chain_id": "kwil-chain-JXlwSx",
    "block_height": 63676,
    "block_hash": "27f3f5dca2985874672c8a30fc6f8a3367eb93a1cf502e5854682f3342d76ed1"
  },
  "error": ""
}
```

```
$ ./kwil-cli utils chain-info --output text
Chain ID: kwil-chain-JXlwSx
Height: 63548
Hash: 3bbebe0e3fd5a911c55f5be63e84d4795207ca36f1ed36195d2f911131fef27b
```