### PR TITLE
fix integraion test locally parallel issue

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: jchappelow/kwil-postgres:latest
+        image: kwildb/postgres:latest
         env:
           POSTGRES_PORT: 5432
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -77,7 +77,7 @@ jobs:
         with:
           install-mode: "binary"
           version: "latest"
-          #skip-cache: true
+          skip-pkg-cache: true
           args: ./... ./core/... ./test/... ./parse/... --timeout=10m --config=.golangci.yml --skip-dirs ./core/rpc/protobuf
 
       # unit test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    #runs-on: ubuntu-latest
+#    runs-on: ubuntu-latest
     runs-on: self-hosted
     if: ${{ !github.event.pull_request.draft }} # only run on non-draft PRs
 
@@ -31,18 +31,14 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: true
-          token: ${{ secrets.KWIL_MACH_SECRET }}
 
       - name: Install Protoc
         uses: arduino/setup-protoc@v3
         with:
           version: '23.4'
-          repo-token: ${{ secrets.KWIL_MACH_SECRET }}
 
       - name: Install Taskfile
         uses: arduino/setup-task@v2
-        with:
-          repo-token: ${{ secrets.KWIL_MACH_SECRET }}
 
       #ubuntu-latest has go 1.21 installed https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md#go
       #self-hosted also has go 1.21 installed
@@ -55,11 +51,8 @@ jobs:
           cache: false
 
       - name: Install dependencies
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.KWIL_MACH_SECRET }}
         run: |
           go version
-          git config --global url."https://${GH_ACCESS_TOKEN}:x-oauth-basic@github.com/kwilteam/".insteadOf "https://github.com/kwilteam/"
           task install:deps
 
       # checks
@@ -132,17 +125,23 @@ jobs:
           docker pull kwilbrennan/extensions-math:multi-arch --platform linux/amd64
 
       - name: Pull kgw repo & create vendor
+        env:
+          GH_ACCESS_TOKEN: ${{ secrets.KWIL_MACH_SECRET }}
         # we only pull the repo, not build the image, because we want to use the cache
         # provided by the docker/build-push-action
         # vendor is used to bypass private repo issues
         # TODO: in go 1.22, there is a "go work vendor" that we can try instead of GOWORK=off
         run: |
+          git config --global url."https://${GH_ACCESS_TOKEN}:x-oauth-basic@github.com/kwilteam/".insteadOf
+          "https://github.com/kwilteam/"
           rm -rf /tmp/kgw
           git clone https://github.com/kwilteam/kgw.git /tmp/kgw
           cd /tmp/kgw
           git checkout action-call-workaround # REMOVE!
           GOWORK=off go mod vendor
           cd -
+          git config --global unset url
+
 
       - name: Build kgw image
         id: docker_build_kgw
@@ -182,7 +181,7 @@ jobs:
           testGroupID=$(id -g)
           cp test/acceptance/docker-compose.override.yml.example test/acceptance/docker-compose.override.yml
           sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/acceptance/docker-compose.override.yml
-          KACT_LOG_LEVEL=warn task test:act:nb -- -parallel-mode
+          KACT_LOG_LEVEL=warn task test:act:nb -parallel-mode -parallel 2
 
       - name: Run integration test
         # CI machine is more powerful, no need to set parallel limit
@@ -191,7 +190,7 @@ jobs:
           testGroupID=$(id -g)
           cp test/integration/docker-compose.override.yml.example test/integration/docker-compose.override.yml
           sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/integration/docker-compose.override.yml
-          KIT_LOG_LEVEL=warn go test -count=1 -timeout 0 ./test/integration -v -parallel-mode
+          KIT_LOG_LEVEL=warn go test -count=1 -timeout 0 ./test/integration -v -parallel-mode -parallel 2
 
       - name: Move cache
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,7 +8,6 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
-#    runs-on: self-hosted
     if: ${{ !github.event.pull_request.draft }} # only run on non-draft PRs
 
     services:
