### PR TITLE
[release-v0.7] deps: remove replace directives and tests in non-workspace mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -158,7 +158,7 @@ jobs:
           testGroupID=$(id -g)
           cp test/acceptance/docker-compose.override.yml.example test/acceptance/docker-compose.override.yml
           sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/acceptance/docker-compose.override.yml
-          KACT_LOG_LEVEL=warn task test:act:nb -- -parallel-mode -parallel 2
+          KACT_LOG_LEVEL=warn task test:act:nb -- -parallel-mode -parallel 1
 
       - name: Run integration test
         # without kgw test, probably should disable this ?
@@ -167,7 +167,7 @@ jobs:
           testGroupID=$(id -g)
           cp test/integration/docker-compose.override.yml.example test/integration/docker-compose.override.yml
           sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/integration/docker-compose.override.yml
-          KIT_LOG_LEVEL=warn task test:it:nb -- -parallel-mode -parallel 2
+          KIT_LOG_LEVEL=warn task test:it:nb -- -parallel-mode -parallel 1
 
       - name: Move cache
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -68,17 +68,28 @@ jobs:
           ./scripts/swagger/check_up
 
       - name: Compile packages, apps, and specs
-        run: | # enter workspace mode to do this on one line
-          go work init && go work use . ./parse ./test ./core
-          go build -mod=readonly ./... ./parse/... ./core/... ./test/specifications/
+        run: |
+          go build -mod=readonly ./...
+          (cd parse; go build -mod=readonly ./...)
+          (cd core; go build -mod=readonly ./...)
 
-      - name: Lint
+      - name: Install Linter
         uses: golangci/golangci-lint-action@v4.0.0
         with:
           install-mode: "binary"
           version: "latest"
           skip-pkg-cache: true
-          args: ./... ./core/... ./test/... ./parse/... --timeout=10m --config=.golangci.yml --skip-dirs ./core/rpc/protobuf
+          # golangci-lint needs to be run separately for every Go module, and
+          # its GitHub Action doesn't provide any way to do that. Have it fetch
+          # the golangci-lint binary, trick it into not running by sending only
+          # `--help`, then run the full set of lints below. DO NOT run separate
+          # modules as separate golangci-lint-action steps. Its post run caching
+          # can be extremely slow, and that's amplified in a very painful way if
+          # it needs to be run multiple times.
+          args: --help
+
+      - name: Lint
+        run: task lint
 
       # unit test
       - name: Run unit test

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -63,8 +63,11 @@ tasks:
   lint:
     desc: Lint with golangci-lint
     cmds:
-      # skip-dirs only works in .yaml
-      - golangci-lint run ./... ./core/... ./test/... ./parse/... -c .golangci.yml
+      - |
+        golangci-lint run ./... -c .golangci.yml
+        (cd core; golangci-lint run ./... --skip-dirs rpc/http -c ../.golangci.yml)
+        (cd test; golangci-lint run ./...  -c ../.golangci.yml)
+        (cd parse; golangci-lint run ./... -c ../.golangci.yml)
 
   linter:
     desc: Install the linter (not for CI which has an action for this)
@@ -235,15 +238,15 @@ tasks:
   test:unit:
     desc: Run unit tests
     cmds:
-      - go test ./core/... -tags=ext_test -count=1
-      - CGO_ENABLED=1 go test ./parse/... -tags=ext_test -count=1
+      - (cd core; go test ./... -tags=ext_test -count=1)
+      - (cd parse; CGO_ENABLED=1 go test ./... -tags=ext_test -count=1)
       - CGO_ENABLED=1 go test ./... -tags=ext_test,pglive -count=1 -p=1 # no parallel for now because several try to use one pg database
 
   test:unit:race:
     desc: Run unit tests with the race detector
     cmds:
-      - go test ./core/... -tags=ext_test -count=1 -race
-      - CGO_ENABLED=1 go test ./parse/... -tags=ext_test -count=1 -race
+      - (cd core; go test ./... -tags=ext_test -count=1 -race)
+      - (cd parse; CGO_ENABLED=1 go test ./... -tags=ext_test -count=1 -race)
       - CGO_ENABLED=1 go test ./... -tags=ext_test -count=1 -race
 
   test:it:

--- a/go.mod
+++ b/go.mod
@@ -2,11 +2,6 @@ module github.com/kwilteam/kwil-db
 
 go 1.21
 
