### PR TITLE
accounts: mock DB

### DIFF
--- a/common/sql/sql.go
+++ b/common/sql/sql.go
@@ -14,8 +14,7 @@ var (
 // It has root user access, and can execute any Postgres command.
 type DB interface {
 	Executor
-	// BeginTx starts a new transaction.
-	BeginTx(ctx context.Context) (Tx, error)
+	TxMaker
 	// AccessMode gets the access mode of the database.
 	// It can be either read-write or read-only.
 	AccessMode() AccessMode

--- a/internal/accounts/accounts_pg_test.go
+++ b/internal/accounts/accounts_pg_test.go
@@ -1,0 +1,48 @@
+//go:build pglive
+
+package accounts
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kwilteam/kwil-db/internal/sql/pg"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_AccountsLive(t *testing.T) {
+	cfg := &pg.DBConfig{
+		PoolConfig: pg.PoolConfig{
+			ConnConfig: pg.ConnConfig{
+				Host:   "127.0.0.1",
+				Port:   "5432",
+				User:   "kwild",
+				Pass:   "kwild", // would be ignored if pg_hba.conf set with trust
+				DBName: "kwil_test_db",
+			},
+			MaxConns: 11,
+		},
+	}
+
+	for _, tc := range acctsTestCases {
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			db, err := pg.NewDB(ctx, cfg)
+			require.NoError(t, err)
+			defer db.Close()
+			tx, err := db.BeginTx(ctx)
+
+			require.NoError(t, err)
+			defer tx.Rollback(ctx) // always rollback to avoid cleanup
+
+			defer db.Execute(ctx, `DROP SCHEMA IF EXISTS `+schemaName+` CASCADE;`)
+
+			err = InitializeAccountStore(ctx, tx)
+			require.NoError(t, err)
+
+			tc.fn(t, tx)
+		})
+	}
+}

