### PR TITLE
test: include nested delete action call

### DIFF
--- a/test/acceptance/test-data/test_db.kf
+++ b/test/acceptance/test-data/test_db.kf
@@ -59,6 +59,10 @@ action create_post($id, $title, $content) public {
     ), $title, $content);
 }
 
+action delete_nested() public {
+    delete_user(); // ensure it parses as an action call, not a SQL statement (DELETE)
+}
+
 action delete_post($id) public {
     DELETE FROM posts
     WHERE id = $id AND user_id = (


### PR DESCRIPTION
This updates the acceptance test's kf scheme with a call to a `delete_user` action so that we can ensure it does not fail by incorrectly parsing as and SQL statement.
The acceptance test fails at `v0.7.0-rc.1` with: `deploy_database.go:15: cannot parse database schema syntax error: line 1:0 "mismatched input 'delete_user' expecting {<EOF>, ';', 'DELETE', 'INSERT', 'SELECT', 'UPDATE', 'WITH'}" (with 1+ errors): delete_user();`