### PR TITLE
kwil-admin: fix minor typo

### DIFF
--- a/cmd/kwil-admin/cmds/validators/list.go
+++ b/cmd/kwil-admin/cmds/validators/list.go
@@ -16,7 +16,7 @@ var (
 	listLong = `List the current validator set of the network.`
 
 	listExample = `# List the current validator set of the network
-kwil-admin validators list-validators`
+kwil-admin validators list`
 )
 
 func listCmd() *cobra.Command {

--- a/cmd/kwil-admin/cmds/validators/list.go
+++ b/cmd/kwil-admin/cmds/validators/list.go
@@ -16,7 +16,7 @@ var (
 	listLong = `List the current validator set of the network.`
 
 	listExample = `# List the current validator set of the network
-kwild validators list`
+kwil-admin validators list-validators`
 )
 
 func listCmd() *cobra.Command {


### PR DESCRIPTION
fix minor typo for `validators list-validators` command