### PR TITLE
kwil-admin: fix key {info,gen} incorrect lengths

### DIFF
--- a/cmd/kwil-admin/cmds/key/gen.go
+++ b/cmd/kwil-admin/cmds/key/gen.go
@@ -33,7 +33,8 @@ func genCmd() *cobra.Command {
 				if raw {
 					return display.PrintCmd(cmd, display.RespString(hex.EncodeToString(privKey)))
 				} else {
-					return display.PrintCmd(cmd, abci.PrivKeyInfo(privKey))
+					keyInfo, _ := abci.PrivKeyInfo(privKey) // just generated, won't error
+					return display.PrintCmd(cmd, keyInfo)
 				}
 			}
 

--- a/cmd/kwil-admin/cmds/key/info.go
+++ b/cmd/kwil-admin/cmds/key/info.go
@@ -1,6 +1,7 @@
 package key
 
 import (
+	"encoding/hex"
 	"errors"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
@@ -33,14 +34,26 @@ func infoCmd() *cobra.Command {
 			// if len(args) == 1, then the private key is passed as a hex string
 			// otherwise, it is passed as a file path
 			if len(args) == 1 {
-				return display.PrintCmd(cmd, abci.PrivKeyInfo([]byte(args[0])))
+				key, err := hex.DecodeString(args[0])
+				if err != nil {
+					return display.PrintErr(cmd, err)
+				}
+				keyInfo, err := abci.PrivKeyInfo(key)
+				if err != nil {
+					return display.PrintErr(cmd, err)
+				}
+				return display.PrintCmd(cmd, keyInfo)
 			} else if privkeyFile != "" {
 				key, err := abci.ReadKeyFile(privkeyFile)
 				if err != nil {
 					return display.PrintErr(cmd, err)
 				}
 
-				return display.PrintCmd(cmd, abci.PrivKeyInfo(key))
+				keyInfo, err := abci.PrivKeyInfo(key)
+				if err != nil {
+					return display.PrintErr(cmd, err)
+				}
+				return display.PrintCmd(cmd, keyInfo)
 			} else {
 				return display.PrintErr(cmd, errors.New("must provide with the private key file or hex string"))
 			}

--- a/internal/abci/utils.go
+++ b/internal/abci/utils.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 
@@ -69,7 +70,10 @@ func abciStatus(status snapshots.Status) abciTypes.ResponseApplySnapshotChunk_Re
 	}
 }
 
-func PrivKeyInfo(privateKey []byte) *PrivateKeyInfo {
+func PrivKeyInfo(privateKey []byte) (*PrivateKeyInfo, error) {
+	if len(privateKey) != ed25519.PrivateKeySize {
+		return nil, errors.New("incorrect private key length")
+	}
 	priv := ed25519.PrivKey(privateKey)
 	pub := priv.PubKey().(ed25519.PubKey)
 	nodeID := p2p.PubKeyToID(pub)
@@ -82,7 +86,7 @@ func PrivKeyInfo(privateKey []byte) *PrivateKeyInfo {
 		PublicKeyPlainHex:     hex.EncodeToString(pub.Bytes()),
 		Address:               pub.Address().String(),
 		NodeID:                fmt.Sprintf("%v", nodeID), // same as address, just upper case
-	}
+	}, nil
 }
 
 type PrivateKeyInfo struct {


### PR DESCRIPTION
Fixes:

- The `kwil-admin key info` command was not working with a hex positional.
- Length of the key was not checked by `internal/abci.PrivKeyInfo`, and shorter length keys would return results, although incorrect.