### PR TITLE
updated protobuf download link

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Learn more about Kwil at [kwil.com](https://kwil.com).
 To build Kwil, you will need to install:
 
 1. [Go](https://golang.org/doc/install)
-2. [Protocol Buffers](https://protobuf.dev/downloads/), with the `protoc` executable binary on your `PATH`.
+2. [Protocol Buffers](https://protobuf.dev/downloads/) (optional), with the `protoc` executable binary on your `PATH`.
 3. [Taskfile](https://taskfile.dev/installation)
 4. Protocol buffers go plugins and other command line tools. The `tool` task will install the required versions of the tools into your `GOPATH`, so be sure to include `GOPATH/bin` on your `PATH`.
 


### PR DESCRIPTION
Updated the protobuf download link. The old one pointed to a golang protobuf tutorial, but unless someone is altering protobuf they don't need to know that.

I'm also not sure if people actually need to install protobuf anyways, since we now include the generated files in the repo?