### PR TITLE
ci: try race build again for docker image

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -170,7 +170,7 @@ jobs:
             git_commit=${{ github.sha }}
             version=${{ env.GIT_TAG }}
             build_time=${{ env.BUILD_TIME }}
-          #  go_race=-race
+            go_race=-race
           file: ./build/package/docker/kwild.dockerfile
           push: false
           tags: kwild:latest


### PR DESCRIPTION
Just a follow-up on https://github.com/kwilteam/kwil-db/pull/512, I want to see if we can run with a `-race` build in acceptance and integ tests.