### PR TITLE
resolve various logging issues

### DIFF
--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -680,6 +680,8 @@ func (a *AbciApp) Info(p0 abciTypes.RequestInfo) abciTypes.ResponseInfo {
 		panic(newFatalError("Info", &p0, fmt.Sprintf("failed to get app hash: %v", err)))
 	}
 
+	a.log.Info("ABCI application is ready", zap.Int64("height", height))
+
 	return abciTypes.ResponseInfo{
 		LastBlockHeight:  height,
 		LastBlockAppHash: appHash,
@@ -722,7 +724,7 @@ func (a *AbciApp) InitChain(p0 abciTypes.RequestInitChain) abciTypes.ResponseIni
 		panic(fmt.Sprintf("failed to set app hash: %v", err))
 	}
 
-	logger.Debug("initialized chain", zap.String("app hash", fmt.Sprintf("%x", a.cfg.GenesisAppHash)))
+	logger.Info("initialized chain", zap.String("app hash", fmt.Sprintf("%x", a.cfg.GenesisAppHash)))
 
 	return abciTypes.ResponseInitChain{
 		Validators: valUpdates,

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -123,7 +123,7 @@ func NewCometBftNode(app abciTypes.Application, conf *cometConfig.Config, genDoc
 		return nil, fmt.Errorf("invalid node config: %w", err)
 	}
 
-	logger := NewLogWrapper(log)
+	logger := NewLogWrapper(log.Named("cometbft"))
 
 	privateValidator, err := privval.NewValidatorSigner(privateKey, atomicStore)
 	if err != nil {

--- a/internal/engine/types/errors.go
+++ b/internal/engine/types/errors.go
@@ -1,4 +1,4 @@
-package engine
+package types
 
 import "errors"
 

--- a/internal/services/grpc/txsvc/v1/schema.go
+++ b/internal/services/grpc/txsvc/v1/schema.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 
 	txpb "github.com/kwilteam/kwil-db/core/rpc/protobuf/tx/v1"
-	"github.com/kwilteam/kwil-db/internal/engine"
+	engineTypes "github.com/kwilteam/kwil-db/internal/engine/types"
 	"go.uber.org/zap"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
@@ -17,11 +17,11 @@ func (s *Service) GetSchema(ctx context.Context, req *txpb.GetSchemaRequest) (*t
 	if err != nil {
 		logger.Debug("failed to get schema", zap.Error(err))
 
-		if errors.Is(err, engine.ErrDatasetNotFound) {
+		if errors.Is(err, engineTypes.ErrDatasetNotFound) {
 			return nil, status.Error(codes.NotFound, "dataset not found")
 		}
 
-		return nil, status.Error(codes.Internal, "failed to get schema")
+		return nil, status.Error(codes.Unknown, "failed to get schema")
 	}
 
 	txSchema, err := convertSchemaFromEngine(schema)

--- a/internal/services/grpc/txsvc/v1/tx_query.go
+++ b/internal/services/grpc/txsvc/v1/tx_query.go
@@ -25,8 +25,8 @@ func (s *Service) TxQuery(ctx context.Context, req *txpb.TxQueryRequest) (*txpb.
 			logger.Debug("transaction not found")
 			return nil, status.Error(codes.NotFound, "transaction not found")
 		}
-		logger.Error("failed to query tx", zap.Error(err))
-		return nil, status.Error(codes.Internal, "failed to query transaction")
+		logger.Warn("failed to query tx", zap.Error(err))
+		return nil, status.Error(codes.Unknown, "failed to query transaction")
 	}
 
 	originalTx := &transactions.Transaction{}

--- a/internal/services/grpc_server/logging.go
+++ b/internal/services/grpc_server/logging.go
@@ -23,10 +23,14 @@ func codeToLevel(code codes.Code) log.Level {
 		return log.InfoLevel
 
 	case codes.DeadlineExceeded, codes.PermissionDenied, codes.ResourceExhausted, codes.FailedPrecondition,
-		codes.Aborted, codes.OutOfRange, codes.Unavailable:
+		codes.Aborted, codes.OutOfRange, codes.Unavailable, codes.Unknown, codes.Unimplemented:
 		return log.WarnLevel
 
-	case codes.Unknown, codes.Unimplemented, codes.Internal, codes.DataLoss:
+	case codes.Internal, codes.DataLoss:
+		// WARNING: This error level will result in a call stack dump, so try
+		// not to use these codes unless we know that there is a server error,
+		// as opposed to a user-generated error such as bad inputs. The docs for
+		// Internal state that it should indicate "something is very broken".
 		return log.ErrorLevel
 
 	default:


### PR DESCRIPTION
On our test network, I have observed several very loud and concerning errors logged, even displaying call stacks, but which turn out to be silly request (client) issues like asking for a non-existent dataset.  On a server, logging at error level of severity should generally indicate a serious issue with the server rather than bad client requests.

This change:
- Restores the use of a recognized error type (`ErrDatasetNotFound`) in the engine.  Note that there is no need to decorate an error message with the dbid since the caller knows what they asked for.
- Gives the ABCI logger it's own name so it displays as `kwild.abci` instead of `kwild`, and logs the startup calls to `Info` / `InitChain`
- Replaces the use of grpc's `codes.Internal` with `codes.Unknown` in a handful of places to avoid severe error logging when it is likely to have been a user request problem.
- Revises `codeToLevel` for the gRPC service's mapping from code to log level so that `Unknown` is warn level instead of error, and added a block comment describing the meaning and implications of error level ("something is very broken" in gRPC terms).