### PR TITLE
feat: enable cors Access-Control-Allow-Credentials

### DIFF
--- a/internal/services/grpc_gateway/middleware/cors/cors.go
+++ b/internal/services/grpc_gateway/middleware/cors/cors.go
@@ -36,6 +36,7 @@ func MCors(cors []string) *middleware.NamedMiddleware {
 					w.Header().Set("Access-Control-Allow-Origin", r.Header.Get("Origin"))
 					w.Header().Set("Access-Control-Allow-Methods", AllowMethods)
 					w.Header().Set("Access-Control-Allow-Headers", AllowHeaders)
+					w.Header().Set("Access-Control-Allow-Credentials", "true")
 				}
 
 				if r.Method == "OPTIONS" {


### PR DESCRIPTION
For axios to working in frontend, our api need to set `Access-Control-Allow-Credentials` header