### PR TITLE
cli: add `account id` subcommand to return identifier/address

### DIFF
--- a/cmd/kwil-cli/cmds/account/account.go
+++ b/cmd/kwil-cli/cmds/account/account.go
@@ -1,8 +1,34 @@
 package account
 
 import (
+	"encoding/hex"
+	"errors"
+
+	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
+
 	"github.com/spf13/cobra"
 )
+
+var idCmd = &cobra.Command{
+	Use:   "id",
+	Short: "Show the account ID.",
+	Long:  "Returns the Kwil account identifier (typically an Ethereum address), if a private key is configured.",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		conf, err := config.LoadCliConfig()
+		if err != nil {
+			return display.PrintErr(cmd, err)
+		}
+
+		if conf.PrivateKey == nil {
+			return display.PrintErr(cmd, errors.New("no private key configured"))
+		}
+
+		signer := &auth.EthPersonalSigner{Key: *conf.PrivateKey}
+		return display.PrintCmd(cmd, display.RespString(hex.EncodeToString(signer.Identity())))
+	},
+}
 
 var nonceOverride int64
 
@@ -16,6 +42,7 @@ func NewCmdAccount() *cobra.Command {
 	trCmd := transferCmd() // gets the nonce override flag
 
 	cmd.AddCommand(
+		idCmd,
 		balanceCmd(),
 		trCmd,
 	)


### PR DESCRIPTION
This adds the `account id` subcommand to `kwil-cli`.  The purpose is to return the account identifier for the configured private key.  I don't think there was another easy way to get this.  I was using this to get the account for a genesis `alloc` for a new testnet.

I can also rename this to `account address` and prepend "0x" to the displayed string.