### PR TITLE
engine: remove @action and @dataset env vars

### DIFF
--- a/internal/engine/execution/context.go
+++ b/internal/engine/execution/context.go
@@ -71,8 +71,6 @@ func (s *ScopeContext) Values() map[string]any {
 
 	// set environment variables
 	values["@caller"] = s.execution.Data.CallerIdentifier
-	values["@dataset"] = s.execution.Data.Dataset
-	values["@procedure"] = s.execution.Data.Procedure
 
 	return values
 }

--- a/internal/engine/types/execution.go
+++ b/internal/engine/types/execution.go
@@ -5,14 +5,10 @@ package types
 type ExecutionData struct {
 	// Dataset is the DBID of the dataset that was called.
 	// Even if a procedure in another dataset is called, this will always be the original dataset.
-	// This is injected as a variable for usage in the query, under
-	// the variable name "@dataset".
 	Dataset string
 
 	// Procedure is the original procedure that was called.
 	// Even if a nested procedure is called, this will always be the original procedure.
-	// This is injected as a variable for usage in the query, under
-	// the variable name "@procedure".
 	Procedure string
 
 	// Mutative indicates whether the execution can mutate state.


### PR DESCRIPTION
Resolves https://github.com/kwilteam/kwil-db/issues/405

This removes the `@action` and `@dataset` kuneiform environment variables from the execution engine.

Both `ExecutionData` fields are still used, so I just revised their docs.

Should happen next:
- remove from Kuniform spec and parser
- remove from docs