### PR TITLE
engine,txapp,oracles: fix types1 import and unset GlobalContext.service

### DIFF
--- a/internal/oracles/mgr.go
+++ b/internal/oracles/mgr.go
@@ -5,13 +5,14 @@ import (
 	"context"
 	"time"
 
-	types1 "github.com/kwilteam/kwil-db/common"
+	"go.uber.org/zap"
+
+	common "github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/extensions/oracles"
 	"github.com/kwilteam/kwil-db/internal/abci/cometbft"
 	"github.com/kwilteam/kwil-db/internal/events"
-	"go.uber.org/zap"
 )
 
 // OracleMgr listens for any Validator state changes and node catch up status
@@ -90,7 +91,7 @@ func (omgr *OracleMgr) Start() {
 				omgr.logger.Info("Node is a validator and caught up with the network, starting oracles")
 
 				for name, start := range oracles.RegisteredOracles() {
-					go start(ctx2, &types1.Service{
+					go start(ctx2, &common.Service{
 						Logger:           *omgr.logger.Named(name),
 						ExtensionConfigs: omgr.config,
 					}, &scopedKVEventStore{

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -7,12 +7,13 @@ import (
 	"fmt"
 	"math/big"
 
-	types1 "github.com/kwilteam/kwil-db/common"
+	"go.uber.org/zap"
+
+	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 	"github.com/kwilteam/kwil-db/internal/ident"
 	"github.com/kwilteam/kwil-db/internal/voting"
-	"go.uber.org/zap"
 )
 
 func init() {
@@ -243,7 +244,7 @@ func (e *executeActionRoute) Execute(ctx TxContext, router *TxApp, tx *transacti
 	defer tx2.Rollback(ctx.Ctx)
 
 	for i := range args {
-		_, err = router.Engine.Call(ctx.Ctx, tx2, &types1.ExecutionData{
+		_, err = router.Engine.Call(ctx.Ctx, tx2, &common.ExecutionData{
 			Dataset:   action.DBID,
 			Procedure: action.Action,
 			Args:      args[i],


### PR DESCRIPTION
This fixes more incorrect imports in the vein of https://github.com/kwilteam/kwil-db/pull/539

This also fixes an unset `GlobalContext.service` field from https://github.com/kwilteam/kwil-db/pull/517#discussion_r1498297237