### PR TITLE
kwild: add pprof capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@ cmd/cmd
 .data/
 .build/
 .task/
+*.pprof
 **/__debug_bin.exe
 **/__debug_bin*
 .pgdata/

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -55,6 +55,8 @@ type AppConfig struct {
 	TLSKeyFile   string `mapstructure:"tls_key_file"`
 	EnableRPCTLS bool   `mapstructure:"rpctls"`
 	Hostname     string `mapstructure:"hostname"`
+	ProfileMode  string `mapstructure:"profile_mode"`
+	ProfileFile  string `mapstructure:"profile_file"`
 }
 
 type SnapshotConfig struct {

--- a/cmd/kwild/flags.go
+++ b/cmd/kwild/flags.go
@@ -28,6 +28,9 @@ func addKwildFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 	flagSet.BoolVar(&cfg.AppCfg.EnableRPCTLS, "app.rpctls", cfg.AppCfg.EnableRPCTLS, "Use TLS on the user gRPC server")
 	flagSet.StringVar(&cfg.AppCfg.Hostname, "app.hostname", cfg.AppCfg.Hostname, "kwild Server hostname")
 
+	flagSet.StringVar(&cfg.AppCfg.ProfileMode, "app.profile_mode", cfg.AppCfg.ProfileMode, "kwild profile mode (http, cpu, mem, mutex, or block)")
+	flagSet.StringVar(&cfg.AppCfg.ProfileFile, "app.profile_file", cfg.AppCfg.ProfileFile, "kwild profile output file path (e.g. cpu.pprof)")
+
 	// Extension endpoints flags
 	flagSet.StringSliceVar(&cfg.AppCfg.ExtensionEndpoints, "app.extension_endpoints", cfg.AppCfg.ExtensionEndpoints, "kwild extension endpoints")
 

--- a/cmd/kwild/main.go
+++ b/cmd/kwild/main.go
@@ -3,9 +3,14 @@ package main
 import (
 	"context"
 	"fmt"
+	"net/http"
+	_ "net/http/pprof"
 	"os"
 	"os/signal"
+	"runtime"
+	"runtime/pprof"
 	"syscall"
+	"time"
 
 	"github.com/kwilteam/kwil-db/cmd/kwild/config"
 	"github.com/kwilteam/kwil-db/cmd/kwild/server"
@@ -54,6 +59,12 @@ var rootCmd = &cobra.Command{
 			return fmt.Errorf("failed to initialize private key and genesis: %w", err)
 		}
 
+		stopProfiler, err := startProfilers(kwildCfg)
+		if err != nil {
+			return err
+		}
+		defer stopProfiler()
+
 		signalChan := make(chan os.Signal, 1)
 		signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
 		ctx, cancel := context.WithCancel(cmd.Context())
@@ -70,4 +81,77 @@ var rootCmd = &cobra.Command{
 
 		return svr.Start(ctx)
 	},
+}
+
+func startProfilers(cfg *config.KwildConfig) (func(), error) {
+	mode := cfg.AppCfg.ProfileMode
+	pprofFile := kwildCfg.AppCfg.ProfileFile
+	if pprofFile == "" {
+		pprofFile = fmt.Sprintf("kwild-%s.pprof", mode)
+	}
+
+	switch cfg.AppCfg.ProfileMode {
+	case "http":
+		// http pprof uses http.DefaultServeMux, so we register a redirect
+		// handler with the root path on the default mux.
+		http.Handle("/", http.RedirectHandler("/debug/pprof/", http.StatusSeeOther))
+		go func() {
+			if err := http.ListenAndServe("localhost:6060", nil); err != nil {
+				fmt.Printf("http.ListenAndServe: %v\n", err)
+			}
+		}()
+		return func() {}, nil
+	case "cpu":
+		f, err := os.Create(pprofFile)
+		if err != nil {
+			return nil, err
+		}
+		err = pprof.StartCPUProfile(f)
+		if err != nil {
+			return nil, fmt.Errorf("error starting CPU profiler: %w", err)
+		}
+		return pprof.StopCPUProfile, nil
+	case "mem":
+		f, err := os.Create(pprofFile)
+		if err != nil {
+			return nil, err
+		}
+		timer := time.NewTimer(time.Second * 15)
+		go func() {
+			<-timer.C
+			if err = pprof.WriteHeapProfile(f); err != nil {
+				fmt.Printf("WriteHeapProfile: %v\n", err)
+			}
+			f.Close()
+		}()
+		return func() { timer.Reset(0) }, nil
+	case "block":
+		f, err := os.Create(pprofFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not create block profile file %q: %v", pprofFile, err)
+		}
+		runtime.SetBlockProfileRate(1)
+		return func() {
+			pprof.Lookup("block").WriteTo(f, 0)
+			f.Close()
+			runtime.SetBlockProfileRate(0)
+		}, nil
+	case "mutex":
+		f, err := os.Create(pprofFile)
+		if err != nil {
+			return nil, fmt.Errorf("could not create mutex profile file %q: %v", pprofFile, err)
+		}
+		runtime.SetMutexProfileFraction(1)
+		return func() {
+			if mp := pprof.Lookup("mutex"); mp != nil {
+				mp.WriteTo(f, 0)
+			}
+			f.Close()
+			runtime.SetMutexProfileFraction(0)
+		}, nil
+	case "": // disabled
+		return func() {}, nil
+	default:
+		return nil, fmt.Errorf("unknown profile mode %s", cfg.AppCfg.ProfileMode)
+	}
 }

--- a/cmd/kwild/server/server.go
+++ b/cmd/kwild/server/server.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"runtime"
 	"time"
 
 	"github.com/cometbft/cometbft/crypto/ed25519"
@@ -60,7 +61,9 @@ func New(ctx context.Context, cfg *config.KwildConfig, genesisCfg *config.Genesi
 	defer func() {
 		if r := recover(); r != nil {
 			svr = nil
-			err = fmt.Errorf("panic while building kwild: %v", r)
+			stack := make([]byte, 8192)
+			length := runtime.Stack(stack, false)
+			err = fmt.Errorf("panic while building kwild: %v\n\nstack:\n\n%v", r, string(stack[:length]))
 			closers.closeAll()
 		}
 	}()


### PR DESCRIPTION
This adds the ability to profile kwild with the following new switches:

- `profile_mode`, which can be: `http`, `cpu`, `mem`, `mutex`, or `block`

  In "http" mode, this starts the "net/http/pprof" profiling server
  listening on localhost:6060.  See https://pkg.go.dev/net/http/pprof

  The other modes correspond to the profile modes that are described in
  `go help testflag`.

- `profile_file`, which specifies a file to write the profile data to. If not specified, a default of "kwild-{mode}.pprof" is used. This option does not apply to "http" mode.

See also https://go.dev/blog/pprof. That is a little outdated and the easiest way to analyze the captured profiles is like: `go tool pprof -http localhost:8181 kwild kwild-block.pprof` (given a "block" profile captured and a kwild binary)