### PR TITLE
config,nodecfg: write out config file in autogen mode

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -169,4 +169,4 @@ jobs:
 
       - name: Show error log
         if: ${{ failure() }}
-        run: grep -s -i -r -e 'kwild version' -e 'error' -e 'warn'  /tmp/TestKwilAct*/*.log  /tmp/TestKwilInt*/*.log /tmp/TestKwilInt*/*/*.log
+        run: grep -C 20 -s -i -r -e 'kwild version' -e 'error' -e 'warn'  /tmp/TestKwilAct*/*.log  /tmp/TestKwilInt*/*.log /tmp/TestKwilInt*/*/*.log

--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -177,7 +177,7 @@ func GenerateNodeFiles(outputDir string, originalCfg *config.KwildConfig, silenc
 	}
 
 	cfg.AppCfg.PrivateKeyPath = config.PrivateKeyFileName
-	err = writeConfigFile(filepath.Join(rootDir, config.ConfigFileName), cfg)
+	err = WriteConfigFile(filepath.Join(rootDir, config.ConfigFileName), cfg)
 	if err != nil {
 		return nil, err
 	}
@@ -362,7 +362,7 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 			}
 		}
 
-		writeConfigFile(filepath.Join(nodeDir, config.ConfigFileName), cfg)
+		WriteConfigFile(filepath.Join(nodeDir, config.ConfigFileName), cfg)
 	}
 
 	fmt.Printf("Successfully initialized %d node directories: %s\n",

--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -35,8 +35,8 @@ func arrayFormatter(items []string) string {
 	return "[" + strings.Join(formattedStrings, ", ") + "]"
 }
 
-// writeConfigFile writes the config to a file.
-func writeConfigFile(configFilePath string, cfg *config.KwildConfig) error {
+// WriteConfigFile writes the config to a file.
+func WriteConfigFile(configFilePath string, cfg *config.KwildConfig) error {
 	var buffer bytes.Buffer
 
 	if err := configTemplate.Execute(&buffer, cfg); err != nil {
@@ -47,15 +47,12 @@ func writeConfigFile(configFilePath string, cfg *config.KwildConfig) error {
 }
 
 const defaultConfigTemplate = `
-# This is a TOML config file.
-# For more information, see https://github.com/toml-lang/toml
-
 # NOTE: Any path below can be absolute (e.g. "/var/myawesomeapp/data") or
 # relative to the home directory (e.g. "data")
 
 # Root Directory Structure:
 # RootDir/
-#   |- config.toml    (app and chain configuration for running the kwild node)
+#   |- config.toml   (app and chain configuration for running the kwild node)
 #   |- private_key   (node's private key)
 #   |- abci/
 #   |   |- config/
@@ -64,7 +61,6 @@ const defaultConfigTemplate = `
 #   |   |- data/
 #   |   |   |- blockchain db files/dir (blockstore.db, state.db, etc)
 #   |   |- info/
-#   |- application/wal
 #   |- signing/
 
 # Only the config.toml and genesis file are required to run the kwild node

--- a/cmd/kwil-admin/nodecfg/toml_test.go
+++ b/cmd/kwil-admin/nodecfg/toml_test.go
@@ -16,7 +16,7 @@ func Test_Generate_TOML(t *testing.T) {
 	cfg.AppCfg.GrpcListenAddress = "localhost:9000"
 	cfg.AppCfg.ExtensionEndpoints = []string{"localhost:9001", "localhost:9002"}
 	cfg.Logging.OutputPaths = []string{"stdout", "file"}
-	err := writeConfigFile("test.toml", cfg)
+	err := WriteConfigFile("test.toml", cfg)
 	assert.NoError(t, err)
 	defer os.Remove("test.toml")
 

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -34,19 +34,13 @@
 grpc_listen_addr = "localhost:50051"
 
 # TCP address for the KWILD App's HTTP server to listen on
-http_listen_addr = "localhost:8080"
+http_listen_addr = "0.0.0.0:8080"
 
 # UNIX socket for KWILD Admin server to listen on
 admin_unix_socket = "/tmp/kwil_admin.sock"
 
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = []
-
-# Toggle to enable gas costs for transactions and queries
-without_gas_costs = true
-
-# Toggle to disable nonces for transactions and queries
-without_nonces = false
 
 # PostgreSQL database host (UNIX socket path or IP address with no port)
 pg_db_host = "127.0.0.1"

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -43,12 +43,6 @@ http_listen_addr = "localhost:8080"
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = ["localhost:50052", "localhost:50053", "localhost:50054"]
 
-# Toggle to enable gas costs for transactions and queries
-without_gas_costs = true
-
-# Toggle to disable nonces for transactions and queries
-without_nonces = false
-
 # PostgreSQL database host (UNIX socket path or IP address with no port)
 pg_db_host = "127.0.0.1"
 


### PR DESCRIPTION
When doing `--autogen`, write out the `config.toml` from the generated configuration.

Also, in autogen mode, change the default `HTTPListenAddr` to all interfaces rather than localhost.  I've kept the default in  other cases at `localhost:8080`.  This adds a little more logic.

Testing in `deployments/compose/kwil`:

```
kwild-single           | Root directory "/app/.kwild"
kwild-single           | Private key path: /app/.kwild/private_key
kwild-single           | Generated new private key, path: /app/.kwild/private_key
kwild-single           | Generated new genesis file: /app/.kwild/genesis.json
kwild-single           | Writing config file to /app/.kwild/config.toml
```

![image](https://github.com/kwilteam/kwil-db/assets/140431406/b2ba5604-9150-4dad-a2bc-3c93cd055907)

