### PR TITLE
kwil-admin: make parent .kwil-admin directory if needed

### DIFF
--- a/cmd/kwil-admin/node.go
+++ b/cmd/kwil-admin/node.go
@@ -51,6 +51,9 @@ func (ngkc *NodeGenAuthKeyCmd) run(ctx context.Context, a *args) error {
 	if fileExists(clientKeyFile) {
 		return fmt.Errorf("key file exists: %v", clientKeyFile)
 	}
+	if err := os.MkdirAll(filepath.Dir(clientKeyFile), 0755); err != nil {
+		return fmt.Errorf("failed to create key file dir: %v", err)
+	}
 
 	clientCertFile := a.Node.ClientTLSCertFile
 	if !filepath.IsAbs(clientCertFile) {
@@ -58,6 +61,9 @@ func (ngkc *NodeGenAuthKeyCmd) run(ctx context.Context, a *args) error {
 	}
 	if fileExists(clientCertFile) {
 		return fmt.Errorf("cert file exists: %v", clientCertFile)
+	}
+	if err := os.MkdirAll(filepath.Dir(clientCertFile), 0755); err != nil {
+		return fmt.Errorf("failed to create key file dir: %v", err)
 	}
 
 	return transport.GenTLSKeyPair(clientCertFile, clientKeyFile, "kwild CA", nil)


### PR DESCRIPTION
The makes the folder for the key generated by the `node gen-auth-key` command, which is typically `~/.kwil-admin`.  Prior you had to make sure you created that folder first.

Note that the `os.MkdirAll` call is a no-op if it already exists.