### PR TITLE
fix/cli-configs

### DIFF
--- a/cmd/kwil-cli/config/config.go
+++ b/cmd/kwil-cli/config/config.go
@@ -52,9 +52,9 @@ func DefaultKwilCliPersistedConfig() *kwilCliPersistedConfig {
 // and also to work with viper(flags)
 type kwilCliPersistedConfig struct {
 	// NOTE: `mapstructure` is used by viper, name is same as the viper key name
-	PrivateKey string `mapstructure:"private_key" json:"private_key"`
-	GrpcURL    string `mapstructure:"grpc_url" json:"grpc_url"`
-	ChainID    string `mapstructure:"chain_id" json:"chain_id"`
+	PrivateKey string `mapstructure:"private_key" json:"private_key,omitempty"`
+	GrpcURL    string `mapstructure:"grpc_url" json:"grpc_url,omitempty"`
+	ChainID    string `mapstructure:"chain_id" json:"chain_id,omitempty"`
 }
 
 func (c *kwilCliPersistedConfig) toKwilCliConfig() (*KwilCliConfig, error) {


### PR DESCRIPTION
When configuring the CLI and skipping values, they were persisted and read back as empty strings, and would then override the defaults. This fixes that issue.