### PR TITLE
fix gateway client auth error

### DIFF
--- a/core/rpc/client/gateway/http/client.go
+++ b/core/rpc/client/gateway/http/client.go
@@ -78,14 +78,13 @@ func (g *GatewayHttpClient) Auth(ctx context.Context, auth *types.GatewayAuth) e
 	}
 	defer res.Body.Close()
 
-	if res.StatusCode != http.StatusOK {
-		return errors.Join(rpcClient.ErrNotFound, errors.New(res.Status))
-	}
+	// standard http error(not from the gateway)
+	fallbackErr := errors.New(res.Status)
 
 	var r gatewayAuthPostResponse
 	err = json.NewDecoder(res.Body).Decode(&r)
 	if err != nil {
-		return err
+		return errors.Join(fallbackErr, err)
 	}
 
 	if r.Error != "" {


### PR DESCRIPTION
This pr fix the gateway error message, it will try to output error detail returned by gateway

Before:
```
Do you want to sign this message?: y
authentication failed: gateway auth: not found
401 Unauthorized
```

After:
```
Do you want to sign this message?: y
authentication failed: gateway auth: invalid signature
```

**NOTE**: this should be back-ported to v0.6