### PR TITLE
fixed default kwil provider being grpc

### DIFF
--- a/cmd/kwil-cli/config/config.go
+++ b/cmd/kwil-cli/config/config.go
@@ -50,7 +50,7 @@ func (c *KwilCliConfig) Store() error {
 
 func DefaultKwilCliPersistedConfig() *kwilCliPersistedConfig {
 	return &kwilCliPersistedConfig{
-		GrpcURL: "127.0.0.1:50051",
+		GrpcURL: "http://localhost:8080",
 	}
 }
 

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -51,7 +51,7 @@ func init() {
 func BindGlobalFlags(fs *pflag.FlagSet) {
 	// Bind flags to environment variables
 	fs.String(globalPrivateKeyFlag, cliCfg.PrivateKey, "the private key of the wallet that will be used for signing")
-	fs.String(globalProviderFlag, cliCfg.GrpcURL, "the Kwil provider gRPC endpoint")
+	fs.String(globalProviderFlag, cliCfg.GrpcURL, "the Kwil provider HTTP endpoint")
 	fs.String(globalChainIDFlag, cliCfg.ChainID, "the expected/intended Kwil Chain ID")
 	fs.String(globalTlsCertFlag, cliCfg.TLSCertFile, "the path to the TLS certificate (if the provider endpoint is using TLS)")
 


### PR DESCRIPTION
The default kwil provider was still grpc.  I didn't rename any variables out of fear of breaking anything