### PR TITLE
[v0.7.2] core: fix parse kgw error, so it output detailed message

### DIFF
--- a/core/rpc/client/user/http/error.go
+++ b/core/rpc/client/user/http/error.go
@@ -90,6 +90,18 @@ func parseBroadcastError(respTxt []byte) (bool, error) {
 			return false, err
 		}
 	}
+
+	// for kgw error response
+	if protoStatus.GetCode() == 0 { // if it's grpc status, it should have a code, code 0 is not error code
+		// NOTE: this could be removed once #623 is merged
+		// try to parse kgw error first
+		var kgwErr gatewayErrResponse
+		err := json.Unmarshal(respTxt, &kgwErr)
+		if err == nil {
+			return true, errors.Join(errors.New(kgwErr.Error))
+		}
+	}
+
 	stat := grpcStatus.FromProto(&protoStatus)
 	code, message := stat.Code(), stat.Message()
 	rpcErr := &client.RPCError{


### PR DESCRIPTION
The issuse: when kwil-cli request a provider, error detail is not avaliable for kgw response.

Since both kwild and kgw requests are handled by same http client, and for now they have different error response(#623 try to fix this)
This pr change the `parseErrorResponse` function, to support kgw error response.


The output(mocked):

before

```
$ .build/kwil-cli database call --action owner_only --name testdb --kwil-provider http://localhost:8090 --authenticate
error calling action: call action: 400 Bad Request
err code = 0, msg =

$ .build/kwil-cli database call --action owner_only --name testdb --kwil-provider http://localhost:8080
error calling action: call action: 400 Bad Request
err code = 3, msg = mock call bad request error
```


after 
```
$ .build/kwil-cli database call --action owner_only --name testdb --kwil-provider http://localhost:8090 --authenticate
error calling action: call action: 400 Bad Request
JUST SOME CALL ERROR !!!

$ .build/kwil-cli database call --action owner_only --name testdb --kwil-provider http://localhost:8080
error calling action: call action: 400 Bad Request
err code = 3, msg = mock call bad request error
```
8090 is kgw, 8080 is kwil-db

