### PR TITLE
ci: disable go cache for self-hosted runner

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -41,6 +41,7 @@ jobs:
         with:
           go-version: '1.21.x'
           check-latest: true
+          cache: false
 
       - name: Install dependencies
         env:


### PR DESCRIPTION
Apparently self-hosted runners don't require the go caching, and for some reason it can take 20 minutes.

I saw this:

![image](https://github.com/kwilteam/kwil-db/assets/140431406/e91159c8-7c96-4a66-8d90-c9f220c067f9)

I can't explain why that should take so long on bare metal, especially the fast machine we have, but it did.  Probably there is a way to tweak the compression program so it uses faster settings or perhaps an uncompressed tar, but according to discussion at https://github.com/actions/setup-go/issues/431 and https://github.com/actions/setup-go/issues/403 that there is no point to using the action's cache on a self-hosted runner.

Thus, this PR sets `cache: false` for actions/setup-go@v4



