### PR TITLE
ci: only trigger release workflow on 'published'

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,7 +3,6 @@ name: Release
 on:
   release:
     types:
-      - created # won't trigger from draft release
       - published
 
 jobs:


### PR DESCRIPTION
The release workflow runs on 'created' and 'published' type.
Based on https://github.com/kwilteam/kwil-db/actions/workflows/release.yaml, we don't need 'created' trigger type.


Two reasons:
- 'created' won't be triggered for a draft release
- - we configured goreleaser to create 'draft' release by default.    Cannot create non-draft, non-pre-release, non-latest-release through gorelease.
- - it'll trigger twice if we created a non-draft release directly.
- 'published' will be triggered by 'pre-publish', so we can turn 'draft' to 'pre-release' to run the test, if test pass, turn it into 'latest-release'