### PR TITLE
Consensus Failure: Validator join/approve crashes after clean restart

### DIFF
--- a/internal/validators/mgr.go
+++ b/internal/validators/mgr.go
@@ -205,6 +205,7 @@ func (vm *ValidatorMgr) init() error {
 			pubkey:     dbj.Candidate,
 			power:      dbj.Power,
 			validators: make(map[string]bool, len(dbj.Board)),
+			expiresAt:  dbj.ExpiresAt,
 		}
 
 		for i, vi := range dbj.Board {
@@ -361,6 +362,7 @@ func (vm *ValidatorMgr) Approve(ctx context.Context, joiner, approver []byte) er
 	} else {
 		// Record the vote. Check threshold in Finalize.
 		if err := vm.db.AddApproval(ctx, joiner, approver); err != nil {
+			candidate.validators[string(approver)] = false
 			return fmt.Errorf("failed to record approval: %v", err)
 		}
 	}

--- a/internal/validators/sql.go
+++ b/internal/validators/sql.go
@@ -224,7 +224,7 @@ func (vs *validatorStore) addApproval(ctx context.Context, joiner, approver []by
 	// We could just YOLO update, potentially updating zero rows if there's no
 	// join request for this candidate or if approver is not an eligible voting
 	// validator, but let's go the extra mile.
-	res, err := vs.db.Query(ctx, sqlEligibleApprove, map[string]any{
+	res, err := vs.db.Execute(ctx, sqlEligibleApprove, map[string]any{
 		"$candidate": joiner,
 		"$validator": approver,
 	})


### PR DESCRIPTION
This PR fixes 2 bugs resulting in diverging app hashes when node restarts:

-  Join expiry not set during the ValidatorMgr init after restart.
-  If Both validator join and approval goes in the same block, the way we implemented the approval always fails as it doesn't find join request in the db (which is expected).  But we are not clearing out the approval locally. So if node restarts it clears the approval node for the join request, whereas the other nodes don't resulting in app hash divergence. 

Approves approval request if both join and approval request are in the same block.