### PR TITLE
kwild,utils/url: allow using default port or host

### DIFF
--- a/cmd/kwild/config/config_test.go
+++ b/cmd/kwild/config/config_test.go
@@ -1,18 +1,16 @@
-package config_test
+package config
 
 import (
 	"path/filepath"
 	"testing"
 
-	"github.com/kwilteam/kwil-db/cmd/kwild/config"
-
 	"github.com/stretchr/testify/assert"
 )
 
 func Test_Config_Toml(t *testing.T) {
-	cfg := config.DefaultConfig()
+	cfg := DefaultConfig()
 
-	tomlCfg, err := config.LoadConfigFile(filepath.Join("test_data", config.ConfigFileName))
+	tomlCfg, err := LoadConfigFile(filepath.Join("test_data", ConfigFileName))
 	assert.NoError(t, err)
 
 	err = cfg.Merge(tomlCfg)
@@ -27,4 +25,80 @@ func Test_Config_Toml(t *testing.T) {
 	assert.Equal(t, "localhost:50053", cfg.AppCfg.ExtensionEndpoints[1])
 
 	// TODO: Add bunch of other validations for different types
+}
+
+func Test_cleanListenAddr(t *testing.T) {
+	type args struct {
+		listen        string
+		defaultListen string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"orig ok",
+			args{
+				listen:        "127.0.0.2:9090",
+				defaultListen: "127.0.0.1:8080",
+			},
+			"127.0.0.2:9090",
+		},
+		{
+			"orig lacks port",
+			args{
+				listen:        "127.0.0.2",
+				defaultListen: "127.0.0.1:8080",
+			},
+			"127.0.0.2:8080",
+		},
+		{
+			"orig lacks IP",
+			args{
+				listen:        ":9090",
+				defaultListen: "127.0.0.1:8080",
+			},
+			"127.0.0.1:9090",
+		},
+		{
+			"ipv6 too many colons, fallback to input",
+			args{
+				listen:        "2f:2f::",
+				defaultListen: "127.0.0.1:8080",
+			},
+			"2f:2f::",
+		},
+		{
+			"ipv6 bracketed no port",
+			args{
+				listen:        "[2f:2f::]",
+				defaultListen: "127.0.0.1:8080",
+			},
+			"[2f:2f::]:8080",
+		},
+		{
+			"ipv6 bracketed with port",
+			args{
+				listen:        "[2f:2f::]:9090",
+				defaultListen: "127.0.0.1:8080",
+			},
+			"[2f:2f::]:9090",
+		},
+		{
+			"ipv6 default, input with only port",
+			args{
+				listen:        ":9090",
+				defaultListen: "[::1]:8080",
+			},
+			"[::1]:9090",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanListenAddr(tt.args.listen, tt.args.defaultListen); got != tt.want {
+				t.Errorf("cleanListenAddr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -671,7 +671,7 @@ func buildCometNode(d *coreDependencies, closer *closeFuncs, abciApp abciTypes.A
 		Logger:         *d.log.Named("private-validator-signature-store"),
 	})
 	if err != nil {
-		failBuild(err, "failed to build comet node")
+		failBuild(err, "failed to open comet node KV store")
 	}
 	closer.addCloser(db.Close, "closing signing store")
 

--- a/cmd/kwild/server/cometbft_test.go
+++ b/cmd/kwild/server/cometbft_test.go
@@ -1,0 +1,71 @@
+package server
+
+import "testing"
+
+func Test_cleanListenAddr(t *testing.T) {
+	type args struct {
+		addr        string
+		defaultPort string
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		{
+			"ok no change",
+			args{
+				addr:        "tcp://127.0.0.1:9090",
+				defaultPort: "8080",
+			},
+			"tcp://127.0.0.1:9090",
+		},
+		{
+			"no port or scheme",
+			args{
+				addr:        "127.0.0.1",
+				defaultPort: "8080",
+			},
+			"tcp://127.0.0.1:8080",
+		},
+		{
+			"no scheme",
+			args{
+				addr:        "127.0.0.1:9090",
+				defaultPort: "8080",
+			},
+			"tcp://127.0.0.1:9090",
+		},
+		{
+			"ok no change",
+			args{
+				addr:        "tcp://localhost:9090",
+				defaultPort: "8080",
+			},
+			"tcp://localhost:9090",
+		},
+		{
+			"no port or scheme",
+			args{
+				addr:        "localhost",
+				defaultPort: "8080",
+			},
+			"tcp://localhost:8080",
+		},
+		{
+			"no scheme",
+			args{
+				addr:        "localhost:9090",
+				defaultPort: "8080",
+			},
+			"tcp://localhost:9090",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := cleanListenAddr(tt.args.addr, tt.args.defaultPort); got != tt.want {
+				t.Errorf("cleanListenAddr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/core/utils/url/url_test.go
+++ b/core/utils/url/url_test.go
@@ -54,6 +54,56 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			name: "no scheme (IP)",
+			url:  "127.0.0.1:8080",
+			want: &url.URL{
+				Original: "127.0.0.1:8080",
+				Scheme:   url.TCP,
+				Target:   "127.0.0.1:8080",
+				Port:     8080,
+			},
+		},
+		{
+			name: "no scheme or port (IP)",
+			url:  "127.0.0.1",
+			want: &url.URL{
+				Original: "127.0.0.1",
+				Scheme:   url.TCP,
+				Target:   "127.0.0.1",
+				Port:     0,
+			},
+		},
+		{
+			name: "no scheme or port",
+			url:  "localhost",
+			want: &url.URL{
+				Original: "localhost",
+				Scheme:   url.TCP,
+				Target:   "localhost",
+				Port:     0,
+			},
+		},
+		{
+			name: "no scheme",
+			url:  "localhost:8080",
+			want: &url.URL{
+				Original: "localhost:8080",
+				Scheme:   url.TCP,
+				Target:   "localhost:8080",
+				Port:     8080,
+			},
+		},
+		{
+			name: "IPv6 with scheme",
+			url:  "tcp://[d4:93::1]:22",
+			want: &url.URL{
+				Original: "tcp://[d4:93::1]:22",
+				Scheme:   url.TCP,
+				Target:   "[d4:93::1]:22",
+				Port:     22,
+			},
+		},
+		{
 			name:    "unknown scheme",
 			url:     "foo://localhost:8080",
 			wantErr: url.ErrUnknownScheme,
@@ -83,7 +133,7 @@ func TestParseURL(t *testing.T) {
 				return
 			}
 
-			assert.Equal(t, *got, *tt.want)
+			assert.EqualExportedValues(t, *got, *tt.want)
 		})
 	}
 }

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -193,7 +193,7 @@ func (d *KwilCliDriver) DeployDatabase(_ context.Context, db *transactions.Schem
 	cmd := d.newKwilCliCmd("database", "deploy", "-p", schemaFile, "-t", "json")
 	out, err := mustRun(cmd, d.logger)
 	if err != nil {
-		return nil, fmt.Errorf("failed to deploy databse: %w", err)
+		return nil, fmt.Errorf("failed to deploy database: %w", err)
 	}
 
 	txHash, err = parseRespTxHash(out.Result)


### PR DESCRIPTION
Rebirth of https://github.com/kwilteam/kwil-db/pull/527

This allows the listen addresses for app gRPC and HTTP to be partially specified, with only one of port or host, in which case it will use the default parsed from the full default listen address.

A similar change is applied for the cometbft listen addresses, but also applying the default scheme since cometbft requires a fully qualified URL with scheme unlike our apps listeners.