--- a/internal/accounts/accounts_test.go
+++ b/internal/accounts/accounts_test.go
@@ -1,5 +1,3 @@
-//go:build pglive
-
 package accounts
 
 import (
@@ -9,286 +7,319 @@ import (
 	"testing"
 
 	sql "github.com/kwilteam/kwil-db/common/sql"
-	"github.com/kwilteam/kwil-db/internal/sql/pg"
+	"github.com/kwilteam/kwil-db/core/types"
 
 	"github.com/stretchr/testify/require"
 )
+
+type mockTx struct {
+	*mockDB
+}
+
+func (m *mockTx) Commit(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockTx) Rollback(ctx context.Context) error {
+	return nil
+}
+
+type mockDB struct {
+	accts map[string]*types.Account //string([]byte{a,c,c,t})
+}
+
+func newDB() *mockDB {
+	return &mockDB{
+		accts: make(map[string]*types.Account),
+	}
+}
+
+func (m *mockDB) AccessMode() sql.AccessMode {
+	return sql.ReadWrite // not use in these tests
+}
+
+func (m *mockDB) BeginTx(ctx context.Context) (sql.Tx, error) {
+	return &mockTx{m}, nil
+}
+
+func (m *mockDB) Execute(ctx context.Context, stmt string, args ...any) (*sql.ResultSet, error) {
+	// mock some expected queries from internal functions
+	switch stmt {
+	case sqlCreateAccount: // via createAccount and createAccountWithNonce
+		id := args[0].([]byte)
+		bal, ok := big.NewInt(0).SetString(args[1].(string), 10)
+		if !ok {
+			return nil, errors.New("not a string balance")
+		}
+		m.accts[string(id)] = &types.Account{
+			Identifier: id,
+			Nonce:      args[2].(int64),
+			Balance:    bal,
+		}
+		return &sql.ResultSet{
+			Status: sql.CommandTag{
+				RowsAffected: 1,
+				Text:         `INSERT ...`,
+			},
+		}, nil
+	case sqlUpdateAccount: // via updateAccount
+		bal, ok := big.NewInt(0).SetString(args[0].(string), 10)
+		if !ok {
+			return nil, errors.New("not a string balance")
+		}
+		id, nonce := args[2].([]byte), args[1].(int64)
+
+		acct, ok := m.accts[string(id)]
+		if !ok {
+			return &sql.ResultSet{
+				Status: sql.CommandTag{
+					RowsAffected: 0,
+					Text:         `UPDATE ...`,
+				},
+			}, nil
+		}
+
+		acct.Balance = bal
+		acct.Nonce = nonce
+
+		return &sql.ResultSet{
+			Status: sql.CommandTag{
+				RowsAffected: 1,
+				Text:         `UPDATE ...`,
+			},
+		}, nil
+	case sqlGetAccount: // via getAccount
+		id := args[0].([]byte)
+		acct, ok := m.accts[string(id)]
+		if !ok {
+			return &sql.ResultSet{}, nil // not ErrNoRows since we don't use Scan in pg
+		}
+		return &sql.ResultSet{
+			Columns: []string{"balance", "nonce"},
+			Rows: [][]any{
+				{acct.Balance.String(), acct.Nonce},
+			},
+		}, nil
+	default:
+		return nil, errors.New("bad query")
+	}
+}
 
 var (
 	account1 = []byte("account1")
 	account2 = []byte("account2")
 )
 
+type acctsTestCase struct {
+	name string
+	fn   func(t *testing.T, db sql.DB)
+}
+
+// once we have a way to increase balances in accounts, we will have to add tests
+// for spending a valid amount
+var acctsTestCases = []acctsTestCase{
+	{
+		name: "credit and debit",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Credit(ctx, db, account1, big.NewInt(-100))
+			require.NoError(t, err)
+		},
+	},
+	{
+		name: "debit non-existent account",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(-100))
+			require.ErrorIs(t, err, ErrNegativeBalance)
+		},
+	},
+	{
+		name: "credit and over-debit",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Credit(ctx, db, account1, big.NewInt(-101))
+			require.ErrorIs(t, err, ErrNegativeBalance)
+		},
+	},
+	{
+		name: "transfer to nonexistent account",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Transfer(ctx, db, account1, account2, big.NewInt(100))
+			require.NoError(t, err)
+
+			acc, err := GetAccount(ctx, db, account1)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(0), acc.Balance)
+
+			acc, err = GetAccount(ctx, db, account2)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(100), acc.Balance)
+		},
+	},
+	{
+		name: "transfer to existing account",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Credit(ctx, db, account2, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Transfer(ctx, db, account1, account2, big.NewInt(50))
+			require.NoError(t, err)
+
+			acc, err := GetAccount(ctx, db, account1)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(50), acc.Balance)
+
+			acc, err = GetAccount(ctx, db, account2)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(150), acc.Balance)
+		},
+	},
+	{
+		name: "transfer negative amount",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Transfer(ctx, db, account1, account2, big.NewInt(-50))
+			require.ErrorIs(t, err, ErrNegativeTransfer)
+		},
+	},
+	{
+		name: "transfer more than you have",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Transfer(ctx, db, account1, account2, big.NewInt(150))
+			require.ErrorIs(t, err, ErrInsufficientFunds)
+		},
+	},
+	{
+		name: "get non existent account",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			acc, err := GetAccount(ctx, db, account1)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(0), acc.Balance)
+			require.Equal(t, int64(0), acc.Nonce)
+		},
+	},
+	{
+		name: "spend from non existent account",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Spend(ctx, db, account1, big.NewInt(100), 1)
+			require.ErrorIs(t, err, ErrAccountNotFound)
+		},
+	},
+	{
+		name: "spend more than you have",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Spend(ctx, db, account1, big.NewInt(101), 1)
+			require.ErrorIs(t, err, ErrInsufficientFunds)
+
+			acc, err := GetAccount(ctx, db, account1)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(100), acc.Balance)
+		},
+	},
+	{
+		name: "spend with invalid nonce",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Spend(ctx, db, account1, big.NewInt(50), 2)
+			require.ErrorIs(t, err, ErrInvalidNonce)
+
+			acc, err := GetAccount(ctx, db, account1)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(100), acc.Balance)
+		},
+	},
+	{
+		name: "valid spend",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Credit(ctx, db, account1, big.NewInt(100))
+			require.NoError(t, err)
+
+			err = Spend(ctx, db, account1, big.NewInt(50), 1)
+			require.NoError(t, err)
+
+			acc, err := GetAccount(ctx, db, account1)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(50), acc.Balance)
+		},
+	},
+	{
+		name: "spend 0 on non-existent account",
+		fn: func(t *testing.T, db sql.DB) {
+			ctx := context.Background()
+
+			err := Spend(ctx, db, account1, big.NewInt(0), 1)
+			require.NoError(t, err)
+
+			acc, err := GetAccount(ctx, db, account1)
+			require.NoError(t, err)
+
+			require.Equal(t, big.NewInt(0), acc.Balance)
+			require.Equal(t, int64(1), acc.Nonce)
+		},
+	},
+}
+
 func Test_Accounts(t *testing.T) {
-	cfg := &pg.DBConfig{
-		PoolConfig: pg.PoolConfig{
-			ConnConfig: pg.ConnConfig{
-				Host:   "127.0.0.1",
-				Port:   "5432",
-				User:   "kwild",
-				Pass:   "kwild", // would be ignored if pg_hba.conf set with trust
-				DBName: "kwil_test_db",
-			},
-			MaxConns: 11,
-		},
-	}
-
-	type testCase struct {
-		name string
-		fn   func(t *testing.T, db sql.DB)
-	}
-
-	// once we have a way to increase balances in accounts, we will have to add tests
-	// for spending a valid amount
-	testCases := []testCase{
-		{
-			name: "credit and debit",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Credit(ctx, db, account1, big.NewInt(-100))
-				require.NoError(t, err)
-			},
-		},
-		{
-			name: "debit non-existent account",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(-100))
-				require.ErrorIs(t, err, ErrNegativeBalance)
-			},
-		},
-		{
-			name: "credit and over-debit",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Credit(ctx, db, account1, big.NewInt(-101))
-				require.ErrorIs(t, err, ErrNegativeBalance)
-			},
-		},
-		{
-			name: "transfer to nonexistent account",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Transfer(ctx, db, account1, account2, big.NewInt(100))
-				require.NoError(t, err)
-
-				acc, err := GetAccount(ctx, db, account1)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(0), acc.Balance)
-
-				acc, err = GetAccount(ctx, db, account2)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(100), acc.Balance)
-			},
-		},
-		{
-			name: "transfer to existing account",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Credit(ctx, db, account2, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Transfer(ctx, db, account1, account2, big.NewInt(50))
-				require.NoError(t, err)
-
-				acc, err := GetAccount(ctx, db, account1)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(50), acc.Balance)
-
-				acc, err = GetAccount(ctx, db, account2)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(150), acc.Balance)
-			},
-		},
-		{
-			name: "transfer negative amount",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Transfer(ctx, db, account1, account2, big.NewInt(-50))
-				require.ErrorIs(t, err, ErrNegativeTransfer)
-			},
-		},
-		{
-			name: "transfer more than you have",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Transfer(ctx, db, account1, account2, big.NewInt(150))
-				require.ErrorIs(t, err, ErrInsufficientFunds)
-			},
-		},
-		{
-			name: "get non existent account",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				acc, err := GetAccount(ctx, db, account1)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(0), acc.Balance)
-				require.Equal(t, int64(0), acc.Nonce)
-			},
-		},
-		{
-			name: "spend from non existent account",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Spend(ctx, db, account1, big.NewInt(100), 1)
-				require.ErrorIs(t, err, ErrAccountNotFound)
-			},
-		},
-		{
-			name: "spend more than you have",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Spend(ctx, db, account1, big.NewInt(101), 1)
-				require.ErrorIs(t, err, ErrInsufficientFunds)
-
-				acc, err := GetAccount(ctx, db, account1)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(100), acc.Balance)
-			},
-		},
-		{
-			name: "spend with invalid nonce",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Spend(ctx, db, account1, big.NewInt(50), 2)
-				require.ErrorIs(t, err, ErrInvalidNonce)
-
-				acc, err := GetAccount(ctx, db, account1)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(100), acc.Balance)
-			},
-		},
-		{
-			name: "valid spend",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Credit(ctx, db, account1, big.NewInt(100))
-				require.NoError(t, err)
-
-				err = Spend(ctx, db, account1, big.NewInt(50), 1)
-				require.NoError(t, err)
-
-				acc, err := GetAccount(ctx, db, account1)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(50), acc.Balance)
-			},
-		},
-		{
-			name: "spend 0 on non-existent account",
-			fn: func(t *testing.T, db sql.DB) {
-				ctx := context.Background()
-
-				err := Spend(ctx, db, account1, big.NewInt(0), 1)
-				require.NoError(t, err)
-
-				acc, err := GetAccount(ctx, db, account1)
-				require.NoError(t, err)
-
-				require.Equal(t, big.NewInt(0), acc.Balance)
-				require.Equal(t, int64(1), acc.Nonce)
-			},
-		},
-	}
-
-	for _, tc := range testCases {
+	for _, tc := range acctsTestCases {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
 
-			db, err := pg.NewDB(ctx, cfg)
-			require.NoError(t, err)
-			defer db.Close()
-			tx, err := db.BeginTx(ctx)
-
-			require.NoError(t, err)
-			defer tx.Rollback(ctx) // always rollback to avoid cleanup
-
-			defer db.Execute(ctx, `DROP SCHEMA IF EXISTS `+schemaName+` CASCADE;`)
-
-			err = InitializeAccountStore(ctx, tx)
-			require.NoError(t, err)
+			db := newDB()
+			tx, _ := db.BeginTx(ctx)
 
 			tc.fn(t, tx)
 		})
