### PR TITLE
try fix test network jitter

### DIFF
--- a/test/acceptance/helper.go
+++ b/test/acceptance/helper.go
@@ -226,7 +226,7 @@ func (r *ActHelper) runDockerCompose(ctx context.Context) {
 
 	r.t.Cleanup(func() {
 		r.t.Logf("teardown docker compose")
-		err := dc.Down(ctx, compose.RemoveOrphans(true), compose.RemoveImagesLocal, compose.RemoveVolumes(true))
+		err := dc.Down(ctx)
 		require.NoErrorf(r.t, err, "failed to teardown %s", dc.Services())
 	})
 

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -396,7 +396,7 @@ func (r *IntHelper) RunDockerComposeWithServices(ctx context.Context, services [
 
 	r.t.Cleanup(func() {
 		r.t.Logf("teardown %s", dc.Services())
-		err := dc.Down(ctx, compose.RemoveOrphans(true), compose.RemoveImagesLocal, compose.RemoveVolumes(true))
+		err := dc.Down(ctx)
 		require.NoErrorf(r.t, err, "failed to teardown %s", dc.Services())
 	})
 


### PR DESCRIPTION
This pr change the behavior to do nothing when test cleanup, to avoid the anecdotal network jitter issue https://github.com/kwilteam/kwil-db/actions/runs/8057247286/job/22008434691#step:24:209

We now have `Prune Docker` step in CI so it's also redundant.

BTW, originally I want to solve this problem by running all tests in one network, after I got some wired bugs I realized I cannot do it that way, since we use `nodeX`(dns name) to reach out different node, in same network those dns will change in parallel mode very often/quick, leading to network issue.