### PR TITLE
stress,client: nonce chaos and failed execution options

### DIFF
--- a/core/client/tx.go
+++ b/core/client/tx.go
@@ -44,9 +44,12 @@ func (c *Client) newTx(ctx context.Context, data transactions.Payload, txOpts *c
 	}
 
 	// estimate price
-	price, err := c.txClient.EstimateCost(ctx, tx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to estimate price: %w", err)
+	price := txOpts.Fee
+	if price == nil {
+		price, err = c.txClient.EstimateCost(ctx, tx)
+		if err != nil {
+			return nil, fmt.Errorf("failed to estimate price: %w", err)
+		}
 	}
 
 	// set fee

--- a/test/stress/hammer.go
+++ b/test/stress/hammer.go
@@ -133,6 +133,14 @@ func hammer(ctx context.Context) error {
 		return err
 	}
 
+	userID, userName, err := h.getOrCreateUser(ctx, dbid)
+	if err != nil {
+		return fmt.Errorf("getOrCreateUser: %w", err)
+	}
+	h.printf("user ID = %d / user name = %v", userID, userName)
+
+	h.nonceChaos = nonceChaos // after successfully deploying the test db and creating a user in it
+
 	// ## badgering read-only requests to various systems
 
 	// bother the account store
@@ -208,12 +216,6 @@ func hammer(ctx context.Context) error {
 	// concurrently posting and retrieving random posts.
 
 	var pid atomic.Int64 // post ID accessed by separate goroutines
-
-	userID, userName, err := h.getOrCreateUser(ctx, dbid)
-	if err != nil {
-		return fmt.Errorf("getOrCreateUser: %w", err)
-	}
-	h.printf("user ID = %d / user name = %v", userID, userName)
 
 	nextPostID, err := h.nextPostID(ctx, dbid, userID)
 	if err != nil {

--- a/test/stress/main.go
+++ b/test/stress/main.go
@@ -39,9 +39,8 @@ var (
 	txPollInterval time.Duration
 
 	sequentialBroadcast bool
+	nonceChaos          int
 	rpcTiming           bool
-
-	// badNonces bool
 
 	wg sync.WaitGroup
 )
@@ -69,6 +68,7 @@ func main() {
 	flag.IntVar(&maxContentLen, "el", 50_000, "maximum content length in an executed post action")
 
 	flag.BoolVar(&sequentialBroadcast, "sb", false, "sequential broadcast (disallow concurrent broadcast, waiting for broadcast result before releasing nonce lock)")
+	flag.IntVar(&nonceChaos, "nc", 0, "nonce chaos rate (apply nonce jitter every 1/nc times)")
 	flag.BoolVar(&rpcTiming, "v", false, "print RPC durations")
 
 	flag.DurationVar(&txPollInterval, "pollint", 200*time.Millisecond, "polling interval when waiting for tx confirmation")


### PR DESCRIPTION
This updates the stress tool with:
- a "nonce chaos" (`-nc`) option to apply a random jitter to the correct nonce at a rate of 1/nc times.
- When using the `create_post` action, create action call transactions that intentionally fail execution with incorrect argument count or types.  This ensures nonce and balance updates happen regardless of the execution outcome (tx code), and that the node is resilient to failures in user SQL queries as well as the engine's handling of procedure call errors.

This also fixes a bug in `core/client.Client` where the `WithFee` option was ignored.  This is not critical since kwil-cli does not use it like it does the `WithNonce` option from `--nonce`, but I did want to have the stress tool do unexpected things with the `tx.Body.Fee` field and I realized this was impossible.

Putting this PR up now despite more related work being in progress because I am now diagnosing the cause of a consensus failure and persistent app hash mismatch after restart. I will investigate and find the root cause and fix, but in short, on validator node A `FinalizeBlock` returned an error because postgres/connection was down (I had closed my laptop lid), but on sentry node B it had gotten through `FinalizeBlock` without error for that same block before the pg connection died.  Node B finalize had gotten apphash X.  After restarting node A, it tried finalizing that block again and got apphash Y.  I'm not sure why since the transaction for that block was not committed (and not prepared either according to "0 orphaned" prepared transactions reported on restart.  Investigating...