### PR TITLE
scripts,build: add GO_RACEFLAG var to build with -race

### DIFF
--- a/build/package/docker/kwild.dockerfile
+++ b/build/package/docker/kwild.dockerfile
@@ -4,19 +4,21 @@ ARG version
 ARG build_time
 ARG git_commit
 ARG go_build_tags
+ARG go_race
 
 WORKDIR /app
 RUN mkdir -p /var/run/kwil
 RUN chmod 777 /var/run/kwil
 RUN apk update && apk add git ca-certificates-bundle
+RUN if [ -n "$go_race" ]; then apk add --no-cache gcc g++; fi
 
 COPY . .
 RUN test -f go.work && rm go.work || true
 
-RUN GOWORK=off GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" GO_BUILDTAGS=$go_build_tags ./scripts/build/binary kwild
+RUN GOWORK=off GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" GO_BUILDTAGS=$go_build_tags GO_RACEFLAG=$go_race ./scripts/build/binary kwild
 
-RUN GOWORK=off GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" ./scripts/build/binary kwil-admin
-RUN GOWORK=off GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" ./scripts/build/binary kwil-cli
+RUN GOWORK=off GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" GO_RACEFLAG=$go_race ./scripts/build/binary kwil-admin
+RUN GOWORK=off GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" GO_RACEFLAG=$go_race ./scripts/build/binary kwil-cli
 RUN chmod +x /app/dist/kwild /app/dist/kwil-admin /app/dist/kwil-cli
 
 FROM alpine:3.17

--- a/scripts/build/.go_variables
+++ b/scripts/build/.go_variables
@@ -5,7 +5,7 @@ set -eu
 
 : "${CGO_ENABLED=}"
 : "${GO_LINKMODE=static}"
-: "${GO_BUILDMODE=}"
+: "${GO_RACEFLAG=}"
 : "${GO_BUILDTAGS=}"
 : "${GO_STRIP=}"
 : "${GO_GCFLAGS=}"
@@ -21,6 +21,11 @@ BINARY=${1:-}
 TARGET=${TARGET:-".build"}
 TARGET="$TARGET/${BINARY}"
 export TARGET
+
+if [ -n "$GO_RACEFLAG" ]; then
+    echo "Building with race detector enabled. Enabling CGO."
+    CGO_ENABLED=1
+fi
 
 if [ -z "$CGO_ENABLED" ]; then
     case "$(go env GOOS)" in

--- a/scripts/build/binary
+++ b/scripts/build/binary
@@ -10,4 +10,4 @@ set -eu
 
 echo "Building $GO_LINKMODE $(basename "${TARGET}")"
 
-(set -x ; go build -o "${TARGET}" -tags "${GO_BUILDTAGS}" -ldflags "${GO_LDFLAGS}" -gcflags "${GO_GCFLAGS}" ${GO_BUILDMODE} "${SOURCE}")
+(set -x ; go build -o "${TARGET}" -tags "${GO_BUILDTAGS}" -ldflags "${GO_LDFLAGS}" -gcflags "${GO_GCFLAGS}" ${GO_RACEFLAG} "${SOURCE}")

--- a/scripts/build/docker
+++ b/scripts/build/docker
@@ -13,6 +13,12 @@ DOCKER_FILE="${IMAGE}.dockerfile"
 
 test -z "${EXTRA}" || DOCKER_FILE="${IMAGE}.${EXTRA}.dockerfile"
 
+# We could change the image name if the race detector is enabled. For now this
+# is commented out so that tests using kwild:latest can use these builds.
+# if [ -n "$GO_RACEFLAG" ]; then
+#   IMAGE="${IMAGE}.race"
+# fi
+
 echo Building "${IMAGE}"
 
 BUILD_ARGS="${BUILD_ARGS:-}"
@@ -20,6 +26,7 @@ BUILD_ARGS="${BUILD_ARGS} --build-arg version=${GIT_VERSION}"
 BUILD_ARGS="${BUILD_ARGS} --build-arg git_commit=${GIT_COMMIT}"
 BUILD_ARGS="${BUILD_ARGS} --build-arg build_time=${BUILD_TIME}"
 BUILD_ARGS="${BUILD_ARGS} --build-arg go_build_tags=${GO_BUILDTAGS:-}"
+BUILD_ARGS="${BUILD_ARGS} --build-arg go_race=${GO_RACEFLAG:-}"
 
 export DOCKER_BUILDKIT=1
 


### PR DESCRIPTION
This updates the build scripts and docker file to recognize a `GO_RACEFLAG` env variable to build with `-race`.

`GO_RACEFLAG="-race" task build` or `GO_RACEFLAG="-race" task build:docker`

Instead of making a different docker file or creating a different tag or image name such as `kwild.race`, I've left it to generate `kwild:latest` so that we can use it with the acceptance and integration tests as-is.  I'm open to this changing though.  It was just simplest.