### PR TITLE
test: stress with gateway client support

### DIFF
--- a/test/stress/db.go
+++ b/test/stress/db.go
@@ -11,7 +11,6 @@ import (
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 	"github.com/kwilteam/kwil-db/core/utils"
 	"github.com/kwilteam/kwil-db/core/utils/random"
-
 	"go.uber.org/zap"
 )
 
@@ -74,7 +73,7 @@ func (h *harness) deployDBAsync(ctx context.Context) (string, <-chan asyncResp, 
 		return "", nil, err
 	}
 
-	dbid := utils.GenerateDBID(schema.Name, h.Signer.Identity())
+	dbid := utils.GenerateDBID(schema.Name, h.signer.Identity())
 	// fmt.Println("deployDBAsync", dbid)
 	promise := make(chan asyncResp, 1)
 	go func() {

--- a/test/stress/harness.go
+++ b/test/stress/harness.go
@@ -7,7 +7,9 @@ import (
 	"math/big"
 	"sync"
 
+	"github.com/kwilteam/kwil-db/cmd/kwil-cli/cmds/common"
 	"github.com/kwilteam/kwil-db/core/client"
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
@@ -18,9 +20,11 @@ import (
 // used nonces so it can correctly make multiple unconfirmed transactions with
 // increasing nonces. See underNonceLock and recoverNonce.
 type harness struct {
-	*client.Client
+	common.Client
 	logger *log.Logger
 	acctID []byte
+
+	signer auth.Signer
 
 	nonceMtx sync.Mutex
 	nonce    int64 // atomic.Int64

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -17,8 +17,11 @@ import (
 )
 
 var (
-	host string
-	key  string
+	host            string
+	gatewayProvider bool
+	key             string
+
+	chainId string
 
 	runTime time.Duration
 
@@ -44,8 +47,12 @@ var (
 )
 
 func main() {
-	flag.StringVar(&host, "host", "http://127.0.0.1:8080", "gRPC will be used if host is without schema")
+	flag.StringVar(&host, "host", "http://127.0.0.1:8080", "provider's http url, schema is required")
+	flag.BoolVar(&gatewayProvider, "gw", false, "gateway provider instead of vanilla provider, "+
+		"need to make sure host is same as gateway's domain")
 	flag.StringVar(&key, "key", "", "existing key to use instead of generating a new one")
+
+	flag.StringVar(&chainId, "chain", "kwil-test-chain", "chain ID")
 
 	flag.DurationVar(&runTime, "run", 30*time.Minute, "terminate after running this long")
 

--- a/test/stress/scheme.go
+++ b/test/stress/scheme.go
@@ -16,11 +16,12 @@ var testScheme string
 
 // These are the actions currently used by the harness.
 const (
-	actGetPost      = "get_post_unauthenticated"
+	actGetPost      = "get_post"
 	actCreatePost   = "create_post"
 	actCreateUser   = "create_user"
 	actListUsers    = "list_users"
 	actGetUserPosts = "get_user_posts_by_userid"
+	actAuthnOnly    = "authn_only" // matters with KGW
 )
 
 func loadTestSchema() (*transactions.Schema, error) {
@@ -54,7 +55,7 @@ func init() {
 		haveActions[act.Name] = true
 	}
 	for _, expected := range []string{actGetPost, actCreatePost, actCreateUser,
-		actListUsers, actGetUserPosts} {
+		actListUsers, actGetUserPosts, actAuthnOnly} {
 		if !haveActions[expected] {
 			panic(fmt.Sprintf("missing action %v", expected))
 		}

--- a/test/stress/scheme.kf
+++ b/test/stress/scheme.kf
@@ -102,3 +102,8 @@ action multi_select() public {
 action owner_only() public owner view {
     select 'owner only';
 }
+
+@kgw(authn='true')
+action authn_only() public view {
+    select 'authn only';
+}


### PR DESCRIPTION
In order to stress test KGW apis, the stress tool needs to support test kgw provider. This pr does this.

## changes
- new flag  `gw` to indicate a kgw provider
- remove support for gRPC provider
- create default Client or GatewayClient according to `gw` flag

To test KGW, you can:
```
# start a local network
task dev:testnet:up:nb

# run kgw
KGW_DEV=true ./kgw  --ip-request-rate 0 -d http://localhost:8090 --cors-allow-origins *  -b 127.0.0.1:8080 127.0.0.1:8081 127.0.0.1:8082 127.0.0.1:8083  --allow-deploy-db --schema-sync-interval 3

# run stress test
./stress -host http://localhost:8090 -gw  -vi 2s
```