-replace (
-	github.com/kwilteam/kwil-db/core => ./core
-	github.com/kwilteam/kwil-db/parse => ./parse
-)
-
 require (
 	dario.cat/mergo v1.0.0
 	github.com/alexliesenfeld/health v0.6.0

--- a/go.sum
+++ b/go.sum
@@ -276,6 +276,10 @@ github.com/kwilteam/action-grammar-go v0.1.0 h1:pAjWZUYlDwQUWpQz5uOPQDIz1TLWXyLY
 github.com/kwilteam/action-grammar-go v0.1.0/go.mod h1:hHGHtnrJpASW9P+F7pdr/EP2M1Hxy1N9Wx/TmjVdV6I=
 github.com/kwilteam/kuneiform v0.6.0 h1:Y8VWrJN1cl9idqX+LBSQd+c3m/JjDDRInBSKq3i27NY=
 github.com/kwilteam/kuneiform v0.6.0/go.mod h1:b3Ce6falEDBQ0xgLpa/hjFjUQoD8aFEg96yewS/3wzg=
+github.com/kwilteam/kwil-db/core v0.1.0 h1:Me06sWMeqPw0Wl7yrS/OMqaLL6YpQ6qkPKjA9XXVCr8=
+github.com/kwilteam/kwil-db/core v0.1.0/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
+github.com/kwilteam/kwil-db/parse v0.1.1 h1:NGydeWRpACUOpi+KkVyqtWHPzwPzjeM5FTBL3yTBFqo=
+github.com/kwilteam/kwil-db/parse v0.1.1/go.mod h1:dcCGZsaGzZmRDv1l0TPHoHRLt1IFYiFs/yyuO56t95Y=
 github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7 h1:YiPBu0pOeYOtOVfwKQqdWB07SUef9LvngF4bVFD+x34=
 github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7/go.mod h1:+BrFrV+3qcdYIfptqjwatE5gT19azuRHJzw77wMPY8c=
 github.com/kwilteam/sql-grammar-go v0.1.0 h1:rSS7DER9PWVDmFwNyoInG5oXrn+E9UrZkjref84L4Qk=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0.7.0-pre"
+const kwilVersion = "0.7.0-rc.1"
 
 // KwildVersion may be set at compile time by:
 //

--- a/test/go.mod
+++ b/test/go.mod
@@ -2,14 +2,6 @@ module github.com/kwilteam/kwil-db/test
 
 go 1.21
 
-// During development cycle, use the workspace kwil-db module. Remove this after
-// tagging kwil-db module.
-replace (
-	github.com/kwilteam/kwil-db => ../
-	github.com/kwilteam/kwil-db/core => ../core
-	github.com/kwilteam/kwil-db/parse => ../parse
-)
-
 require (
 	github.com/cometbft/cometbft v0.38.5
 	github.com/cstockton/go-conv v1.0.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -476,6 +476,12 @@ github.com/kwilteam/action-grammar-go v0.1.0 h1:pAjWZUYlDwQUWpQz5uOPQDIz1TLWXyLY
 github.com/kwilteam/action-grammar-go v0.1.0/go.mod h1:hHGHtnrJpASW9P+F7pdr/EP2M1Hxy1N9Wx/TmjVdV6I=
 github.com/kwilteam/kuneiform v0.6.0 h1:Y8VWrJN1cl9idqX+LBSQd+c3m/JjDDRInBSKq3i27NY=
 github.com/kwilteam/kuneiform v0.6.0/go.mod h1:b3Ce6falEDBQ0xgLpa/hjFjUQoD8aFEg96yewS/3wzg=
+github.com/kwilteam/kwil-db v0.7.0-beta.0.20240301172606-26b70b87eba0 h1:iTI03CYyyXxMTcrjYxjeLQy4iNnXQkz9JHivbBDv7CQ=
+github.com/kwilteam/kwil-db v0.7.0-beta.0.20240301172606-26b70b87eba0/go.mod h1:ODw765YX9cXPcPEZh66j4ML+1X6Uz+7Japdys2X/jFY=
+github.com/kwilteam/kwil-db/core v0.1.0 h1:Me06sWMeqPw0Wl7yrS/OMqaLL6YpQ6qkPKjA9XXVCr8=
+github.com/kwilteam/kwil-db/core v0.1.0/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
+github.com/kwilteam/kwil-db/parse v0.1.1 h1:NGydeWRpACUOpi+KkVyqtWHPzwPzjeM5FTBL3yTBFqo=
+github.com/kwilteam/kwil-db/parse v0.1.1/go.mod h1:dcCGZsaGzZmRDv1l0TPHoHRLt1IFYiFs/yyuO56t95Y=
 github.com/kwilteam/sql-grammar-go v0.1.0 h1:rSS7DER9PWVDmFwNyoInG5oXrn+E9UrZkjref84L4Qk=
 github.com/kwilteam/sql-grammar-go v0.1.0/go.mod h1:A9AXaH5Vl/uPsY88fWqvU9O7z7P4YfvndaGyc8s//2s=
 github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0SNc=


### PR DESCRIPTION
In preparation for a release version with importable packages and go install'able applications, this removes the `replace` directives from the main module's go.mod.

This also removes the replace directives from the `test` module so that it tests what is actually built, not just what is in the git workspace.

With the replaces removed from the go.mod files, development on `release-v0.6` branch may require a go.work with `replace` directives in it.  However, if a build fails or CI fails without any replaces in go.mod or a go.work, that indicates we probably have to tag either the `core` or `parse` submodules and then update the main module's go.mod `require` on it.