### PR TITLE
docker: no wal sender timeout in postgres image

### DIFF
--- a/build/package/docker/postgres.dockerfile
+++ b/build/package/docker/postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.1
+FROM postgres:16.2
 
 # Inject the init script that makes the kwild superuser and a kwild database
 # owned by that kwild user, as well as a kwil_test_db database for tests.
@@ -13,4 +13,5 @@ COPY ./pginit.sql /docker-entrypoint-initdb.d/init.sql
 # ENV POSTGRES_DB kwild
 
 # Override the default entrypoint/command to include the additional configuration
-CMD ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=10", "-c", "max_replication_slots=10", "-c", "max_prepared_transactions=2"]
+CMD ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=10", "-c", "max_replication_slots=10", \
+	"-c", "track_commit_timestamp=true", "-c", "wal_sender_timeout=0", "-c", "max_prepared_transactions=2"]


### PR DESCRIPTION
This removes the wal sender timeout, which is not helpful for kwild's application:

- https://bugzilla.redhat.com/show_bug.cgi?id=1342255
- https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Source.PostgreSQL.html
- https://www.postgresql.org/docs/current/runtime-config-replication.html