@@ -124,38 +123,6 @@ jobs:
         run: |
           docker pull kwilbrennan/extensions-math:multi-arch --platform linux/amd64
 
-      - name: Pull kgw repo & create vendor
-        env:
-          GH_ACCESS_TOKEN: ${{ secrets.KWIL_MACH_SECRET }}
-        # we only pull the repo, not build the image, because we want to use the cache
-        # provided by the docker/build-push-action
-        # vendor is used to bypass private repo issues
-        # TODO: in go 1.22, there is a "go work vendor" that we can try instead of GOWORK=off
-        run: |
-          git config --global url."https://${GH_ACCESS_TOKEN}:x-oauth-basic@github.com/kwilteam/".insteadOf
-          "https://github.com/kwilteam/"
-          rm -rf /tmp/kgw
-          git clone https://github.com/kwilteam/kgw.git /tmp/kgw
-          cd /tmp/kgw
-          git checkout action-call-workaround # REMOVE!
-          GOWORK=off go mod vendor
-          cd -
-          git config --global unset url
-
-
-      - name: Build kgw image
-        id: docker_build_kgw
-        uses: docker/build-push-action@v5
-        with:
-          context: /tmp/kgw
-          load: true
-          builder: ${{ steps.buildx.outputs.name }}
-          file: /tmp/kgw/Dockerfile
-          push: false
-          tags: kgw:latest
-          cache-from: type=local,src=/tmp/.buildx-cache-kgw
-          cache-to: type=local,dest=/tmp/.buildx-cache-kgw-new
-
       - name: Build kwild image
         id: docker_build_kwild
         uses: docker/build-push-action@v5
@@ -184,13 +151,13 @@ jobs:
           KACT_LOG_LEVEL=warn task test:act:nb -parallel-mode -parallel 2
 
       - name: Run integration test
-        # CI machine is more powerful, no need to set parallel limit
+        # without kgw test, probably should disable this ?
         run: |
           testUserID=$(id -u)
           testGroupID=$(id -g)
           cp test/integration/docker-compose.override.yml.example test/integration/docker-compose.override.yml
           sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/integration/docker-compose.override.yml
-          KIT_LOG_LEVEL=warn go test -count=1 -timeout 0 ./test/integration -v -parallel-mode -parallel 2
+          KIT_LOG_LEVEL=warn task test:it:nb -- -parallel-mode -parallel 2
 
       - name: Move cache
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -47,7 +47,7 @@ jobs:
         with:
           go-version: '1.22.x'
           check-latest: true
-          cache: false
+          #cache: false
 
       - name: Install dependencies
         run: |
@@ -77,7 +77,7 @@ jobs:
         with:
           install-mode: "binary"
           version: "latest"
-          skip-cache: true
+          #skip-cache: true
           args: ./... ./core/... ./test/... ./parse/... --timeout=10m --config=.golangci.yml --skip-dirs ./core/rpc/protobuf
 
       # unit test

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -185,12 +185,13 @@ jobs:
           KACT_LOG_LEVEL=warn task test:act:nb -- -parallel-mode
 
       - name: Run integration test
+        # CI machine is more powerful, no need to set parallel limit
         run: |
           testUserID=$(id -u)
           testGroupID=$(id -g)
           cp test/integration/docker-compose.override.yml.example test/integration/docker-compose.override.yml
           sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/integration/docker-compose.override.yml
-          KIT_LOG_LEVEL=warn task test:it:nb:all -- -parallel-mode
+          KIT_LOG_LEVEL=warn go test -count=1 -timeout 0 ./test/integration -v -parallel-mode
 
       - name: Move cache
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,8 +7,8 @@ on:
 
 jobs:
   test:
-#    runs-on: ubuntu-latest
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
+#    runs-on: self-hosted
     if: ${{ !github.event.pull_request.draft }} # only run on non-draft PRs
 
     services:

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,8 +98,7 @@ jobs:
         uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache-kwild
