### PR TITLE
removed circular abci import

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,7 +31,6 @@ builds:
     tags:
       - osusergo
       - netgo
-      - auth_nep413
     env:
       - CGO_ENABLED=0
 

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -31,6 +31,7 @@ builds:
     tags:
       - osusergo
       - netgo
+      - auth_nep413
     env:
       - CGO_ENABLED=0
 

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -107,7 +107,6 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 
 	eventBroadcaster := buildEventBroadcaster(d, ev, wrappedCmtClient, txApp)
 	abciApp.SetEventBroadcaster(eventBroadcaster.RunBroadcast)
-	abciApp.SetValidatorGetter(wrappedCmtClient.GetValidators)
 	// oracle manager
 	om := buildOracleManager(d, closers, ev, cometBftNode, txApp)
 

--- a/cmd/kwild/server/utils.go
+++ b/cmd/kwild/server/utils.go
@@ -8,7 +8,6 @@ import (
 	"math"
 	"strings"
 
-	ctypes "github.com/kwilteam/kwil-db/core/types"
 	types "github.com/kwilteam/kwil-db/core/types/admin"
 	"github.com/kwilteam/kwil-db/extensions/actions"
 	"github.com/kwilteam/kwil-db/internal/abci"
@@ -179,25 +178,6 @@ func (wc *wrappedCometBFTClient) TxQuery(ctx context.Context, hash []byte, prove
 		}
 	}
 	return nil, abci.ErrTxNotFound
-}
-
-// GetValidators returns the current validator set at the given height by the CometBFT.
-// If height is nil, it returns the validator set at the last committed height.
-func (wc *wrappedCometBFTClient) GetValidators(ctx context.Context, height *int64) ([]*ctypes.Validator, error) {
-	res, err := wc.cl.Validators(ctx, height, nil, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	vals := make([]*ctypes.Validator, len(res.Validators))
-	for i, v := range res.Validators {
-		vals[i] = &ctypes.Validator{
-			PubKey: v.PubKey.Bytes(),
-			Power:  v.VotingPower,
-		}
-	}
-
-	return vals, nil
 }
 
 // atomicReadWriter implements the CometBFT AtomicReadWriter interface.

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -61,6 +61,8 @@ func NewAbciApp(cfg *AbciConfig, kv KVStore, snapshotter SnapshotModule,
 		consensusParams: consensusParams,
 
 		log: log,
+
+		validatorAddressToPubKey: make(map[string][]byte),
 	}
 
 	return app
@@ -109,7 +111,9 @@ type AbciApp struct {
 	consensusParams *txapp.ConsensusParams
 
 	broadcastFn EventBroadcaster
-	validatorFn ValidatorGetter
+
+	// validatorAddressToPubKey is a map of validator addresses to their public keys
+	validatorAddressToPubKey map[string][]byte
 }
 
 func (a *AbciApp) ChainID() string {
@@ -217,18 +221,13 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 // FinalizeBlock is on the consensus connection
 func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinalizeBlock) (*abciTypes.ResponseFinalizeBlock, error) {
 	fmt.Printf("\n\n")
-	logger := a.log.With(zap.String("stage", "ABCI FinalizeBlock"), zap.Int("height", int(req.Height)))
+	logger := a.log.With(zap.String("stage", "ABCI FinalizeBlock"), zap.Int64("height", req.Height))
 
 	res := &abciTypes.ResponseFinalizeBlock{}
 
 	err := a.txApp.Begin(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("begin tx commit failed: %w", err)
-	}
-
-	valAddrMap, err := a.getValidatorPubKeyAddrMap(ctx, &req.Height)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get validator address map: %w", err)
 	}
 
 	initialValidators, err := a.txApp.GetValidators(ctx)
@@ -246,7 +245,7 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 		logger.Info("punish validator", zap.String("addr", addr))
 
 		// This is why we need the addr=>pubkey map. Why, comet, why?
-		pubkey, ok := valAddrMap[addr]
+		pubkey, ok := a.validatorAddressToPubKey[addr]
 		if !ok {
 			return nil, fmt.Errorf("unknown validator address %v", addr)
 		}
@@ -259,7 +258,7 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 	}
 
 	addr := proposerAddrToString(req.ProposerAddress)
