### PR TITLE
kgw: handle __Host- prefix in https

### DIFF
--- a/core/gatewayclient/client.go
+++ b/core/gatewayclient/client.go
@@ -57,7 +57,7 @@ func (acj *customAuthCookieJar) SetCookies(u *url.URL, cookies []*http.Cookie) {
 		return
 	}
 	for _, c := range cookies {
-		if c.Name == kgwAuthCookieName {
+		if c.Name == kgwAuthCookieName || c.Name == kgwAuthCookieNameSecure {
 			acj.handleAuthCookie(c)
 		}
 	}
@@ -192,7 +192,7 @@ func (c *GatewayClient) SetAuthCookie(cookie *http.Cookie) error {
 	if cookie.Domain != "" && cookie.Domain != c.target.Host {
 		return fmt.Errorf("cookie domain %s not valid for host %s", cookie.Domain, c.target.Host)
 	}
-	if cookie.Name != kgwAuthCookieName {
+	if cookie.Name != kgwAuthCookieName && cookie.Name != kgwAuthCookieNameSecure {
 		return fmt.Errorf("cookie name %s not valid", cookie.Name)
 	}
 

--- a/core/gatewayclient/msg.go
+++ b/core/gatewayclient/msg.go
@@ -24,8 +24,9 @@ import (
 //    authentication required endpoints.
 
 const (
-	kgwAuthVersion    = "1"
-	kgwAuthCookieName = "kgw_session"
+	kgwAuthVersion          = "1"
+	kgwAuthCookieName       = "kgw_session"
+	kgwAuthCookieNameSecure = "__Host-" + kgwAuthCookieName
 )
 
 // GatewayAuthSignFunc is the function that signs the authentication message.


### PR DESCRIPTION
kwilteam/kgw#18
This add support for kgw cookie prefix for https. 

NOTE: This needs to be back ported to v0.6.6