### PR TITLE
spammer listener extension to push the eventstore and pg performance limitation

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -266,3 +266,18 @@ tasks:
     dir: test # different module
     cmds:
       - go test -count=1 -timeout 0 ./integration -v {{.CLI_ARGS}}
+
+  test:it:ext:
+    desc: Run integration tests ('ext' and 'short' mode)
+    deps:
+      - task: build:cli
+      - task: build:admin
+      - task: GO_BUILDTAGS="ext_test" build:docker
+    cmds:
+      - task: test:it:nb
+
+  test:it:ext:nb:
+    desc: Run integration tests ('ext' and 'short' mode)
+    dir: test # different module
+    cmds:
+      - go test -short -ext -count=1 -timeout 0 ./integration -v {{.CLI_ARGS}}

--- a/extensions/listeners/spammer/spam.go
+++ b/extensions/listeners/spammer/spam.go
@@ -1,0 +1,43 @@
+//go:build ext_test
+
+package spammer
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/extensions/listeners"
+)
+
+const ListenerName = "spammer"
+
+func init() {
+	err := listeners.RegisterListener(ListenerName, Start)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func Start(ctx context.Context, service *common.Service, eventStore listeners.EventStore) error {
+	if _, ok := service.ExtensionConfigs[ListenerName]; !ok {
+		return fmt.Errorf("spammer listener not configured, not starting spam oracle")
+	}
+	service.Logger.Info("Starting spam oracle")
+	count := 0
+	for {
+		select {
+		case <-ctx.Done(): // Properly handle context cancellation
+			return nil
+		default:
+			err := eventStore.Broadcast(ctx, "spam-resolution", []byte(fmt.Sprintf("spam%d", count)))
+			if err != nil {
+				return err
+			}
+			count++
+			if count == 10000 {
+				return nil
+			}
+		}
+	}
+}

--- a/extensions/others.go
+++ b/extensions/others.go
@@ -1,0 +1,8 @@
+//go:build ext_test
+
+package extensions
+
+import (
+	_ "github.com/kwilteam/kwil-db/extensions/listeners/spammer"
+	_ "github.com/kwilteam/kwil-db/extensions/resolutions/spam"
+)

--- a/extensions/precompiles/math.go
+++ b/extensions/precompiles/math.go
@@ -10,7 +10,7 @@ import (
 )
 
 func init() {
-	err := RegisterPrecompile("math", InitializeMath)
+	err := RegisterPrecompile("math-precompile", InitializeMath)
 	if err != nil {
 		panic(err)
 	}

--- a/extensions/register.go
+++ b/extensions/register.go
@@ -4,4 +4,6 @@ package extensions
 // this directory has 0 dependencies, so it can import anything
 // it is imported by cmd/kwild/main.go, so any other files in this directory will be compiled
 
-import _ "github.com/kwilteam/kwil-db/extensions/listeners/eth_deposits"
+import (
+	_ "github.com/kwilteam/kwil-db/extensions/listeners/eth_deposits"
+)

--- a/extensions/resolutions/spam/spam-resolution.go
+++ b/extensions/resolutions/spam/spam-resolution.go
@@ -1,0 +1,24 @@
+//go:build ext_test
+
+package spam
+
+import (
+	"context"
+
+	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/extensions/resolutions"
+)
+
+func init() {
+	// Register a resolution
+	err := resolutions.RegisterResolution("spam-resolution", resolutions.ResolutionConfig{
+		ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error {
+			// This is where the resolution logic goes
+			app.Service.Logger.Info("Spam resolution logic approved")
+			return nil
+		},
+	})
+	if err != nil {
+		panic(err)
+	}
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/drhodes/golorem v0.0.0-20220328165741-da82e5b29246
 	github.com/ethereum/go-ethereum v1.13.8
 	github.com/kwilteam/kuneiform v0.6.0
-	github.com/kwilteam/kwil-db v0.7.0-beta.0.20240301172606-26b70b87eba0
+	github.com/kwilteam/kwil-db v0.7.0-rc.1
 	github.com/kwilteam/kwil-db/core v0.1.0
 	github.com/stretchr/testify v1.8.4
 	github.com/testcontainers/testcontainers-go v0.27.0


### PR DESCRIPTION
Probably not to be pushed in the release till we figure out a better way to test custom extensions. this needs a ext-test build tag and run the tests with -ext flag. 

