### PR TITLE
feat: uuid extension

### DIFF
--- a/extensions/actions/uuid.go
+++ b/extensions/actions/uuid.go
@@ -64,7 +64,7 @@ func (u *uuidExtension) Call(scope *execution.ProcedureContext, method string, a
 	// convert the method to lowercase
 	lowerMethod := strings.ToLower(method)
 
-	// there will be two methods on the extension:
+	// there will be one method on the extension:
 	// - uuidv5: generates a uuidv5 from a byte slice and returns as a string
 	switch lowerMethod {
 	default:


### PR DESCRIPTION
This pull request adds a `uuid` extension, allowing for calling `uuidv5` method in kuneiform to auto-generate uuids.

## Sample usage
1. Build the kwild binary with the uuid extension and start the daemon.

```bash
GO_BUILDTAGS=actions_uuid task build:kwild
```

2. Call the extension in Kuneiform

```
database id_test;

use uuid as id;

table users {
    id text primary,
    username text notnull,
    wallet text notnull
}

action uuid_from_wallet ($username) public {
    $uuid = id.uuidv5(@caller);

    INSERT INTO users
    VALUES (
        $uuid,
        $username,
        @caller
    );
}
```

Let me know if you have any feedback!