-          #key: ${{ runner.os }}-buildx-kwild-${{ github.sha }}
-          key: ${{ runner.os }}-buildx-kwild
+          key: ${{ runner.os }}-buildx-kwild-${{ github.sha }}
           restore-keys: |
             ${{ runner.os }}-buildx-kwild
 
@@ -148,7 +147,7 @@ jobs:
           testGroupID=$(id -g)
           cp test/acceptance/docker-compose.override.yml.example test/acceptance/docker-compose.override.yml
           sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/acceptance/docker-compose.override.yml
-          KACT_LOG_LEVEL=warn task test:act:nb -parallel-mode -parallel 2
+          KACT_LOG_LEVEL=warn task test:act:nb -- -parallel-mode -parallel 2
 
       - name: Run integration test
         # without kgw test, probably should disable this ?
@@ -163,8 +162,6 @@ jobs:
         run: |
           rm -rf /tmp/.buildx-cache-kwild
           mv /tmp/.buildx-cache-kwild-new /tmp/.buildx-cache-kwild
-          rm -rf /tmp/.buildx-cache-kgw
-            mv /tmp/.buildx-cache-kgw-new /tmp/.buildx-cache-kgw
 
       - name: Prune Docker
         if: ${{ always() }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -243,11 +243,11 @@ tasks:
   test:it:nb:
     desc: Run integration tests ('short' mode)
     dir: test # different module
-    cmds:
-      - go test -short -count=1 -timeout 0 ./integration -v -p 4 {{.CLI_ARGS}}
+    cmds: # parallel limit(-parallel 5) is needed in local dev workflow
+      - go test -short -count=1 -timeout 0 ./integration -v -parallel 5 {{.CLI_ARGS}}
 
   test:it:nb:all:
     desc: Run integration tests
     dir: test # different module
     cmds:
-      - go test -count=1 -timeout 0 ./integration -v -p 4 {{.CLI_ARGS}}
+      - go test -count=1 -timeout 0 ./integration -v -parallel 5 {{.CLI_ARGS}}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -196,7 +196,7 @@ tasks:
   # e.g.
   # - task test:act:nb -- -remote
   # - task test:act:nb -- -drivers grpc
-  # - task test:act:nb -- -parallel-mode
+  # - task test:act:nb -- -parallel-mode -parallel 2
   test:act:nb:
     desc: Run acceptance tests without building docker image
     dir: test # different module
@@ -243,11 +243,11 @@ tasks:
   test:it:nb:
     desc: Run integration tests ('short' mode)
     dir: test # different module
-    cmds: # parallel limit(-parallel 5) is needed in local dev workflow
-      - go test -short -count=1 -timeout 0 ./integration -v -parallel 5 {{.CLI_ARGS}}
+    cmds:
+      - go test -short -count=1 -timeout 0 ./integration -v {{.CLI_ARGS}}
 
   test:it:nb:all:
     desc: Run integration tests
     dir: test # different module
     cmds:
-      - go test -count=1 -timeout 0 ./integration -v -parallel 5 {{.CLI_ARGS}}
+      - go test -count=1 -timeout 0 ./integration -v {{.CLI_ARGS}}

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -255,7 +255,7 @@ func (r *IntHelper) LoadConfig() {
 		GanacheComposeFile:        getEnv("KIT_GANACHE_COMPOSE_FILE", "./ganache-docker-compose.yml"),
 	}
 
-	waitTimeout := getEnv("KIT_WAIT_TIMEOUT", "10s")
+	waitTimeout := getEnv("KIT_WAIT_TIMEOUT", "20s")
 	r.cfg.WaitTimeout, err = time.ParseDuration(waitTimeout)
 	require.NoError(r.t, err, "invalid wait timeout")
 


### PR DESCRIPTION
This fix the issue running integration test locally in parallel mode:
- increase default testcontainer wait timeout to 20s
- use correct test flag `parallel` to control the maximum number of tests to run simultaneously
- no parallel number control on CI, since CI machine is more powerful, and we expect test to finish asap