### PR TITLE
server,pg: fix shutdown sequence

### DIFF
--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -2,6 +2,7 @@ package root
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
 	_ "net/http/pprof"
@@ -75,6 +76,9 @@ func RootCmd() *cobra.Command {
 
 			svr, err := server.New(ctx, kwildCfg, genesisConfig, nodeKey, autoGen)
 			if err != nil {
+				if errors.Is(err, context.Canceled) {
+					return nil // clean shutdown
+				}
 				return err
 			}
 

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -714,9 +714,31 @@ func buildCometNode(d *coreDependencies, closer *closeFuncs, abciApp abciTypes.A
 	return node
 }
 
+// panicErr is the type given to panic from failBuild so that the wrapped error
+// may be type-inspected.
+type panicErr struct {
+	err error
+	msg string
+}
+
+func (pe panicErr) String() string {
+	return pe.msg
+}
+
+func (pe panicErr) Error() string { // error interface
+	return pe.msg
+}
+
+func (pe panicErr) Unwrap() error {
+	return pe.err
+}
+
 func failBuild(err error, msg string) {
 	if err != nil {
-		panic(fmt.Sprintf("%s: %s", msg, err.Error()))
+		panic(panicErr{
+			err: err,
+			msg: fmt.Sprintf("%s: %s", msg, err),
+		})
 	}
 }
 

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -289,10 +289,15 @@ type coreDependencies struct {
 // it is used to close all resources on shutdown
 type closeFuncs struct {
 	closers []func() error
+	logger  log.Logger
 }
 
-func (c *closeFuncs) addCloser(f func() error) {
-	c.closers = append([]func() error{f}, c.closers...) // slices.Insert(c.closers, 0, f)
+func (c *closeFuncs) addCloser(f func() error, msg string) {
+	// push to top of stack
+	c.closers = slices.Insert(c.closers, 0, func() error {
+		c.logger.Info(msg)
+		return f()
+	})
 }
 
 // closeAll closes all closers
@@ -355,7 +360,7 @@ func buildEventStore(d *coreDependencies, closers *closeFuncs) *events.EventStor
 	if err != nil {
 		failBuild(err, "failed to build event store")
 	}
-	closers.addCloser(db.Close)
+	closers.addCloser(db.Close, "closing event store")
 
 	e, err := events.NewEventStore(d.ctx, db)
 	if err != nil {
@@ -391,7 +396,7 @@ func buildDB(d *coreDependencies, closer *closeFuncs) *pg.DB {
 	if err != nil {
 		failBuild(err, "kwild database open failed")
 	}
-	closer.addCloser(db.Close)
+	closer.addCloser(db.Close, "closing main DB")
 
 	return db
 }
@@ -560,7 +565,7 @@ func buildAdminService(d *coreDependencies, closer *closeFuncs, admsvc admpb.Adm
 		if err != nil {
 			failBuild(err, "failed to build grpc server")
 		}
-		closer.addCloser(lis.Close)
+		closer.addCloser(lis.Close, "stopping admin service")
 
 		// client certs
 		caCertPool := x509.NewCertPool()
@@ -632,7 +637,7 @@ func buildAdminService(d *coreDependencies, closer *closeFuncs, admsvc admpb.Adm
 			failBuild(err, "failed to listen to unix socket")
 		}
 
-		closer.addCloser(lis.Close)
+		closer.addCloser(lis.Close, "stopping admin service")
 
 		err = os.Chmod(u.Target, 0777) // TODO: probably want this to be more restrictive
 		if err != nil {
@@ -679,7 +684,7 @@ func buildCometNode(d *coreDependencies, closer *closeFuncs, abciApp abciTypes.A
 	if err != nil {
 		failBuild(err, "failed to build comet node")
 	}
-	closer.addCloser(db.Close)
+	closer.addCloser(db.Close, "closing signing store")
 
 	readWriter := &atomicReadWriter{
 		kv:  db,
@@ -700,7 +705,7 @@ func buildCometNode(d *coreDependencies, closer *closeFuncs, abciApp abciTypes.A
 		}
 	}
 
-	node, err := cometbft.NewCometBftNode(abciApp, nodeCfg, genDoc, d.privKey,
+	node, err := cometbft.NewCometBftNode(d.ctx, abciApp, nodeCfg, genDoc, d.privKey,
 		readWriter, &d.log)
 	if err != nil {
 		failBuild(err, "failed to build comet node")

--- a/cmd/kwild/server/server.go
+++ b/cmd/kwild/server/server.go
@@ -54,8 +54,15 @@ const (
 
 // New builds the kwild server.
 func New(ctx context.Context, cfg *config.KwildConfig, genesisCfg *config.GenesisConfig, nodeKey *crypto.Ed25519PrivateKey, autogen bool) (svr *Server, err error) {
+	logger, err := log.NewChecked(*cfg.LogConfig())
+	if err != nil {
+		return nil, fmt.Errorf("invalid logger config: %w", err)
+	}
+	logger = *logger.Named("kwild")
+
 	closers := &closeFuncs{
 		closers: make([]func() error, 0),
+		logger:  logger,
 	}
 
 	defer func() {
@@ -67,12 +74,6 @@ func New(ctx context.Context, cfg *config.KwildConfig, genesisCfg *config.Genesi
 			closers.closeAll()
 		}
 	}()
-
-	logger, err := log.NewChecked(*cfg.LogConfig())
-	if err != nil {
-		return nil, fmt.Errorf("invalid logger config: %w", err)
-	}
-	logger = *logger.Named("kwild")
 
 	if cfg.AppCfg.TLSKeyFile == "" || cfg.AppCfg.TLSCertFile == "" {
 		return nil, errors.New("unspecified TLS key and/or certificate")

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -196,7 +196,7 @@ func NewCometBftNode(ctx context.Context, app abciTypes.Application, conf *comet
 	)
 	if err != nil {
 		if errors.Is(ctx.Err(), context.Canceled) {
-			err = context.Canceled // canceled and comet forgot to use %w in doHandshake and elsehwere
+			err = context.Canceled // canceled and comet forgot to use %w in doHandshake and elsewhere
 		}
 		return nil, fmt.Errorf("failed to create CometBFT node: %w", err)
 	}

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -1,6 +1,7 @@
 package cometbft
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"os"
@@ -163,7 +164,7 @@ WARNING: These files are overwritten on kwild startup.`
 }
 
 // NewCometBftNode creates a new CometBFT node.
-func NewCometBftNode(app abciTypes.Application, conf *cometConfig.Config, genDoc *types.GenesisDoc, privateKey cometEd25519.PrivKey, atomicStore privval.AtomicReadWriter, log *log.Logger) (*CometBftNode, error) {
+func NewCometBftNode(ctx context.Context, app abciTypes.Application, conf *cometConfig.Config, genDoc *types.GenesisDoc, privateKey cometEd25519.PrivKey, atomicStore privval.AtomicReadWriter, log *log.Logger) (*CometBftNode, error) {
 	if err := writeCometBFTConfigs(conf, genDoc); err != nil {
 		return nil, fmt.Errorf("failed to write the effective cometbft config files: %w", err)
 	}
@@ -180,7 +181,8 @@ func NewCometBftNode(app abciTypes.Application, conf *cometConfig.Config, genDoc
 		return nil, fmt.Errorf("failed to create private validator: %v", err)
 	}
 
-	node, err := cometNodes.NewNode(
+	node, err := cometNodes.NewNodeWithContext(
+		ctx,
 		conf,
 		privateValidator,
 		&p2p.NodeKey{

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -195,7 +195,10 @@ func NewCometBftNode(ctx context.Context, app abciTypes.Application, conf *comet
 		logger,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create CometBFT node: %v", err)
+		if errors.Is(ctx.Err(), context.Canceled) {
+			err = context.Canceled // canceled and comet forgot to use %w in doHandshake and elsehwere
+		}
+		return nil, fmt.Errorf("failed to create CometBFT node: %w", err)
 	}
 
 	return &CometBftNode{

--- a/internal/sql/pg/db.go
+++ b/internal/sql/pg/db.go
@@ -320,7 +320,10 @@ func (db *DB) precommit(ctx context.Context) ([]byte, error) {
 
 	// Wait for the "commit id" from the replication monitor.
 	select {
-	case commitID := <-resChan:
+	case commitID, ok := <-resChan:
+		if !ok {
+			return nil, errors.New("resChan unexpectedly closed")
+		}
 		logger.Debugf("received commit ID %x", commitID)
 		// The transaction is ready to commit, stored in a file with postgres in
 		// the pg_twophase folder of the pg cluster data_directory.

--- a/internal/sql/pg/repl_test.go
+++ b/internal/sql/pg/repl_test.go
@@ -57,7 +57,7 @@ func Test_repl(t *testing.T) {
 
 	const publicationName = "kwild_repl"
 	var slotName = publicationName + random.String(8)
-	commitChan, errChan, err := startRepl(ctx, conn, publicationName, slotName, schemaFilter)
+	commitChan, errChan, quit, err := startRepl(ctx, conn, publicationName, slotName, schemaFilter)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -92,7 +92,7 @@ func Test_repl(t *testing.T) {
 				if !bytes.Equal(commitHash, wantCommitHash) {
 					t.Errorf("commit hash mismatch, got %x, wanted %x", commitHash, wantCommitHash)
 				}
-				cancel()
+				quit()
 			case err := <-errChan:
 				if errors.Is(err, context.Canceled) {
 					return
@@ -103,7 +103,7 @@ func Test_repl(t *testing.T) {
 				}
 				if err != nil {
 					t.Error(err)
-					cancel()
+					quit()
 				}
 				return
 			}
@@ -132,4 +132,5 @@ func Test_repl(t *testing.T) {
 	}
 
 	wg.Wait()
+	connQ.Close(ctx)
 }

--- a/internal/sql/pg/replmon.go
+++ b/internal/sql/pg/replmon.go
@@ -55,15 +55,13 @@ type replMon struct {
 // request a commit ID promise using the recvID method prior to committing a
 // transaction.
 func newReplMon(ctx context.Context, host, port, user, pass, dbName string, schemaFilter func(string) bool) (*replMon, error) {
-	ctx, quit := context.WithCancel(ctx)
 	conn, err := replConn(ctx, host, port, user, pass, dbName)
 	if err != nil {
-		quit()
 		return nil, err
 	}
 
 	var slotName = publicationName + random.String(8) // arbitrary, so just avoid collisions
-	commitChan, errChan, err := startRepl(ctx, conn, publicationName, slotName, schemaFilter)
+	commitChan, errChan, quit, err := startRepl(ctx, conn, publicationName, slotName, schemaFilter)
 	if err != nil {
 		quit()
 		conn.Close(ctx)


### PR DESCRIPTION
This resolves the shutdown triggered appHash mismatch I have been observing.  It also resolves some shutdown sequence issues that led to the issue.

@charithabandi's debugging lead to identifying these issues and their fixes. Thanks so much!

In short, we were pulling the plug on parts of the DB subsystems before killing cometbft's node.  Also, we actually didn't have a way to stop the node's replay process before, but now we are using `NewNodeWithContext`.  Also, the `pg` package now does not shutdown the replication monitor goroutines on global context cancellation, only the connection establishment functions.  It now correctly stops the goroutines where it was intended in the `Close` method.