### PR TITLE
txapp: is/not validator checks

### DIFF
--- a/internal/txapp/errors.go
+++ b/internal/txapp/errors.go
@@ -4,5 +4,6 @@ import "errors"
 
 var (
 	ErrCallerNotValidator = errors.New("caller is not a validator")
+	ErrCallerIsValidator  = errors.New("caller is already a validator")
 	ErrCallerNotProposer  = errors.New("caller is not the block proposer")
 )


### PR DESCRIPTION
Resolves at least some of https://github.com/kwilteam/kwil-db/issues/582

I need to manually test these negative paths, but these seem to be the most apparent missing checks.