### PR TITLE
scripts: set KwilVersion from git describe as before

### DIFF
--- a/scripts/build/.go_variables
+++ b/scripts/build/.go_variables
@@ -58,6 +58,11 @@ if [ "$CGO_ENABLED" = "1" ] && [ "$GO_LINKMODE" = "static" ]; then
     # from the glibc version used for linking"
     GO_BUILDTAGS="$GO_BUILDTAGS osusergo netgo auth_nep413 auth_ed25519_sha256"
 fi
+# Set the KwilVersion to the `git describe` info that includes latest tag.
+# The specific git revision and commit time comes from debug.ReadBuildInfo
+# at runtime, but that does not include the tag.
+VERSION_PKG="github.com/kwilteam/kwil-db/internal/version"
+GO_LDFLAGS="$GO_LDFLAGS -X \"${VERSION_PKG}.KwilVersion=${GIT_VERSION}\""
 if [ -n "$GO_STRIP" ]; then
     GO_LDFLAGS="$GO_LDFLAGS -s -w"
 fi


### PR DESCRIPTION
This sets the KwilVersion from the git describe output when building the binaries with the scripts/build/binary script.

This will cause builds on the release branch that use this script to report "v0.6.4". However, it will set nonsense like "v0.6.1-24-g78b2acae-dirty" when building from main despite the default KwilVersion being set to v0.7.0-pre in internal/version/version.go.

Note that on the release branch, we would not need this script change if internal/version.KwilVersion were set by default in version.go to const kwilVersion = "0.6.4".