### PR TITLE
PG Sanity checks at Genesis 

### DIFF
--- a/deployments/compose/kwil/docker-compose.yml
+++ b/deployments/compose/kwil/docker-compose.yml
@@ -65,10 +65,10 @@ services:
       --app.http-listen-addr=:8080
       --chain.p2p.external-address=tcp://0.0.0.0:26656
       --chain.rpc.listen-addr=tcp://0.0.0.0:26657
-      --app.pg_db_host=172.5.100.3
-      --app.pg_db_port=5432
-      --app.pg_db_user=kwild
-      --app.pg_db_pass=kwild
+      --app.pg-db-host=172.5.100.3
+      --app.pg-db-port=5432
+      --app.pg-db-user=kwild
+      --app.pg-db-pass=kwild
 
 networks:
   kwilnet0:


### PR DESCRIPTION
Voters/Validators is one good indicator of whether we are using stale pg instance or a new instance as we always initialize voters in the genesis. So using that to do sanity checks at the genesis. 