### PR TITLE
CI: add print error step

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -166,3 +166,7 @@ jobs:
       - name: Prune Docker
         if: ${{ always() }}
         run: docker rm $(docker ps -a -q) -f ; docker network prune -f ; docker volume prune -f || true
+
+      - name: Show error log
+        if: ${{ failure() }}
+        run: grep -i -r -e 'error' -e 'warn'  /tmp/TestKwilAct*/*.log  /tmp/TestKwilInt*/*.log /tmp/TestKwilInt*/*/*.log


### PR DESCRIPTION
Since we switch back to github's public runner, we no longer have access to the logs for failed test case.
This pr tries to print error if a step fails, by just `grep` the log files