### PR TITLE
config: show private key load error

### DIFF
--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -627,7 +627,7 @@ func ReadOrCreatePrivateKeyFile(keyPath string, autogen bool) (priv, pub []byte,
 	}
 
 	if !autogen {
-		return nil, nil, false, fmt.Errorf("private key not found")
+		return nil, nil, false, fmt.Errorf("failed to load private key: %w", err)
 	}
 
 	priv, pub, err = newNodeKey()


### PR DESCRIPTION
The following error was confusing and unhelpful:

```
Private key path: /home/jon/.kwild-sentry/private_key
Error: failed to initialize private key and genesis: private key not found
```

It was indeed there, so why did it say not found?

Now it does not throw away the error, which says the real problem, which was a secp256k1 key instead of an ed25519 key:

```
Error: failed to initialize private key and genesis: failed to load private key: invalid private key: invalid ed25519 private key length: 32
```
