### PR TITLE
version,kwild: begin 0.7 release cycle

### DIFF
--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -16,10 +16,10 @@ import (
 
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/log"
-	"github.com/mitchellh/mapstructure"
-	toml "github.com/pelletier/go-toml/v2"
 
 	merge "dario.cat/mergo"
+	"github.com/mitchellh/mapstructure"
+	toml "github.com/pelletier/go-toml/v2"
 	"github.com/spf13/pflag"
 	"github.com/spf13/viper"
 )
@@ -258,6 +258,8 @@ func GetCfg(flagCfg *KwildConfig) (*KwildConfig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to expand root directory \"%v\": %v", rootDir, err)
 	}
+
+	fmt.Printf("Root directory \"%v\"\n", rootDir)
 
 	// make sure the root dir exists
 	err = os.MkdirAll(rootDir, 0755)

--- a/cmd/kwild/main.go
+++ b/cmd/kwild/main.go
@@ -46,6 +46,8 @@ func rootCmd() *cobra.Command {
 		Args:              cobra.NoArgs, // just flags
 		Version:           version.KwilVersion,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			fmt.Printf("kwild version %v (Go version %s)\n", version.KwilVersion, runtime.Version())
+
 			var err error
 			kwildCfg, err = config.GetCfg(flagCfg)
 			if err != nil {

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0.6.0-beta" // precursor to 0.6.0+release
+const kwilVersion = "0.7.0-pre"
 
 // KwildVersion may be set at compile time by:
 //


### PR DESCRIPTION
This begins the 0.7 release cycle.  With cometbft 0.38 in use now on `main`, we'll need to create a stable 0.6 release branch for any updates to 0.6.x.

For a reminder of why our apps are aware of the version, and why we bump at the beginning of the release cycle, please see: https://github.com/kwilteam/kwil-db/pull/325#issuecomment-1739768424


```
$  ./kwild 
kwild version 0.7.0-pre+6a56c2438.dirty (Go version go1.21.5)
Root directory "/home/jon/.kwild"
Private key path: /home/jon/.kwild/private_key

```