### PR TITLE
test: retain data in failed integ/acct tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -84,7 +84,7 @@ jobs:
           go build -mod=readonly ./... ./parse/... ./core/... ./test/specifications/
 
       - name: Lint
-        uses: golangci/golangci-lint-action@3cfe3a4abbb849e10058ce4af15d205b6da42804
+        uses: golangci/golangci-lint-action@v4.0.0
         with:
           install-mode: "binary"
           version: "latest"
@@ -170,6 +170,7 @@ jobs:
             git_commit=${{ github.sha }}
             version=${{ env.GIT_TAG }}
             build_time=${{ env.BUILD_TIME }}
+          #  go_race=-race
           file: ./build/package/docker/kwild.dockerfile
           push: false
           tags: kwild:latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -157,7 +157,7 @@ tasks:
     cmds:
       - task: dev:up:nb
 
-  dev:up:nb: # run `task dev:up:nb -- -messy` if you don't want cleanup
+  dev:up:nb:
     desc: Start the dev environment without rebuilding docker image
     env:
       # NOTE: this timeout should be long enough to attach to debugger
@@ -196,7 +196,6 @@ tasks:
   # e.g.
   # - task test:act:nb -- -remote
   # - task test:act:nb -- -drivers grpc
-  # - task test:act:nb -- -messy
   # - task test:act:nb -- -parallel-mode
   test:act:nb:
     desc: Run acceptance tests without building docker image

--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -267,6 +267,7 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 			return fmt.Errorf("failed to merge config file %s: %w", genCfg.ConfigFile, err)
 		}
 	}
+	cfg.Logging.OutputPaths = append(cfg.Logging.OutputPaths, "kwild.log")
 
 	privateKeys := make([]cmtEd.PrivKey, nNodes)
 	for i := range privateKeys {

--- a/deployments/compose/kwil/single/docker-compose.yml
+++ b/deployments/compose/kwil/single/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
-    volumes: 
+    volumes:
       - pgkwil:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -75,4 +75,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.5.100.0/16
+        - subnet: 172.5.100.0/23

--- a/test/acceptance/docker-compose-dev.yml
+++ b/test/acceptance/docker-compose-dev.yml
@@ -14,6 +14,8 @@ services:
       - "40000:40000" # debugger, if build with debug dockerfile
     #env_file:
       # NOTE: docker compose by default will use `.env` file if presented
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnode}

--- a/test/acceptance/docker-compose.yml
+++ b/test/acceptance/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - "40000" # debugger, if build with debug dockerfile
     #env_file:
       # NOTE: docker compose by default will use `.env` file if presented
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnode}

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -15,7 +15,6 @@ import (
 
 var dev = flag.Bool("dev", false, "run for development purpose (no tests)")
 var remote = flag.Bool("remote", false, "test against remote node")
-var noCleanup = flag.Bool("messy", false, "do not cleanup test directories or stop the docker compose when done")
 
 // NOTE: `-parallel` is a flag that is already used by `go test`
 var parallelMode = flag.Bool("parallel-mode", false, "run tests in parallelMode mode")
@@ -33,10 +32,6 @@ func TestLocalDevSetup(t *testing.T) {
 	cfg := helper.LoadConfig()
 	cfg.DockerComposeFile = "./docker-compose-dev.yml" // use the dev compose file
 	cfg.GasEnabled = true
-
-	if *noCleanup {
-		cfg.NoCleanup = true
-	}
 
 	helper.Setup(ctx)
 	helper.WaitUntilInterrupt()
@@ -60,9 +55,6 @@ func TestKwildTransferAcceptance(t *testing.T) {
 			helper := acceptance.NewActHelper(t)
 			cfg := helper.LoadConfig()
 			cfg.GasEnabled = true
-			if *noCleanup {
-				cfg.NoCleanup = true
-			}
 			if !*remote {
 				helper.Setup(ctx)
 			}

--- a/test/go.mod
+++ b/test/go.mod
@@ -22,7 +22,6 @@ require (
 	github.com/testcontainers/testcontainers-go v0.27.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.27.0
 	go.uber.org/zap v1.26.0
-	google.golang.org/grpc v1.60.0
 )
 
 require (
@@ -242,6 +241,7 @@ require (
 	google.golang.org/genproto v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20231106174013-bbf56f31fb17 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20231120223509-83a465c0220f // indirect
+	google.golang.org/grpc v1.60.0 // indirect
 	google.golang.org/protobuf v1.31.0 // indirect
 	gopkg.in/inf.v0 v0.9.1 // indirect
 	gopkg.in/ini.v1 v1.67.0 // indirect

--- a/test/integration/docker-compose.yml.template
+++ b/test/integration/docker-compose.yml.template
@@ -11,6 +11,8 @@ services:
       - "26657"
     #env_file:
       # NOTE: docker compose by default will use `.env` file if presented
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnet}/node0
@@ -68,6 +70,8 @@ services:
       - "50051"
       - "26656"
       - "26657"
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnet}/node1
@@ -125,6 +129,8 @@ services:
       - "50051"
       - "26656"
       - "26657"
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnet}/node2
@@ -185,6 +191,8 @@ services:
       - "50051"
       - "26656"
       - "26657"
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnet}/node3
@@ -242,6 +250,8 @@ services:
       - "50051"
       - "26656"
       - "26657"
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnet}/node4
@@ -299,6 +309,8 @@ services:
       - "50051"
       - "26656"
       - "26657"
