### PR TITLE
kwil-admin,config: disable genesis-hash command

### DIFF
--- a/cmd/kwil-admin/cmds/setup/cmd.go
+++ b/cmd/kwil-admin/cmds/setup/cmd.go
@@ -10,7 +10,6 @@ import (
 
 const setupLong = `The ` + "`" + `setup` + "`" + ` command provides functions for creating and managing node configuration and data, including:
 	- performing quick setup of a standalone Kwil node (init) and Kwil test networks (testnet)
-	- updating genesis config with initial SQLite files (genesis-hash)
 	- resetting node state and all data files (reset)`
 
 var setupCmd = &cobra.Command{
@@ -24,7 +23,7 @@ func NewSetupCmd() *cobra.Command {
 		initCmd(),
 		resetCmd(),
 		testnetCmd(),
-		genesisHashCmd(),
+		// genesisHashCmd(), // TODO: add back once we've figured out what this means for postgres
 		resetStateCmd(),
 		peerCmd(),
 	)

--- a/cmd/kwil-admin/cmds/setup/genesis-hash.go
+++ b/cmd/kwil-admin/cmds/setup/genesis-hash.go
@@ -1,13 +1,13 @@
 package setup
 
 import (
-	"encoding/hex"
+	"errors"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
-	"github.com/kwilteam/kwil-db/internal/sql/pg"
 	"github.com/spf13/cobra"
 )
 
+//nolint:unused
 var (
 	genesisHashLong = `Compute genesis hash from existing PostgreSQL datasets, and optionally update ` + "`" + `genesis.json` + "`" + `.
 It takes up to 4 arguments, which are the postgres DB name, host, port, user, and password to access the datasets to be included in the genesis hash.
@@ -18,7 +18,7 @@ By default, it will print the genesis hash to stdout. To specify a genesis file 
 kwil-admin setup genesis-hash "kwild" "127.0.0.1" "5432" "kwild" "" --genesis "~/.kwild/abci/config/genesis.json"`
 )
 
-func genesisHashCmd() *cobra.Command {
+func genesisHashCmd() *cobra.Command { //nolint:unused
 
 	var genesisFile string
 
@@ -30,7 +30,8 @@ func genesisHashCmd() *cobra.Command {
 		Hidden:  true, // also not listed added, but this is going to be experimental even when implement properly
 		Args:    cobra.RangeArgs(0, 4),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			panic("not implemented")
+			return display.PrintErr(cmd, errors.New("not implemented"))
+			/* TODO: make this work with postgres
 			dbCfg := &pg.ConnConfig{ // defaults
 				Host:   "127.0.0.1",
 				Port:   "5432",
@@ -54,15 +55,13 @@ func genesisHashCmd() *cobra.Command {
 				dbCfg.Pass = args[4]
 			}
 
-			// TODO:
-			// appHash, err := config.PatchGenesisAppHash(cmd.Context(), dbCfg, genesisFile)
-			// if err != nil {
-			// 	return display.PrintErr(cmd, err)
-			// }
-
-			var appHash []byte
+			appHash, err := config.PatchGenesisAppHash(cmd.Context(), dbCfg, genesisFile)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
 
 			return display.PrintCmd(cmd, display.RespString(hex.EncodeToString(appHash)))
+			*/
 		},
 	}
 

--- a/cmd/kwil-admin/cmds/setup/genesis-hash.go
+++ b/cmd/kwil-admin/cmds/setup/genesis-hash.go
@@ -4,18 +4,18 @@ import (
 	"encoding/hex"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
-	"github.com/kwilteam/kwil-db/cmd/kwild/config"
+	"github.com/kwilteam/kwil-db/internal/sql/pg"
 	"github.com/spf13/cobra"
 )
 
 var (
-	genesisHashLong = `Compute genesis hash from SQLite files, and optionally update ` + "`" + `genesis.json` + "`" + `.
-It takes one argument, which is the path containing the SQLite files to be included in the genesis hash.
+	genesisHashLong = `Compute genesis hash from existing PostgreSQL datasets, and optionally update ` + "`" + `genesis.json` + "`" + `.
+It takes up to 4 arguments, which are the postgres DB name, host, port, user, and password to access the datasets to be included in the genesis hash.
 
 By default, it will print the genesis hash to stdout. To specify a genesis file to update as well, use the ` + "`" + `--genesis` + "`" + ` flag.`
 
-	genesisHashExample = `# Compute genesis hash from SQLite files, and add it to a genesis file
-kwil-admin setup genesis-hash "~/.kwild/data/kwil.db" --genesis "~/.kwild/abci/config/genesis.json"`
+	genesisHashExample = `# Compute genesis hash from existing PostgreSQL datasets, and add it to a genesis file
+kwil-admin setup genesis-hash "kwild" "127.0.0.1" "5432" "kwild" "" --genesis "~/.kwild/abci/config/genesis.json"`
 )
 
 func genesisHashCmd() *cobra.Command {
@@ -24,20 +24,43 @@ func genesisHashCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "genesis-hash",
-		Short:   "Compute genesis hash from SQLite files, and optionally update `genesis.json`.",
+		Short:   "Compute genesis hash from existing PostgreSQL datasets, and optionally update `genesis.json`.",
 		Long:    genesisHashLong,
 		Example: genesisHashExample,
-		Args:    cobra.ExactArgs(1),
+		Hidden:  true, // also not listed added, but this is going to be experimental even when implement properly
+		Args:    cobra.RangeArgs(0, 4),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			expandedPath, err := expandPath(args[0])
-			if err != nil {
-				return display.PrintErr(cmd, err)
+			panic("not implemented")
+			dbCfg := &pg.ConnConfig{ // defaults
+				Host:   "127.0.0.1",
+				Port:   "5432",
+				DBName: "kwild",
+				User:   "kwild",
+				Pass:   "kwild",
+			}
+			if len(args) > 0 {
+				dbCfg.Host = args[0]
+			}
+			if len(args) > 1 {
+				dbCfg.Port = args[1]
+			}
+			if len(args) > 2 {
+				dbCfg.DBName = args[2]
+			}
+			if len(args) > 3 {
+				dbCfg.User = args[3]
+			}
+			if len(args) > 4 {
+				dbCfg.Pass = args[4]
 			}
 
-			appHash, err := config.PatchGenesisAppHash(expandedPath, genesisFile)
-			if err != nil {
-				return display.PrintErr(cmd, err)
-			}
+			// TODO:
+			// appHash, err := config.PatchGenesisAppHash(cmd.Context(), dbCfg, genesisFile)
+			// if err != nil {
+			// 	return display.PrintErr(cmd, err)
+			// }
+
+			var appHash []byte
 
 			return display.PrintCmd(cmd, display.RespString(hex.EncodeToString(appHash)))
 		},

--- a/cmd/kwil-admin/cmds/setup/reset.go
+++ b/cmd/kwil-admin/cmds/setup/reset.go
@@ -19,7 +19,7 @@ kwil-admin setup reset --root-dir "~/.kwild" --sqlpath "~/.kwild/data/kwil.db"`
 )
 
 func resetCmd() *cobra.Command {
-	var rootDir, sqlPath, snapPath string
+	var rootDir, snapPath string
 	var force bool
 
 	cmd := &cobra.Command{
@@ -35,9 +35,6 @@ func resetCmd() *cobra.Command {
 				rootDir = common.DefaultKwildRoot()
 			}
 
-			if sqlPath == "" {
-				sqlPath = config.DefaultSQLitePath
-			}
 			if snapPath == "" {
 				snapPath = config.DefaultSnapshotsDir
 			}
@@ -47,17 +44,12 @@ func resetCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			expandedSQL, err := expandPath(sqlPath)
-			if err != nil {
-				return display.PrintErr(cmd, err)
-			}
-
 			expandedSnap, err := expandPath(snapPath)
 			if err != nil {
 				return display.PrintErr(cmd, err)
 			}
 
-			err = config.ResetAll(expandedRoot, expandedSQL, expandedSnap)
+			err = config.ResetAll(expandedRoot, expandedSnap)
 			if err != nil {
 				return display.PrintErr(cmd, err)
 			}
@@ -67,7 +59,7 @@ func resetCmd() *cobra.Command {
 	}
 
 	cmd.Flags().StringVarP(&rootDir, "root-dir", "r", "", "root directory of the kwild node")
-	cmd.Flags().StringVarP(&sqlPath, "sqlpath", "s", "", "path to the SQLite database")
+	// cmd.Flags().StringVarP(&sqlPath, "sqlpath", "s", "", "path to the SQLite database") // TODO: postgres config
 	cmd.Flags().StringVarP(&snapPath, "snappath", "p", "", "path to the snapshot directory")
 	cmd.Flags().BoolVarP(&force, "force", "f", false, "force removal of default home directory")
 

--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -65,8 +65,6 @@ const defaultConfigTemplate = `
 #   |   |   |- blockchain db files/dir (blockstore.db, state.db, etc)
 #   |   |- info/
 #   |- application/wal
-#   |- data
-#   |   |- kwild.db/
 #   |- signing/
 
 # Only the config.toml and genesis file are required to run the kwild node
@@ -108,19 +106,19 @@ admin_listen_addr = "{{ .AppCfg.AdminListenAddress }}"
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = {{arrayFormatter .AppCfg.ExtensionEndpoints}}
 
-# KWILD PostgreSQL database host (UNIX socket path or IP address with no port)
+# PostgreSQL database host (UNIX socket path or IP address with no port)
 pg_db_host = "{{ .AppCfg.DBHost }}"
 
-# KWILD PostgreSQL database port (may be omitted for UNIX socket hosts)
+# PostgreSQL database port (may be omitted for UNIX socket hosts)
 pg_db_port = "{{ .AppCfg.DBPort }}"
 
-# KWILD PostgreSQL database user (should be a "superuser")
+# PostgreSQL database user (should be a "superuser")
 pg_db_user = "{{ .AppCfg.DBUser }}"
 
-# KWILD PostgreSQL database pass (may be omitted for some pg_hba.conf configurations)
+# PostgreSQL database pass (may be omitted for some pg_hba.conf configurations)
 pg_db_pass = "{{ .AppCfg.DBPass }}"
 
-# KWILD PostgreSQL database name (override database name, default is "kwild")
+# PostgreSQL database name (override database name, default is "kwild")
 pg_db_name = "{{ .AppCfg.DBName }}"
 
 # The path to a file containing certificate that is used to create the HTTPS server.

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -32,8 +32,6 @@ const (
 	defaultAdminClients = "clients.pem"
 )
 
-var DefaultSQLitePath = filepath.Join("data", "kwild.db") // a folder, not a file
-
 type KwildConfig struct {
 	RootDir string
 
@@ -440,11 +438,10 @@ func DefaultConfig() *KwildConfig {
 			GrpcListenAddress:  "localhost:50051",
 			HTTPListenAddress:  "localhost:8080",
 			AdminListenAddress: "unix:///tmp/kwil_admin.sock",
-			// SqliteFilePath:     DefaultSQLitePath,
-			DBHost: "127.0.0.1",
-			DBPort: "5432", // ignored with unix socket, but applies if IP used for DBHost
-			DBUser: "kwild",
-			DBName: "kwild",
+			DBHost:             "127.0.0.1",
+			DBPort:             "5432", // ignored with unix socket, but applies if IP used for DBHost
+			DBUser:             "kwild",
+			DBName:             "kwild",
 			// SnapshotConfig: SnapshotConfig{
 			// 	Enabled:         false,
 			// 	RecurringHeight: uint64(10000),

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -16,9 +16,7 @@
 #   |   |- data/
 #   |   |   |- blockchain db files/dir (blockstore.db, state.db, etc)
 #   |   |- info/            
-#   |- application/wal      
-#   |- data
-#   |   |- kwild.db/    
+#   |- application/wal        
 #   |- snapshots/
 #   |- signing/
 #   |- rcvdSnaps/   (includes the chunks rcvd from the state sync module during db restoration process, its a temp dir)
@@ -50,8 +48,20 @@ without_gas_costs = true
 # Toggle to disable nonces for transactions and queries
 without_nonces = false
 
-# KWILD Sqlite database file path
-sqlite_file_path = "data/kwil.db"
+# PostgreSQL database host (UNIX socket path or IP address with no port)
+pg_db_host = "127.0.0.1"
+
+# PostgreSQL database port (may be omitted for UNIX socket hosts)
+pg_db_port = "5432"
+
+# PostgreSQL database user (should be a "superuser")
+pg_db_user = "kwild"
+
+# PostgreSQL database pass (may be omitted for some pg_hba.conf configurations)
+pg_db_pass = ""
+
+# PostgreSQL database name (override database name, default is "kwild")
+pg_db_name = "kwild"
 
 # The path to a file containing certificate that is used to create the HTTPS server.
 # Might be either absolute path or path related to the kwild root directory.

--- a/cmd/kwild/config/folders.go
+++ b/cmd/kwild/config/folders.go
@@ -5,7 +5,6 @@ package config
 const (
 	ABCIDirName          = "abci" // cometBFT node's root folder
 	ABCIInfoSubDirName   = "info" // e.g. abci/info for kv state data
-	ApplicationDirName   = "application"
 	ReceivedSnapsDirName = "rcvdSnaps"
 	SigningDirName       = "signing"
 

--- a/cmd/kwild/config/genesis.go
+++ b/cmd/kwild/config/genesis.go
@@ -5,12 +5,9 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"hash"
-	"io"
 	"math/big"
 	"os"
 	"path/filepath"
-	"slices"
 	"sort"
 	"time"
 
@@ -308,26 +305,7 @@ func NewGenesisWithValidator(pubKey []byte) *GenesisConfig {
 	return genesisCfg
 }
 
-func listFilesAlphabetically(filePath string) ([]string, error) {
-	files, err := filepath.Glob(filePath)
-	if err != nil {
-		return nil, err
-	}
-	slices.Sort(files)
-	return files, nil
-}
-
-func hashFile(filePath string, hasher hash.Hash) error {
-	file, err := os.Open(filePath)
-	if err != nil {
-		return err
-	}
-	defer file.Close()
-
-	_, err = io.Copy(hasher, file)
-	return err
-}
-
+/* TODO: restore when we figure out how to compute appHash with postgres
 func setGenesisAppHash(appHash []byte, genesisFile string) error {
 	genesisConf, err := LoadGenesisConfig(genesisFile)
 	if err != nil {
@@ -340,6 +318,7 @@ func setGenesisAppHash(appHash []byte, genesisFile string) error {
 	}
 	return nil
 }
+*/
 
 // PatchGenesisAppHash computes the apphash from a full contents of all sqlite
 // files in the provided folder, and if genesis file is provided, updates the

--- a/cmd/kwild/config/reset.go
+++ b/cmd/kwild/config/reset.go
@@ -21,7 +21,7 @@ func ResetChainState(rootDir string) error {
 }
 
 // ResetAll removes all data.
-func ResetAll(rootDir, sqlitePath, snapshotDir string) error {
+func ResetAll(rootDir, snapshotDir string) error {
 	// Remove CometBFT's stuff first.
 	chainRoot := filepath.Join(rootDir, ABCIDirName)
 
@@ -77,11 +77,12 @@ func ResetAll(rootDir, sqlitePath, snapshotDir string) error {
 
 	// The user-configurable paths
 
-	if err := os.RemoveAll(rootify(sqlitePath, rootDir)); err == nil {
-		fmt.Println("Removed all sqlite files", "dir", sqlitePath)
-	} else {
-		fmt.Println("Error removing all sqlite files", "dir", sqlitePath, "err", err)
-	}
+	// TODO: support postgres
+	// if err := os.RemoveAll(rootify(sqlitePath, rootDir)); err == nil {
+	// 	fmt.Println("Removed all sqlite files", "dir", sqlitePath)
+	// } else {
+	// 	fmt.Println("Error removing all sqlite files", "dir", sqlitePath, "err", err)
+	// }
 
 	if err := os.RemoveAll(rootify(snapshotDir, rootDir)); err == nil {
 		fmt.Println("Removed all snapshots", "dir", snapshotDir)

--- a/cmd/kwild/config/reset.go
+++ b/cmd/kwild/config/reset.go
@@ -54,13 +54,6 @@ func ResetAll(rootDir, snapshotDir string) error {
 		fmt.Println("Error removing all info", "dir", infoDir, "err", err)
 	}
 
-	appDir := filepath.Join(rootDir, ApplicationDirName)
-	if err := os.RemoveAll(appDir); err == nil {
-		fmt.Println("Removed all application", "dir", appDir)
-	} else {
-		fmt.Println("Error removing all application", "dir", appDir, "err", err)
-	}
-
 	sigDir := filepath.Join(rootDir, SigningDirName)
 	if err := os.RemoveAll(sigDir); err == nil {
 		fmt.Println("Removed all signing", "dir", sigDir)
@@ -77,12 +70,7 @@ func ResetAll(rootDir, snapshotDir string) error {
 
 	// The user-configurable paths
 
-	// TODO: support postgres
-	// if err := os.RemoveAll(rootify(sqlitePath, rootDir)); err == nil {
-	// 	fmt.Println("Removed all sqlite files", "dir", sqlitePath)
-	// } else {
-	// 	fmt.Println("Error removing all sqlite files", "dir", sqlitePath, "err", err)
-	// }
+	// TODO: support postgres database drop or schema drops
 
 	if err := os.RemoveAll(rootify(snapshotDir, rootDir)); err == nil {
 		fmt.Println("Removed all snapshots", "dir", snapshotDir)

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -17,9 +17,7 @@
 #   |   |- data/
 #   |   |   |- blockchain db files/dir (blockstore.db, state.db, etc)
 #   |   |- info/            
-#   |- application/wal      
-#   |- data
-#   |   |- kwild.db/    
+#   |- application/wal         
 #   |- snapshots/
 #   |- signing/
 #   |- rcvdSnaps/   (includes the chunks rcvd from the state sync module during db restoration process, its a temp dir)
@@ -51,8 +49,20 @@ without_gas_costs = true
 # Toggle to disable nonces for transactions and queries
 without_nonces = false
 
-# KWILD Sqlite database file path
-sqlite_file_path = "data/kwil.db"
+# PostgreSQL database host (UNIX socket path or IP address with no port)
+pg_db_host = "127.0.0.1"
+
+# PostgreSQL database port (may be omitted for UNIX socket hosts)
+pg_db_port = "5432"
+
+# PostgreSQL database user (should be a "superuser")
+pg_db_user = "kwild"
+
+# PostgreSQL database pass (may be omitted for some pg_hba.conf configurations)
+pg_db_pass = ""
+
+# PostgreSQL database name (override database name, default is "kwild")
+pg_db_name = "kwild"
 
 # The path to a file containing certificate that is used to create the HTTPS server.
 # Might be either absolute path or path related to the kwild root directory.

--- a/cmd/kwild/server/server.go
+++ b/cmd/kwild/server/server.go
@@ -44,10 +44,9 @@ type Server struct {
 
 const (
 	// Top-level directory structure for the Server's systems
-	abciDirName        = config.ABCIDirName
-	applicationDirName = config.ApplicationDirName
-	rcvdSnapsDirName   = config.ReceivedSnapsDirName
-	signingDirName     = config.SigningDirName
+	abciDirName      = config.ABCIDirName
+	rcvdSnapsDirName = config.ReceivedSnapsDirName
+	signingDirName   = config.SigningDirName
 
 	// Note that the sqlLite file path is user-configurable
 	// e.g. "data/kwil.db"

--- a/docs/sql/README.md
+++ b/docs/sql/README.md
@@ -1,6 +1,6 @@
 # Kuneiform SQL
 
-Kuneiform SQL is a subset of SQL(SQLite), some features are eliminated to:
+Kuneiform SQL is a subset of SQL, some features are eliminated to:
 * keep it simple while still useful
 * keep it deterministic
 * restrict resource usage

--- a/internal/engine/ddl/index.go
+++ b/internal/engine/ddl/index.go
@@ -7,7 +7,7 @@ import (
 	types "github.com/kwilteam/kwil-db/common"
 )
 
-func indexTypeToSQLiteString(indexType types.IndexType) (string, error) {
+func indexTypeToSQLString(indexType types.IndexType) (string, error) {
 	err := indexType.Clean()
 	if err != nil {
 		return "", err
@@ -29,7 +29,7 @@ func GenerateCreateIndexStatements(pgSchema, tableName string, indexes []*types.
 	var statements []string
 
 	for _, index := range indexes {
-		indexType, err := indexTypeToSQLiteString(index.Type)
+		indexType, err := indexTypeToSQLString(index.Type)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
We don't support genesis-hash computation with postgres yet. Disable the command.

Also fix the reset command so it does not try to delete the old sqlite path, which no longer exists.

Finally, clean-up old SQLite mentions and example configs.