### PR TITLE
cli: do not check chain ID unless signing something

### DIFF
--- a/core/client/opts.go
+++ b/core/client/opts.go
@@ -12,7 +12,7 @@ type ClientOptions struct {
 	// Logger is the logger to use for the client.
 	Logger log.Logger
 
-	// Signer will be used to sign transactions.
+	// Signer will be used to sign transactions and set the Sender field on call messages.
 	Signer auth.Signer
 
 	// The chain ID will be used in all transactions, which helps prevent replay attacks on


### PR DESCRIPTION
Resolves issue raised in Slack: https://kwilteam.slack.com/archives/C05RZNFKNJD/p1702667111090029

This allows commands like `utils ping`, `utils chain-info`, `database list`, and many uses of `database call` to not throw an error if any set chain ID mismatches what the remote host claims on connect.

I debated if a new flag for `DialClient` was required such as `DisregardChainID`, but decided to keep it simple by using `WithoutPrivateKey` to imply if it was important to assert the configured chain ID.

One thing to note that surprised me initially was that there are cases where we still want to load a configured private key even when `WithoutPrivateKey` is set: (1) to set the call message sender, which is needed even for calling `view` actions that have the `owner`  and (2) to infer owner in database call commands.

Also, note that all `call`s when using a gateway with `--authenticate` require the private key regardless of the action, and hence enforces the chain ID check.  I think this is alright (and it was the case prior to this PR).