### PR TITLE
kwild,utils/url: allow using default port or host

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -661,7 +661,7 @@ func buildCometNode(d *coreDependencies, closer *closeFuncs, abciApp abciTypes.A
 		Logger:         *d.log.Named("private-validator-signature-store"),
 	})
 	if err != nil {
-		failBuild(err, "failed to build comet node")
+		failBuild(err, "failed to open comet node KV store")
 	}
 	closer.addCloser(db.Close)
 

--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -2,16 +2,47 @@ package server
 
 import (
 	"fmt"
+	"net"
 	"path/filepath"
+	"strconv"
 	"time"
 
 	"github.com/kwilteam/kwil-db/cmd/kwild/config"
+	"github.com/kwilteam/kwil-db/core/utils/url"
 	"github.com/kwilteam/kwil-db/internal/abci/cometbft"
 
 	cmtCfg "github.com/cometbft/cometbft/config"
 	cmtEd "github.com/cometbft/cometbft/crypto/ed25519"
 	cmttypes "github.com/cometbft/cometbft/types"
 )
+
+// cleanListenAddr tries to ensure the address has a scheme and port, as
+// required by cometbft for it's listen address settings. If it does not parse,
+// it is returned as-is so cometbft can try it.
+func cleanListenAddr(addr, defaultPort string) string {
+	u, err := url.ParseURL(addr)
+	if err != nil { // just see if cometbft takes it
+		return addr
+	}
+
+	parsed := u.URL()
+	if u.Port == 0 {
+		// If port not included or explicitly set to 0, use the default.
+		_, port, _ := net.SplitHostPort(u.Target)
+		if port == "" {
+			parsed.Host = net.JoinHostPort(u.Target, defaultPort)
+		}
+	}
+	return parsed.String()
+}
+
+func portFromURL(u string) string {
+	rpcAddress, err := url.ParseURL(u)
+	if err != nil {
+		return "0"
+	}
+	return strconv.Itoa(rpcAddress.Port)
+}
 
 // newCometConfig creates a new CometBFT config for use with NewCometBftNode.
 // This applies The operator's settings from the Kwil config as well as applying
@@ -35,11 +66,13 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 		nodeCfg.Moniker = userChainCfg.Moniker
 	}
 
-	nodeCfg.RPC.ListenAddress = userChainCfg.RPC.ListenAddress
+	nodeCfg.RPC.ListenAddress = cleanListenAddr(userChainCfg.RPC.ListenAddress,
+		portFromURL(nodeCfg.RPC.ListenAddress))
 	nodeCfg.RPC.TLSCertFile = cfg.AppCfg.TLSCertFile
 	nodeCfg.RPC.TLSKeyFile = cfg.AppCfg.TLSKeyFile
 
-	nodeCfg.P2P.ListenAddress = userChainCfg.P2P.ListenAddress
+	nodeCfg.P2P.ListenAddress = cleanListenAddr(userChainCfg.P2P.ListenAddress,
+		portFromURL(nodeCfg.P2P.ListenAddress))
 	nodeCfg.P2P.ExternalAddress = userChainCfg.P2P.ExternalAddress
 	nodeCfg.P2P.PersistentPeers = userChainCfg.P2P.PersistentPeers
 	nodeCfg.P2P.AddrBookStrict = userChainCfg.P2P.AddrBookStrict

--- a/core/utils/url/url.go
+++ b/core/utils/url/url.go
@@ -20,12 +20,20 @@ type URL struct {
 	Target string
 	// Port is the port number, or 0 if not specified.
 	Port int
+
+	// the parsed url.URL. Not exported for test simplicity.
+	u *url.URL
+}
+
+// URL returns the parsed url.URL.
+func (u *URL) URL() *url.URL {
+	return u.u
 }
 
 // Scheme is a protocol scheme, such as http or tcp.
 type Scheme string
 
-func (s Scheme) valid() bool {
+func (s Scheme) Valid() bool {
 	switch s {
 	case HTTP, HTTPS, TCP, UNIX:
 		return true
@@ -53,9 +61,11 @@ const (
 // - localhost
 // - unix:///var/run/kwil.sock
 // If the URL does not have a scheme, it is assumed to be a tcp address.
+// If it does not have a port, it is set to 0. This is only appropriate for
+// listen addresses.
 func ParseURL(u string) (*URL, error) {
 	original := u
-	// if the url does not have a scheme, assume it's a tcp address
+	// If the url does not have a scheme, assume it's a tcp address, rewrite and reparse.
 	hasScheme, err := hasScheme(u)
 	if err != nil {
 		return nil, err
@@ -69,43 +79,39 @@ func ParseURL(u string) (*URL, error) {
 		return nil, err
 	}
 
-	scheme := Scheme(parsed.Scheme)
-	if !scheme.valid() { // I don't think this can error, but just in case
-		return nil, fmt.Errorf("%w: %s", ErrUnknownScheme, scheme)
-	}
-
-	var target string
-	switch scheme {
+	switch Scheme(parsed.Scheme) {
+	case TCP, HTTP, HTTPS:
 	case UNIX:
-		target, err = expandPath(parsed.Path)
+		target, err := expandPath(parsed.Path)
 		if err != nil {
 			return nil, err
 		}
+		parsed.Host = target
 	default:
-		target = parsed.Host
+		return nil, fmt.Errorf("%w: %s", ErrUnknownScheme, parsed.Scheme)
 	}
 
-	portString := parsed.Port()
-	if portString == "" {
-		portString = "0"
-	}
-	port, err := strconv.ParseInt(portString, 10, 32)
-	if err != nil {
-		return nil, err
+	var port uint64
+	if portString := parsed.Port(); portString != "" {
+		port, err = strconv.ParseUint(portString, 10, 16)
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return &URL{
 		Original: original,
-		Scheme:   scheme,
-		Target:   target,
+		Scheme:   Scheme(parsed.Scheme),
+		Target:   parsed.Host,
 		Port:     int(port),
+		u:        parsed,
 	}, nil
 }
 
 // hasScheme returns true if the url has a known scheme.
 func hasScheme(u string) (bool, error) {
 	parsed, err := url.Parse(u)
-	if err != nil {
+	if err != nil { // TODO: make this work for IPv6 with no scheme
 		return false, err
 	}
 

--- a/core/utils/url/url_test.go
+++ b/core/utils/url/url_test.go
@@ -54,6 +54,26 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			name: "no scheme or port",
+			url:  "localhost",
+			want: &url.URL{
+				Original: "localhost",
+				Scheme:   url.TCP,
+				Target:   "localhost",
+				Port:     0,
+			},
+		},
+		{
+			name: "IPv6 with scheme",
+			url:  "tcp://[d4:93::1]:22",
+			want: &url.URL{
+				Original: "tcp://[d4:93::1]:22",
+				Scheme:   url.TCP,
+				Target:   "[d4:93::1]:22",
+				Port:     22,
+			},
+		},
+		{
 			name:    "unknown scheme",
 			url:     "foo://localhost:8080",
 			wantErr: url.ErrUnknownScheme,
@@ -83,7 +103,7 @@ func TestParseURL(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, *got, *tt.want)
+			assert.EqualExportedValues(t, *got, *tt.want)
 		})
 	}
 }


### PR DESCRIPTION
This allows the listen addresses for app gRPC and HTTP to be partially specified, with only one of port or host, in which case it will use the default parsed from the full default listen address.

A similar change is applied for the cometbft listen addresses, but also applying the default scheme since cometbft requires a fully qualified URL with scheme unlike our apps listeners.