### PR TITLE
fix: skip derive identifier if not viable for action call

### DIFF
--- a/internal/modules/datasets/read.go
+++ b/internal/modules/datasets/read.go
@@ -17,10 +17,15 @@ func (u *DatasetModule) Call(ctx context.Context, dbid string, action string, ar
 	var sender string
 	var err error
 
-	if len(msg.Sender) > 0 && msg.AuthType != "" {
-		sender, err = ident.Identifier(msg.AuthType, msg.Sender)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get sender identifier: %w", err)
+	if len(msg.Sender) > 0 {
+		if msg.AuthType != "" {
+			sender, err = ident.Identifier(msg.AuthType, msg.Sender)
+			if err != nil {
+				return nil, fmt.Errorf("failed to get sender identifier: %w", err)
+			}
+		} else {
+			// auth_type is the http payload field name
+			return nil, fmt.Errorf("auth_type is required")
 		}
 	}
 


### PR DESCRIPTION
For action call, if `Sender` or `AuthType` not set, we should not try to derive identifier.