### PR TITLE
fixed bug where client converts int to float

### DIFF
--- a/core/rpc/client/user/grpc/rpc.go
+++ b/core/rpc/client/user/grpc/rpc.go
@@ -163,13 +163,7 @@ func (c *Client) Call(ctx context.Context, req *transactions.CallMessage,
 		return nil, fmt.Errorf("failed to call: %w", err)
 	}
 
-	var result []map[string]any
-	err = json.Unmarshal(res.Result, &result)
-	if err != nil {
-		return nil, fmt.Errorf("failed to unmarshal result: %w", err)
-	}
-
-	return result, nil
+	return unmarshalMapResults(res.Result)
 }
 
 func (c *Client) GetConfig(ctx context.Context) (*SvcConfig, error) {
@@ -221,17 +215,7 @@ func (c *Client) Query(ctx context.Context, dbid string, query string) ([]map[st
 		return nil, fmt.Errorf("failed to query: %w", err)
 	}
 
-	d := json.NewDecoder(strings.NewReader(string(res.Result)))
-	d.UseNumber()
-
-	// unmashal result
-	var result []map[string]any
-	err = d.Decode(&result)
-	if err != nil {
-		return nil, err
-	}
-
-	return result, nil
+	return unmarshalMapResults(res.Result)
 }
 
 func (c *Client) GetSchema(ctx context.Context, dbid string) (*transactions.Schema, error) {
@@ -243,4 +227,18 @@ func (c *Client) GetSchema(ctx context.Context, dbid string) (*transactions.Sche
 	}
 
 	return conversion.ConvertFromPBSchema(res.Schema), nil
+}
+
+func unmarshalMapResults(b []byte) ([]map[string]any, error) {
+	d := json.NewDecoder(strings.NewReader(string(b)))
+	d.UseNumber()
+
+	// unmashal result
+	var result []map[string]any
+	err := d.Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }

--- a/core/rpc/client/user/http/client.go
+++ b/core/rpc/client/user/http/client.go
@@ -114,14 +114,7 @@ func (c *Client) Call(ctx context.Context, msg *transactions.CallMessage, opts .
 		return nil, err
 	}
 
-	// unmashal result
-	var resultSet []map[string]any
-	err = json.Unmarshal(decodedResult, &resultSet)
-	if err != nil {
-		return nil, err
-	}
-
-	return resultSet, nil
+	return unmarshalMapResults(decodedResult)
 }
 
 func (c *Client) ChainInfo(ctx context.Context) (*types.ChainInfo, error) {
@@ -257,17 +250,7 @@ func (c *Client) Query(ctx context.Context, dbid string, query string) ([]map[st
 		return nil, err
 	}
 
-	d := json.NewDecoder(strings.NewReader(string(decodedResult)))
-	d.UseNumber()
-
-	// unmashal result
-	var resultSet []map[string]any
-	err = d.Decode(&resultSet)
-	if err != nil {
-		return nil, err
-	}
-
-	return resultSet, nil
+	return unmarshalMapResults(decodedResult)
 }
 
 func parseBroadcastError(respTxt []byte) error {
@@ -375,4 +358,18 @@ func (c *Client) TxQuery(ctx context.Context, txHash []byte) (*transactions.TcTx
 		Tx:       *convertedTx,
 		TxResult: *convertedTxResult,
 	}, nil
+}
+
+func unmarshalMapResults(b []byte) ([]map[string]any, error) {
+	d := json.NewDecoder(strings.NewReader(string(b)))
+	d.UseNumber()
+
+	// unmashal result
+	var result []map[string]any
+	err := d.Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	return result, nil
 }


### PR DESCRIPTION
As per: https://github.com/truflation/truflation-stream/issues/17

There is an issue where large numbers, when json marshalled, get converted to floats when unmarshalled.  This implements a fix.