-	proposerPubKey, ok := valAddrMap[addr]
+	proposerPubKey, ok := a.validatorAddressToPubKey[addr]
 	if !ok {
 		return nil, fmt.Errorf("failed to find proposer pubkey corresponding to address %v", addr)
 	}
@@ -318,6 +317,16 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 
 	res.ValidatorUpdates = make([]abciTypes.ValidatorUpdate, len(valUpdates))
 	for i, up := range valUpdates {
+		addr, err := pubkeyToAddr(up.PubKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert pubkey to address: %w", err)
+		}
+		if up.Power == 0 {
+			delete(a.validatorAddressToPubKey, addr)
+		} else {
+			a.validatorAddressToPubKey[addr] = up.PubKey // there may be new validators we need to add
+		}
+
 		res.ValidatorUpdates[i] = abciTypes.Ed25519ValidatorUpdate(up.PubKey, up.Power)
 	}
 
@@ -408,6 +417,20 @@ func (a *AbciApp) Info(ctx context.Context, _ *abciTypes.RequestInfo) (*abciType
 		return nil, fmt.Errorf("failed to get block height: %w", err)
 	}
 
+	validators, err := a.txApp.GetValidators(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validators: %w", err)
+	}
+
+	for _, val := range validators {
+		addr, err := pubkeyToAddr(val.PubKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert pubkey to address: %w", err)
+		}
+
+		a.validatorAddressToPubKey[addr] = val.PubKey
+	}
+
 	appHash, err := a.metadataStore.GetAppHash(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get app hash: %w", err)
@@ -452,6 +475,13 @@ func (a *AbciApp) InitChain(ctx context.Context, req *abciTypes.RequestInitChain
 			PubKey: pk,
 			Power:  vi.Power,
 		}
+
+		addr, err := pubkeyToAddr(pk)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert pubkey to address: %w", err)
+		}
+
+		a.validatorAddressToPubKey[addr] = pk
 	}
 
 	if err := a.txApp.GenesisInit(ctx, vldtrs, genesisAllocs, req.InitialHeight); err != nil {
@@ -700,12 +730,16 @@ func (a *AbciApp) PrepareProposal(ctx context.Context, req *abciTypes.RequestPre
 		zap.Int64("height", req.Height),
 		zap.Int("txs", len(req.Txs)))
 
-	addr, err := a.getValidatorPubKeyByAddr(ctx, proposerAddrToString(req.ProposerAddress), &req.Height)
-	if err != nil {
-		return nil, fmt.Errorf("failed to find proposer pubkey corresponding to %s", proposerAddrToString(req.ProposerAddress))
+	pubKey, ok := a.validatorAddressToPubKey[proposerAddrToString(req.ProposerAddress)]
+	if !ok {
+		// there is an edge case where cometbft will allow a node to PrepareProposal
+		// even if it is not a validator, if it was a validator in the most recent block
+		// we check for this here and do not propose if the node is not a validator
+		// we will also need to check for this in ProcessProposal, in case of byzantine behavior
+		return nil, fmt.Errorf("unknown proposer: failed to find proposer pubkey corresponding to address %v", req.ProposerAddress)
 	}
 
-	okTxns, proposerNonce := a.prepareMempoolTxns(req.Txs, int(req.MaxTxBytes), &a.log, addr)
+	okTxns, proposerNonce := a.prepareMempoolTxns(req.Txs, int(req.MaxTxBytes), &a.log, pubKey)
 	if len(okTxns) != len(req.Txs) {
 		logger.Info("PrepareProposal: number of transactions in proposed block has changed!",
 			zap.Int("in", len(req.Txs)), zap.Int("out", len(okTxns)))
@@ -717,7 +751,7 @@ func (a *AbciApp) PrepareProposal(ctx context.Context, req *abciTypes.RequestPre
 		}
 	}
 
-	bal, nonce, err := a.txApp.AccountInfo(ctx, addr, false)
+	bal, nonce, err := a.txApp.AccountInfo(ctx, pubKey, false)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get proposer account: %w", err)
 	}
@@ -815,11 +849,12 @@ func (a *AbciApp) ProcessProposal(ctx context.Context, req *abciTypes.RequestPro
 		zap.Int64("height", req.Height),
 		zap.Int("txs", len(req.Txs)))
 
-	addr := proposerAddrToString(req.ProposerAddress)
-	proposerPubKey, err := a.getValidatorPubKeyByAddr(ctx, addr, &req.Height)
-	if err != nil {
-		a.log.Warn("received block proposal from unknown validator", zap.String("addr", addr))
-		return &abciTypes.ResponseProcessProposal{Status: abciTypes.ResponseProcessProposal_REJECT}, nil
+	proposerPubKey, ok := a.validatorAddressToPubKey[proposerAddrToString(req.ProposerAddress)]
+	if !ok {
+		// there is an edge case where cometbft will allow a node to PrepareProposal
+		// even if it is not a validator, if it was a validator in the most recent block.
+		// we should therefore reject the proposal if the proposer is not a validator.
+		return nil, fmt.Errorf("unknown proposer: failed to find proposer pubkey corresponding to address %v", req.ProposerAddress)
 	}
 
 	if err := a.validateProposalTransactions(ctx, req.Txs, proposerPubKey); err != nil {
@@ -847,42 +882,6 @@ func (a *AbciApp) createNewAppHash(ctx context.Context, addition []byte) ([]byte
 
 	err = a.metadataStore.SetAppHash(ctx, newHash)
 	return newHash, err
-}
-
-func (a *AbciApp) getValidatorPubKeyByAddr(ctx context.Context, addr string, height *int64) ([]byte, error) {
-	vals, err := a.validatorFn(ctx, height)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, val := range vals {
-		valAddr, err := pubkeyToAddr(val.PubKey)
-		if err != nil {
-			return nil, fmt.Errorf("invalid validator pubkey: %w", err)
-		}
-
-		if addr == valAddr {
-			return val.PubKey, nil
-		}
-	}
-	return nil, fmt.Errorf("validator not found for address %s", addr)
-}
-
-func (a *AbciApp) getValidatorPubKeyAddrMap(ctx context.Context, height *int64) (map[string][]byte, error) {
-	vals, err := a.validatorFn(ctx, height)
-	if err != nil {
-		return nil, err
-	}
-
-	addrMap := make(map[string][]byte)
-	for _, val := range vals {
-		addr, err := pubkeyToAddr(val.PubKey)
-		if err != nil {
-			return nil, fmt.Errorf("invalid validator pubkey: %w", err)
-		}
-		addrMap[addr] = val.PubKey
-	}
-	return addrMap, nil
 }
 
 // TODO: here should probably be other apphash computations such as the genesis
@@ -945,7 +944,3 @@ func (a *AbciApp) SetEventBroadcaster(fn EventBroadcaster) {
 }
 
 type ValidatorGetter func(ctx context.Context, height *int64) ([]*types.Validator, error)
-
-func (a *AbciApp) SetValidatorGetter(fn ValidatorGetter) {
-	a.validatorFn = fn
-}

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -943,5 +943,3 @@ type EventBroadcaster func(ctx context.Context, proposer []byte) error
 func (a *AbciApp) SetEventBroadcaster(fn EventBroadcaster) {
 	a.broadcastFn = fn
 }
-
-type ValidatorGetter func(ctx context.Context, height *int64) ([]*types.Validator, error)


### PR DESCRIPTION
As discussed in Slack, I have removed the circular imports between abci and cometbft. We now simply will:
a. not propose a block if the local node is not a validator in the application
b. reject blocks proposed by nodes that the application does not recognize as validators

