### PR TITLE
abci,kwild: write in-memory cometbft confs to disk for inspect

### DIFF
--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -75,8 +75,19 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 
 	chainRoot := filepath.Join(cfg.RootDir, abciDirName)
 	nodeCfg.SetRoot(chainRoot)
-	nodeCfg.Genesis = filepath.Join(cfg.RootDir, cometbft.GenesisJSONName)
+	// NOTE: The Genesis field is the one in cometbft's GenesisDoc, which is
+	// different from kwild's, which contains more fields (and not string
+	// int64). The documented genesis.json in kwild's root directory is:
+	//   filepath.Join(cfg.RootDir, cometbft.GenesisJSONName)
+	// This file is only used to reflect the in-memory genesis config provided
+	// to cometbft via a GenesisDocProvider. It it is not used by cometbft.
+	nodeCfg.Genesis = filepath.Join(chainRoot, "config", cometbft.GenesisJSONName)
 	nodeCfg.P2P.AddrBook = cometbft.AddrBookPath(chainRoot)
+	// For the same reasons described for the genesis.json path above, clear the
+	// node and validator file fields since they are provided in-memory.
+	nodeCfg.PrivValidatorKey = ""
+	nodeCfg.PrivValidatorState = ""
+	nodeCfg.NodeKey = ""
 
 	return nodeCfg
 }

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -414,6 +414,7 @@ func (a *AbciApp) Commit(ctx context.Context, _ *abciTypes.RequestCommit) (*abci
 
 // Info is part of the Info/Query connection.
 func (a *AbciApp) Info(ctx context.Context, _ *abciTypes.RequestInfo) (*abciTypes.ResponseInfo, error) {
+	// TODO: check kwild_voting.height!!!!!!!!!!!!!!
 	height, err := a.metadataStore.GetBlockHeight(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get block height: %w", err)

--- a/internal/abci/cometbft/genesis.go
+++ b/internal/abci/cometbft/genesis.go
@@ -12,6 +12,7 @@ import (
 const (
 	DataDir          = "data"
 	GenesisJSONName  = "genesis.json"
+	ConfigTOMLName   = "config.toml"
 	AddrBookFileName = "addrbook.json"
 )
 


### PR DESCRIPTION
`kwild` has it's own config.toml and genesis.json files, each with fields and formats that differ from cometbft's.  When we launch a cometbft `Node` we supply the translated configs in-memory.

This change writes out cometbft's version of these files, which reflect the effective config given to the node.  They are written into `<root_dir>/abci/conf`, where `<root_dir>/abci` is considered the cometbft "home" directory.  This helps debug, but more importantly it allows the use of the `cometbft` command-line tool for commands like `inspect` and `rollback`:


```
$  cometbft rollback --hard --home ~/kwil/git/kwil-db/cmd/kwil-admin/.testnet/node0/abci
Rolled back both state and block to height 823 and hash 5C9824172FF1717C32671420A02E76B41779687A7642F3A19D9B5A56ACF3278F
```

```
$  cometbft inspect --home ~/kwil/git/kwil-db/cmd/kwil-admin/.testnet/node0/abci
I[2024-03-14|16:44:58.830] starting inspect server                      module=main 
I[2024-03-14|16:44:58.831] RPC HTTP server starting                     address=tcp://127.0.0.1:26657
I[2024-03-14|16:44:58.831] serve                                        msg="Starting RPC HTTP server on 127.0.0.1:26657"
```

```
$  curl -s --insecure http://localhost:26657/block | jq '.result.block.header.height'
"823"
```

I will prepare docs and/or wiki about how to use these commands for recovery and debugging, with more `curl` commands and processes for dumping pg data to re-apply blocks from cometbft's txns store.