### PR TITLE
fixed bug where byte slices did not get copied off disk correctly

### DIFF
--- a/internal/sessions/session.go
+++ b/internal/sessions/session.go
@@ -134,15 +134,13 @@ func (m *MultiCommitter) Commit(ctx context.Context, idempotencyKey []byte) (id 
 	id = []byte{}
 
 	orderedMap := order.OrderMap(m.committables)
-	for committiableId, c := range orderedMap {
+	for _, c := range orderedMap {
 		newId, err := c.Value.Commit(ctx, idempotencyKey)
 		if err != nil {
 			return nil, err
 		}
 
 		id = append(id, newId...)
-
-		_ = committiableId // TODO: delete this.  Using it for debugging.
 	}
 
 	err = deleteCurrentKey(m.kv)

--- a/internal/sql/sqlite/changeset.go
+++ b/internal/sql/sqlite/changeset.go
@@ -238,9 +238,11 @@ func convertValue(v *sqlite.Value) (*Value, error) {
 			Value:    v.Text(),
 		}
 	case sqlite.TypeBlob:
+		b := make([]byte, len(v.Blob()))
+		copy(b, v.Blob())
 		val = &Value{
 			DataType: DataTypeBlob,
-			Value:    v.Blob(),
+			Value:    b,
 		}
 	case sqlite.TypeNull:
 		val = &Value{


### PR DESCRIPTION
Fixed a bug causing non-determinism where changesets would not read bytes off of the disk correctly.  @jchappelow called this about an hour ago, however I originally fixed it in the wrong place 🤦 .