### PR TITLE
kwil-admin: fix key info by hex

### DIFF
--- a/cmd/kwil-admin/cmds/key/gen.go
+++ b/cmd/kwil-admin/cmds/key/gen.go
@@ -4,8 +4,9 @@ import (
 	"encoding/hex"
 	"os"
 
-	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/kwilteam/kwil-db/cmd/common/display"
+
+	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/spf13/cobra"
 )
 

--- a/cmd/kwil-admin/cmds/key/info.go
+++ b/cmd/kwil-admin/cmds/key/info.go
@@ -8,6 +8,7 @@ import (
 	"os"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
+
 	"github.com/spf13/cobra"
 )
 
@@ -36,17 +37,21 @@ func infoCmd() *cobra.Command {
 			// if len(args) == 1, then the private key is passed as a hex string
 			// otherwise, it is passed as a file path
 			if len(args) == 1 {
-				return display.PrintCmd(cmd, privKeyInfo([]byte(args[0])))
+				key, err := hex.DecodeString(args[0])
+				if err != nil {
+					return display.PrintErr(cmd, fmt.Errorf("private key not valid hex: %w", err))
+				}
+				return display.PrintCmd(cmd, privKeyInfo(key))
 			} else if privkeyFile != "" {
 				key, err := readKeyFile(privkeyFile)
 				if err != nil {
 					return display.PrintErr(cmd, err)
 				}
-
 				return display.PrintCmd(cmd, privKeyInfo(key))
-			} else {
-				return display.PrintErr(cmd, errors.New("must provide with the private key file or hex string"))
 			}
+
+			cmd.Usage()
+			return errors.New("must provide with the private key file or hex string")
 		},
 	}
 

--- a/cmd/kwil-admin/cmds/validators/list.go
+++ b/cmd/kwil-admin/cmds/validators/list.go
@@ -9,6 +9,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/internal/validators"
+
 	"github.com/spf13/cobra"
 )
 
@@ -16,12 +17,13 @@ var (
 	listLong = `List the current validator set of the network.`
 
 	listExample = `# List the current validator set of the network
-kwild validators list-validators`
+kwild validators list`
 )
 
 func listCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "list-validators",
+		Use:     "list-validators", // validators list-validators
+		Aliases: []string{"list"},  // validators list
 		Short:   "List the current validator set of the network.",
 		Long:    listLong,
 		Example: listExample,

--- a/test/driver/operator/cli_driver.go
+++ b/test/driver/operator/cli_driver.go
@@ -126,7 +126,7 @@ func (o *OperatorCLIDriver) ValidatorNodeRemove(ctx context.Context, target []by
 
 func (o *OperatorCLIDriver) ValidatorsList(ctx context.Context) ([]*types.Validator, error) {
 	var res []*types.Validator
-	err := o.runCommand(ctx, &res, "validators", "list-validators")
+	err := o.runCommand(ctx, &res, "validators", "list")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
The `key info` command was interpreting a hex private key provided as an argument without decoding it from hex.

demo with keys cropped:


*before* (incorrect)

```
./kwil-admin key info f7f8de5ab4efb9fdaa5ff6e66bc20993976560e4a4281356a58c0b59051657ae927c5030360c7078cb759dfe57aa61a
Private key (hex): 6637663864653561623465666239666461613566663665363662633230393933393736353630653461343238313335366135386330623539303531363537616539323763353033303336306337303738636237353964666535376161363161666165323635366230313664
Private key (base64): ZjdmOGRlNWFiNGVmYjlmZGFhNWZmNmU2NmJjMjA5OTM5NzY1NjBlNGE0MjgxMzU2YTU4YzBiNTkwNTE2NTdhZTkyN2M1MDMwMzYwYzcwNzhjYjc1OWRmZTU3YWE2MWFmY
Public key (cometized hex): PubKeyEd25519{3937363536306534613432383133353661353863306235393035313635376165}
Public key (plain hex): 3937363536306534613432383133353661353863306235393035313635376165
Address (string): 727E7C74811037F31A5289C3EF21CD49676DD538
Node ID: 727e7c74811037f31a5289c3ef21cd49676dd538
```

*after* (correct)

```
$  ./kwil-admin key info f7f8de5ab4efb9fdaa5ff6e66bc20993976560e4a4281356a58c0b59051657ae927c5030360c7078cb759dfe57aa61afae2656b0
Private key (hex): f7f8de5ab4efb9fdaa5ff6e66bc20993976560e4a4281356a58c0b59051657ae927c5030360c7078cb759dfe57aa61afae2656b0
Private key (base64): 9/jeWrTvuf2qX/bma8IJk5dlYOSkKBNWpYwLWQUWV66SfFAwNgxweMt1nf5XqmG
Public key (base64): knxQMDYMcHjLdZ3+V6phr64mVrAW3YQAPbohiNaMdGg=
Public key (cometized hex): PubKeyEd25519{927C5030360C7078CB759DFE57AA61AFAE2656B016DD84003DBA2188D68C7468}
Public key (plain hex): 927c5030360c7078cb759dfe57aa61afae2656b016dd84003dba2188d68c7468
Address (string): A64F11AF02C337B1999F5AC88C91BA201526BF34
Node ID: a64f11af02c337b1999f5ac88c91ba201526bf34
```