### PR TITLE
core/rpc/client/user/http: read and interpret error messages

### DIFF
--- a/core/rpc/client/user/http/error.go
+++ b/core/rpc/client/user/http/error.go
@@ -1,0 +1,112 @@
+package http
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/kwilteam/kwil-db/core/rpc/client"
+	httpTx "github.com/kwilteam/kwil-db/core/rpc/http/tx"
+	txpb "github.com/kwilteam/kwil-db/core/rpc/protobuf/tx/v1"
+	"github.com/kwilteam/kwil-db/core/types/transactions"
+
+	"google.golang.org/genproto/googleapis/rpc/status"
+	"google.golang.org/grpc/codes"
+	grpcStatus "google.golang.org/grpc/status"
+	"google.golang.org/protobuf/encoding/protojson"
+)
+
+func parseErrorResponse(respTxt []byte) error {
+	// NOTE: here directly use status.Status from googleapis/rpc/status
+	var res status.Status
+	err := json.Unmarshal(respTxt, &res)
+	if err != nil {
+		return err
+	}
+
+	rpcErr := &client.RPCError{
+		Msg:  res.GetMessage(),
+		Code: res.GetCode(),
+	}
+
+	switch res.Code {
+	case int32(codes.NotFound):
+		return errors.Join(client.ErrNotFound, rpcErr)
+	case int32(codes.PermissionDenied), int32(codes.Unauthenticated): // these have different meaning, but are handled via auth
+		return errors.Join(client.ErrUnauthorized, rpcErr)
+	default:
+	}
+
+	return rpcErr
+}
+
+func wrapResponseError(err error, res *http.Response) error {
+	if res != nil {
+		// Wrap certain errors in our own types.
+		switch res.StatusCode {
+		case http.StatusUnauthorized:
+			err = errors.Join(err, client.ErrUnauthorized)
+		case http.StatusNotFound:
+			err = errors.Join(err, client.ErrNotFound)
+		}
+		// Continue to attempt decoding swagger error's response body.
+	}
+
+	if swaggerErr, ok := err.(httpTx.GenericSwaggerError); ok {
+		body := swaggerErr.Body()
+		if body != nil {
+			err = errors.Join(err, parseErrorResponse(body))
+		}
+	}
+
+	return err
+}
+
+// parseBroadcastError parses the response body from a broadcast error.
+// It returns true if the error was parsed successfully, false otherwise.
+func parseBroadcastError(respTxt []byte) (bool, error) {
+	var protoStatus status.Status
+	err := protojson.Unmarshal(respTxt, &protoStatus) // jsonpb is deprecated, otherwise we could use the resp.Body directly
+	if err != nil {
+		if err = json.Unmarshal(respTxt, &protoStatus); err != nil {
+			return false, err
+		}
+	}
+	stat := grpcStatus.FromProto(&protoStatus)
+	code, message := stat.Code(), stat.Message()
+	rpcErr := &client.RPCError{
+		Msg:  message,
+		Code: int32(code),
+	}
+	err = rpcErr
+
+	for _, detail := range stat.Details() {
+		if bcastErr, ok := detail.(*txpb.BroadcastErrorDetails); ok {
+			txCode := transactions.TxCode(bcastErr.Code)
+			switch txCode {
+			case transactions.CodeWrongChain:
+				err = errors.Join(err, transactions.ErrWrongChain)
+			case transactions.CodeInvalidNonce:
+				err = errors.Join(err, transactions.ErrInvalidNonce)
+			case transactions.CodeInvalidAmount:
+				err = errors.Join(err, transactions.ErrInvalidAmount)
+			case transactions.CodeInsufficientBalance:
+				err = errors.Join(err, transactions.ErrInsufficientBalance)
+			}
+
+			// Reset the generic code and message in the RPCError with the
+			// broadcast-specific details. NOTE: this will overwrite if there
+			// are more than one details object, which is not expected.
+			rpcErr.Code = int32(txCode)
+			rpcErr.Msg = bcastErr.Message
+			if bcastErr.Hash != "" { // if there is a tx hash, include it (possibly just executed it)
+				rpcErr.Msg += "\nTxHash: " + bcastErr.Hash
+			}
+		} else { // else unknown details type
+			err = errors.Join(err, fmt.Errorf("unrecognized status error detail type %T", detail))
+		}
+	}
+
+	return true, err
+}

--- a/internal/services/grpc/txsvc/v1/query.go
+++ b/internal/services/grpc/txsvc/v1/query.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 
 	txpb "github.com/kwilteam/kwil-db/core/rpc/protobuf/tx/v1"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
 )
 
 func (s *Service) Query(ctx context.Context, req *txpb.QueryRequest) (*txpb.QueryResponse, error) {
@@ -16,12 +19,14 @@ func (s *Service) Query(ctx context.Context, req *txpb.QueryRequest) (*txpb.Quer
 
 	result, err := s.engine.Query(ctx, tx, req.Dbid, req.Query)
 	if err != nil {
-		return nil, err
+		// We don't know for sure that it's an invalid argument, but an invalid
+		// user-provided query isn't an internal server error.
+		return nil, status.Error(codes.InvalidArgument, err.Error())
 	}
 
 	bts, err := json.Marshal(result.Map()) // marshalling the map is less efficient, but necessary for backwards compatibility
 	if err != nil {
-		return nil, err
+		return nil, status.Errorf(codes.Internal, "failed to marshal call result")
 	}
 
 	return &txpb.QueryResponse{


### PR DESCRIPTION
The request error handling in `core/rpc/client/user/http` was throwing out most error messages sent by the remote service.

This adds uniform error parsing to each of the http client methods.

On the server side, this updates `(*Service).Query` so it doesn't result in "unknown" status codes resulting in http responses with 500 status codes.

---

*before*

```
$ ./kwil-cli database query -n testdb "SELECT * FROM users WHERE age > \"a\""
error querying database: 500 Internal Server Error

```

*after*

```
$ ./kwil-cli database query -n testdb "SELECT * FROM users WHERE age > \"a\""
error querying database: 400 Bad Request
err code = 3, msg = ERROR: column "a" does not exist (SQLSTATE 42703)
```

---

*before*

```
$ ./kwil-cli database call -a get_post -n testdb 'id:a'
error calling action: call action: 400 Bad Request
```

*after*

```
$ ./kwil-cli database call -a get_post -n testdb 'id:a'
error calling action: call action: 400 Bad Request
err code = 3, msg = failed to execute view action: ERROR: invalid input syntax for type bigint: "a" (SQLSTATE 22P02)
```

---

also the missing dbid:

```
$ ./kwil-cli database query -n testdb2 "SELECT * FROM users WHERE age > 25"
error querying database: 400 Bad Request
err code = 3, msg = dataset not found
```

---

Could use some more testing, but it's getting late in the day so wanted to propose this change.