+    environment:
+      GORACE: "halt_on_error=1 log_path=/app/kwil/datarace"
     volumes:
       - type: bind
         source: ${KWIL_HOME:-./.testnet}/node5

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -433,7 +433,18 @@ func (r *IntHelper) RunDockerComposeWithServices(ctx context.Context, services [
 // 4. Generate node configuration files
 // 5. Run docker-compose with the given services
 func (r *IntHelper) Setup(ctx context.Context, services []string) {
-	tmpDir := r.t.TempDir()
+	tmpDir, err := os.MkdirTemp("", "TestKwilInt")
+	if err != nil {
+		r.t.Fatal(err)
+	}
+	r.t.Cleanup(func() {
+		if r.t.Failed() {
+			r.t.Logf("Retaining data for failed test at path %v", tmpDir)
+			return
+		}
+		os.RemoveAll(tmpDir)
+	})
+
 	r.t.Logf("create test directory: %s", tmpDir)
 
 	r.prepareDockerCompose(ctx, tmpDir)

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -78,6 +78,8 @@ func TestKwildDatabaseIntegration(t *testing.T) {
 
 			// Create a new database and verify that the database exists on other nodes
 			specifications.DatabaseDeploySpecification(ctx, t, node0Driver)
+			// TODO: wait for node 1 and 2 to hit whatever height 0 is at
+			time.Sleep(2 * time.Second)
 			specifications.DatabaseVerifySpecification(ctx, t, node1Driver, true)
 			specifications.DatabaseVerifySpecification(ctx, t, node2Driver, true)
 
@@ -143,7 +145,7 @@ func TestKwildValidatorUpdatesIntegration(t *testing.T) {
 
 	ctx := context.Background()
 
-	const expiryBlocks = 10
+	const expiryBlocks = 20
 	const blockInterval = time.Second
 	const numVals, numNonVals = 3, 1
 	opts := []integration.HelperOpt{
@@ -154,7 +156,7 @@ func TestKwildValidatorUpdatesIntegration(t *testing.T) {
 		integration.WithGas(), // must give the joining node some gas too
 	}
 
-	expiryWait := 2 * expiryBlocks * blockInterval
+	const expiryWait = 3 * expiryBlocks * blockInterval / 2
 
 	testDrivers := strings.Split(*drivers, ",")
 	for _, driverType := range testDrivers {
@@ -190,6 +192,7 @@ func TestKwildValidatorUpdatesIntegration(t *testing.T) {
 			 - Consensus reached, Node3 is a Validator
 			*/
 			specifications.ValidatorNodeJoinSpecification(ctx, t, joinerDriver, joinerPubKey, 3)
+			time.Sleep(2 * time.Second)
 			// Node 0,1 approves
 			specifications.ValidatorNodeApproveSpecification(ctx, t, node0Driver, joinerPubKey, 3, 3, false)
 			specifications.ValidatorNodeApproveSpecification(ctx, t, node1Driver, joinerPubKey, 3, 4, true)
@@ -206,6 +209,7 @@ func TestKwildValidatorUpdatesIntegration(t *testing.T) {
 			 Rejoin: (same as join process)
 			*/
 			specifications.ValidatorNodeJoinSpecification(ctx, t, joinerDriver, joinerPubKey, 3)
+			time.Sleep(2 * time.Second)
 			// Node 0, 1 approves
 			specifications.ValidatorNodeApproveSpecification(ctx, t, node0Driver, joinerPubKey, 3, 3, false)
 			specifications.ValidatorNodeApproveSpecification(ctx, t, node1Driver, joinerPubKey, 3, 4, true)


### PR DESCRIPTION
Description in commit message:

```
test: retain data in failed integ/acct tests

This will skip removal of the temporary folder for root_dir if
the test fails.  The containers are still stopped and removed.

This also sets the race detector options to kill kwild when a race
is detected, and to write races to a file in the retained root_dir
instead of stderr, which would be inaccessible after the containers
are stopped and removed.

Finally, this logs to kwild.log for integration tests too. It was
already doing this for acceptance tests.
```

e.g. if I force a data race:

```
$  GO_RACEFLAG="-race" task build:docker
...

$  go test -v -run TestLocalDevSetup -dev
=== RUN   TestLocalDevSetup
    helper.go:178: generate node config
    helper.go:193: created test temp directory: /tmp/TestKwilAct4240829860
Generated new private key: /tmp/TestKwilAct4240829860/private_key
    helper.go:224: setup test environment
    helper.go:231: use compose files: [./docker-compose-dev.yml]
2024/02/16 10:41:34 github.com/testcontainers/testcontainers-go - Connected to docker: 
  Server Version: 25.0.2
  API Version: 1.43
  Operating System: Docker Desktop
  Total Memory: 7732 MB
  Resolved Docker Host: unix:///home/jon/.docker/desktop/docker.sock
  Resolved Docker Socket Path: /var/run/docker.sock
  Test SessionID: b4444eb887dbedf01378ad74145209327a2ef21eb5cbd10b65fff681220a52c1
  Test ProcessID: 648fea08-2481-4de2-9b23-e761b342dff2
[+] Running 5/5
 ✔ Network f50889d6-e7f4-4637-861b-acd74b1aea22_kwil-act-testnet  Created                                                                                                                        0.1s 
 ✔ Network f50889d6-e7f4-4637-861b-acd74b1aea22_default           Created                                                                                                                        0.1s 
 ✔ Container f50889d6-e7f4-4637-861b-acd74b1aea22-pg-1            Healthy                                                                                                                        0.1s 
 ✔ Container f50889d6-e7f4-4637-861b-acd74b1aea22-ext-1           Started                                                                                                                        0.1s 
 ✔ Container f50889d6-e7f4-4637-861b-acd74b1aea22-kwild-1         Started                                                                                                                        0.1s 
    helper.go:258: docker compose up
    helper.go:260: 
        	Error Trace:	/home/jon/kwil/git/kwil-db/test/acceptance/helper.go:260
        	            				/home/jon/kwil/git/kwil-db/test/acceptance/helper.go:271
        	            				/home/jon/kwil/git/kwil-db/test/acceptance/kwild_test.go:41
        	Error:      	Received unexpected error:
        	            	container exited with code 66
        	Test:       	TestLocalDevSetup
        	Messages:   	failed to start kwild node
    helper.go:237: teardown docker compose
[+] Running 5/5
 ✔ Container f50889d6-e7f4-4637-861b-acd74b1aea22-kwild-1         Removed                                                                                                                        0.0s 
 ✔ Container f50889d6-e7f4-4637-861b-acd74b1aea22-ext-1           Removed                                                                                                                        0.2s 
 ✔ Container f50889d6-e7f4-4637-861b-acd74b1aea22-pg-1            Removed                                                                                                                        0.3s 
 ✔ Network f50889d6-e7f4-4637-861b-acd74b1aea22_default           Removed                                                                                                                        0.2s 
 ✔ Network f50889d6-e7f4-4637-861b-acd74b1aea22_kwil-act-testnet  Removed                                                                                                                        0.1s 
    helper.go:186: Retaining data for failed test at path /tmp/TestKwilAct4240829860
--- FAIL: TestLocalDevSetup (5.58s)
FAIL
exit status 1
FAIL	github.com/kwilteam/kwil-db/test/acceptance	5.715s

$  ll /tmp/TestKwilAct4240829860
total 108
drwx------  4 jon  jon   4096 Feb 16 10:41 ./
drwxrwxrwt 58 root root 20480 Feb 16 10:42 ../
drwxr-xr-x  4 jon  jon   4096 Feb 16 10:41 abci/
-rwxr-xr-x  1 jon  jon   7735 Feb 16 10:41 config.toml*
-rw-r-----  1 jon  jon  40309 Feb 16 10:41 datarace.1
-rw-r--r--  1 jon  jon    966 Feb 16 10:41 genesis.json
-rw-r--r--  1 jon  jon  10049 Feb 16 10:41 kwild.log
-rw-------  1 jon  jon    128 Feb 16 10:41 private_key
-rw-r--r--  1 jon  jon    692 Feb 16 10:41 rpc.cert
-rw-------  1 jon  jon    119 Feb 16 10:41 rpc.key
drwx------  2 jon  jon   4096 Feb 16 10:41 signing/

$  head /tmp/TestKwilAct4240829860/datarace.1 
==================
WARNING: DATA RACE
Write at 0x00c0006d0468 by goroutine 364:
  github.com/kwilteam/kwil-db/cmd/kwild/server.(*Server).Start.func9()
      /app/cmd/kwild/server/server.go:199 +0x5a
  golang.org/x/sync/errgroup.(*Group).Go.func1()
      /app/vendor/golang.org/x/sync/errgroup/errgroup.go:75 +0x91

Previous write at 0x00c0006d0468 by main goroutine:
  github.com/kwilteam/kwil-db/cmd/kwild/server.(*Server).Start()


```

What this means:

- The exit code *66* indicates a data race.
- The kwild `root_dir` is still in /tmp/TestKwilAct4240829860
- The datarace._pid_ file contains the race report.
- kwild.log is available to see what lead up to it


