### PR TITLE
deployments,config: further extend postgres Docker, default to 127.0.0.1

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,6 @@ jobs:
       postgres:
         image: jchappelow/kwil-postgres:latest
         env:
-          POSTGRES_USER: kwild
-          POSTGRES_PASSWORD: kwild
           POSTGRES_PORT: 5432
           POSTGRES_DB: kwil_test_db
           POSTGRES_HOST_AUTH_METHOD: trust
@@ -203,4 +201,4 @@ jobs:
 
       - name: Prune Docker
         if: ${{ always() }}
-        run: docker rm $(docker ps -a -q) -f && docker network prune -f || true
+        run: docker rm $(docker ps -a -q) -f ; docker network prune -f ; docker volume prune -f || true

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -16,7 +16,6 @@ jobs:
         image: jchappelow/kwil-postgres:latest
         env:
           POSTGRES_PORT: 5432
-          POSTGRES_DB: kwil_test_db
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-
           --health-cmd pg_isready

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -441,7 +441,7 @@ func DefaultConfig() *KwildConfig {
 			HTTPListenAddress:  "localhost:8080",
 			AdminListenAddress: "unix:///tmp/kwil_admin.sock",
 			// SqliteFilePath:     DefaultSQLitePath,
-			DBHost: "/var/run/postgresql",
+			DBHost: "127.0.0.1",
 			DBPort: "5432", // ignored with unix socket, but applies if IP used for DBHost
 			DBUser: "kwild",
 			DBName: "kwild",

--- a/deployments/compose/postgres/Dockerfile
+++ b/deployments/compose/postgres/Dockerfile
@@ -1,9 +1,8 @@
 FROM postgres:16.1
 
-# Might do these envs, but for now leave it to compose:
-# ENV POSTGRES_USER kwild
-# ENV POSTGRES_PASSWORD kwild
-# ENV POSTGRES_DB kwild
+# Inject the init script that makes the kwild superuser and a kwild database
+# owned by that kwild user, as well as a kwil_test_db database for tests.
+COPY ./init.sql /docker-entrypoint-initdb.d/init.sql
 
 # Override the default entrypoint/command to include the additional configuration
 CMD ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=10", "-c", "max_replication_slots=10", "-c", "max_prepared_transactions=2"]


### PR DESCRIPTION
This updates our extended postgres Dockerfile so that it inserts an init script to create the "kwild" superuser and a "kwild" database owned by that user.  We can do other init tasks in these files, and can also include arbitrary .sh scripts to customize further.

This also changes the default `app.pg_db_host` to `127.0.0.1` instead of `/var/run/postgres` so that it can work with the Docker images and services without having to specify the hosts.

With this, I have pushed to [`jchappelow/kwil-postgres:latest` on Docker Hub](https://hub.docker.com/r/jchappelow/kwil-postgres/tags), and we can do:

```sh
docker run -v /home/jon/kwil-pg-test:/var/lib/postgresql/data -p 5432:5432 \
    -e "POSTGRES_PASSWORD=kwild" jchappelow/kwil-postgres
```

Qs:

- is this a resolution for the quickstart?
- Can we push this Docker image to the kwil account instead
- For multi-node, this doesn't quite help.  Each node needs it's own postgres, so they'd have to run multiple pg containers with different exposed ports, and specify them for each node
- What's the point of the multi-node quick start? I don't quite see the purpose. To just toy with the kwild RPC on a fake chain, the single node does that.  It's not a realistic multi-node scenario, so it doesn't demonstrate a proper way to deploy multiple nodes, but the Tutorial does.
- If multi node quickstart is valuable, maybe we can use the docker compose definition in `deployments/compose/kwil`, which starts two containers, one for kwild and one for postgres, and they automatically connect to each other.  EDIT: would still be tricky to get the different nodes talking.  nvm that