-	}
-}
-
-// func newSpend(address string, amount int64, nonce int64) *accounts.Spend {
-// 	return &accounts.Spend{
-// 		AccountID: []byte(address),
-// 		Amount:    big.NewInt(amount),
-// 		Nonce:     nonce,
-// 	}
-// }
-
-// func newAccount(address string, balance int64, nonce int64) *accounts.Account {
-// 	return &accounts.Account{
-// 		Identifier: []byte(address),
-// 		Balance:    big.NewInt(balance),
-// 		Nonce:      nonce,
-// 	}
-// }
-
-func assertErr(t *testing.T, errs []error, target error) {
-	t.Helper()
-	if target == nil {
-		if len(errs) > 0 {
-			t.Fatalf("expected no error, got %s", errs)
-		}
-		return
-	}
-
-	contains := false
-	for _, err := range errs {
-		if errors.Is(err, target) {
-			contains = true
-		}
-	}
-
-	if !contains {
-		t.Fatalf("expected error %s, got %s", target, errs)
 	}
 }

--- a/internal/accounts/sql.go
+++ b/internal/accounts/sql.go
@@ -27,7 +27,7 @@ const (
 	sqlGetAccount = `SELECT balance, nonce FROM ` + schemaName + `.accounts WHERE identifier = $1`
 )
 
