### PR TITLE
add task tidy

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -58,6 +58,7 @@ tasks:
         (cd core; go mod tidy)
         (cd parse; go mod tidy)
         go mod tidy
+        (cd test; go mod tidy)
 
   lint:
     desc: Lint with golangci-lint


### PR DESCRIPTION
This adds the `tidy` task to run `go mod tidy` in each module in order of module dependencies (bottom to top).  CI does a tidy check, but devs had to get the tidying right manually if they modified any dependencies.

I'm thinking this task shouldn't be a dependency of any other tasks since it's relatively uncommon to really modify dependencies, and `go mod tidy` can get fussy while you are in the middle of changes that you might just be testing.