### PR TITLE
cli: account commands panic on RPC connect failure

### DIFF
--- a/cmd/kwil-cli/cmds/account/balance.go
+++ b/cmd/kwil-cli/cmds/account/balance.go
@@ -34,27 +34,24 @@ func balanceCmd() *cobra.Command {
 				}
 			} // else use our account from the signer
 
-			var acct *types.Account
-			err = common.DialClient(cmd.Context(), cmd, clientFlags, func(ctx context.Context, cl common.Client, conf *config.KwilCliConfig) error {
+			return common.DialClient(cmd.Context(), cmd, clientFlags, func(ctx context.Context, cl common.Client, conf *config.KwilCliConfig) error {
 				if len(acctID) == 0 {
 					acctID = conf.Identity()
 					if len(acctID) == 0 {
 						return display.PrintErr(cmd, errors.New("empty account ID"))
 					}
 				}
-				acct, err = cl.GetAccount(ctx, acctID, types.AccountStatusLatest)
+				acct, err := cl.GetAccount(ctx, acctID, types.AccountStatusLatest)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("get account failed: %w", err))
 				}
-				return nil
+				// NOTE: empty acct.Identifier means it doesn't even have a record
+				// on the network. Perhaps we convey that to the caller? Their
+				// balance is zero regardless, assuming it's the correct acct ID.
+				resp := (*respAccount)(acct)
+				return display.PrintCmd(cmd, resp)
 			})
 
-			// NOTE: empty acct.Identifier means it doesn't even have a record
-			// on the network. Should we convey that to the caller? Their
-			// balance is zero regardless, assuming it's the correct acct ID.
-
-			resp := (*respAccount)(acct)
-			return display.PrintCmd(cmd, resp)
 		},
 	}
 

--- a/cmd/kwil-cli/cmds/account/transfer.go
+++ b/cmd/kwil-cli/cmds/account/transfer.go
@@ -16,8 +16,6 @@ import (
 )
 
 func transferCmd() *cobra.Command {
-	// var recipient, amt string
-
 	cmd := &cobra.Command{
 		Use:   "transfer",
 		Short: "Transfer value to an account",
@@ -34,28 +32,15 @@ func transferCmd() *cobra.Command {
 				return display.PrintErr(cmd, errors.New("invalid decimal amount"))
 			}
 
-			var txHash []byte
-			err = common.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl common.Client, conf *config.KwilCliConfig) error {
-				txHash, err = cl.Transfer(ctx, to, amount, client.WithNonce(nonceOverride))
+			return common.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl common.Client, conf *config.KwilCliConfig) error {
+				txHash, err := cl.Transfer(ctx, to, amount, client.WithNonce(nonceOverride))
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("transfer failed: %w", err))
 				}
-
-				return nil
+				return display.PrintCmd(cmd, display.RespTxHash(txHash))
 			})
-
-			return display.PrintCmd(cmd, display.RespTxHash(txHash))
 		},
 	}
-
-	// const (
-	// 	toFlagName  = "to"
-	// 	amtFlagName = "amount"
-	// )
-	// cmd.Flags().StringVar(&recipient, toFlagName, "", "the recipient (required)")
-	// cmd.Flags().StringVar(&amt, amtFlagName, "", "the recipient (required)")
-
-	// cmd.MarkFlagRequired(toFlagName)
 
 	return cmd
 }


### PR DESCRIPTION
The `kwil-cli account` commands were drafted prior to to the clients overhaul.  This change is essentially a rebase fix for the error path where `DialClient` cannot reach the RPC server.

`kwil-cli` would panic

```
$  ./kwil-cli account balance
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x0 pc=0xa3fca9]

goroutine 1 [running]:
github.com/kwilteam/kwil-db/cmd/kwil-cli/cmds/account.(*respAccount).MarshalText(0x0)
	/home/jon/kwil/git/kwil-db/cmd/kwil-cli/cmds/account/message.go:29 +0x29
github.com/kwilteam/kwil-db/cmd/common/display.(*wrappedMsg).printText(0x58b0ab?, {0xf90ee0, 0xc0000b2028}, {0xf90ee0?, 0xc0000b2030?})
	/home/jon/kwil/git/kwil-db/cmd/common/display/format.go:105 +0x47
...
```

instead of returning a helpful error:

```
307045762e0d74bd8e7196151b950df73d4feea4 42
Error: wrap client: ping: Get "http://127.0.0.1:8080/api/v1/chain_info": dial tcp 127.0.0.1:8080: connect: connection refused
wrap client: ping: Get "http://127.0.0.1:8080/api/v1/chain_info": dial tcp 127.0.0.1:8080: connect: connection refused
```