-func initTables(ctx context.Context, tx sql.DB) error {
+func initTables(ctx context.Context, tx sql.Executor) error {
 	if _, err := tx.Execute(ctx, sqlCreateSchema); err != nil {
 		return err
 	}
@@ -39,26 +39,26 @@ func initTables(ctx context.Context, tx sql.DB) error {
 }
 
 // updateAccount updates the balance and nonce of an account.
-func updateAccount(ctx context.Context, db sql.DB, ident []byte, amount *big.Int, nonce int64) error {
+func updateAccount(ctx context.Context, db sql.Executor, ident []byte, amount *big.Int, nonce int64) error {
 	_, err := db.Execute(ctx, sqlUpdateAccount, amount.String(), nonce, ident)
 	return err
 }
 
 // createAccount creates an account with the given identifier and
 // initial balance. The nonce will be set to 0.
-func createAccount(ctx context.Context, db sql.DB, ident []byte, amt *big.Int) error {
-	_, err := db.Execute(ctx, sqlCreateAccount, ident, amt.String(), 0)
+func createAccount(ctx context.Context, db sql.Executor, ident []byte, amt *big.Int) error {
+	_, err := db.Execute(ctx, sqlCreateAccount, ident, amt.String(), int64(0))
 	return err
 }
 
-func createAccountWithNonce(ctx context.Context, db sql.DB, ident []byte, amt *big.Int, nonce int64) error {
+func createAccountWithNonce(ctx context.Context, db sql.Executor, ident []byte, amt *big.Int, nonce int64) error {
 	_, err := db.Execute(ctx, sqlCreateAccount, ident, amt.String(), nonce)
 	return err
 }
 
 // getAccount retrieves an account from the database.
 // if the account is not found, it returns nil, ErrAccountNotFound.
-func getAccount(ctx context.Context, db sql.DB, ident []byte) (*types.Account, error) {
+func getAccount(ctx context.Context, db sql.Executor, ident []byte) (*types.Account, error) {
 	results, err := db.Execute(ctx, sqlGetAccount, ident)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
First of several updates so unit tests cover more code without the `pglive` tag.  This tag still exists, but for separate tests to ensure that the queries written are actually compatible and correct with postgres.