### PR TITLE
added unique generation for addresses when setting up testnets

### DIFF
--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -98,6 +98,9 @@ grpc_listen_addr = "{{ .AppCfg.GrpcListenAddress }}"
 # TCP or UNIX socket address for the KWILD App's HTTP server to listen on
 http_listen_addr = "{{ .AppCfg.HTTPListenAddress }}"
 
+# TCP or UNIX socket address for the KWILD App's Admin GRPC server to listen on
+admin_listen_addr = "{{ .AppCfg.AdminListenAddress }}"
+
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = {{arrayFormatter .AppCfg.ExtensionEndpoints}}
 

--- a/cmd/kwil-admin/nodecfg/toml_test.go
+++ b/cmd/kwil-admin/nodecfg/toml_test.go
@@ -56,10 +56,47 @@ func Test_GenerateTestnetConfig(t *testing.T) {
 		P2pPort:                 26656,
 	}
 
-	err := GenerateTestnetConfig(&genCfg)
+	err := GenerateTestnetConfig(&genCfg, nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
 	os.RemoveAll(genCfg.OutputDir)
+}
+
+func Test_IncrementingPorts(t *testing.T) {
+	type testcase struct {
+		input  string
+		amount int
+		want   string
+	}
+
+	testcases := []testcase{
+		{
+			input:  "localhost:26656",
+			amount: 1,
+			want:   "localhost:26657",
+		},
+		{
+			input:  "http://localhost:26656",
+			amount: 2,
+			want:   "http://localhost:26658",
+		},
+		{
+			input:  "https://localhost:26656",
+			amount: -2,
+			want:   "https://localhost:26654",
+		},
+		{
+			input:  "tcp://0.0.0.0:26656",
+			amount: 3,
+			want:   "tcp://0.0.0.0:26659",
+		},
+	}
+
+	for _, tc := range testcases {
+		got, err := incrementPort(tc.input, tc.amount)
+		assert.NoError(t, err)
+		assert.Equal(t, tc.want, got)
+	}
 }

--- a/cmd/kwil-admin/setup.go
+++ b/cmd/kwil-admin/setup.go
@@ -42,7 +42,9 @@ func (cc *SetupCmd) run(ctx context.Context) error {
 		cc.Testnet.WithoutGasCosts = true // gas disabled by setup testnet
 		genCfg := nodecfg.TestnetGenerateConfig(*cc.Testnet)
 		genCfg.PopulatePersistentPeers = true // temporary workaround without changing nodecfg
-		return nodecfg.GenerateTestnetConfig(&genCfg)
+		return nodecfg.GenerateTestnetConfig(&genCfg, &nodecfg.ConfigOpts{
+			UniquePorts: true,
+		})
 	case cc.GenesisHash != nil:
 		dbDir, genesisFile := cc.GenesisHash.DBDir, cc.GenesisHash.GenesisFile
 		appHash, err := config.PatchGenesisAppHash(dbDir, genesisFile)

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -213,7 +213,7 @@ func (r *IntHelper) generateNodeConfig() {
 		JoinExpiry:              r.cfg.JoinExpiry,
 		WithoutGasCosts:         true,
 		WithoutNonces:           false,
-	})
+	}, nil)
 	require.NoError(r.t, err, "failed to generate testnet config")
 	r.home = tmpPath
 	r.ExtractPrivateKeys()


### PR DESCRIPTION
I updated the admin tool to automatically generate unique addresses when creating a testnet.  Essentially, you can run:

# Setup:
```bash
kwil-admin setup testnet -v 3 --hostnames "localhost" "localhost" "localhost" --output-dir ./kwil-testnet
```

# Terminals:

```bash
kwild --root_dir ./kwil-testnet/node0
```

```bash
kwild --root_dir ./kwil-testnet/node1
```

```bash
kwild --root_dir ./kwil-testnet/node2
```