### PR TITLE
listeners,eth_deposits: eth client reworking

### DIFF
--- a/internal/listeners/mgr.go
+++ b/internal/listeners/mgr.go
@@ -3,6 +3,8 @@ package listeners
 import (
 	"bytes"
 	"context"
+	"errors"
+	"slices"
 	"time"
 
 	"go.uber.org/zap"
@@ -35,9 +37,11 @@ type ListenerManager struct {
 // ValidatorGetter is able to read the current validator set.
 type ValidatorGetter interface {
 	GetValidators(ctx context.Context) ([]*types.Validator, error)
+	SubscribeValidators() <-chan []*types.Validator
 }
 
-func NewListenerManager(config map[string]map[string]string, eventStore *voting.EventStore, node *cometbft.CometBftNode, nodePubKey []byte, vstore ValidatorGetter, logger log.Logger) *ListenerManager {
+func NewListenerManager(config map[string]map[string]string, eventStore *voting.EventStore,
+	node *cometbft.CometBftNode, nodePubKey []byte, vstore ValidatorGetter, logger log.Logger) *ListenerManager {
 	return &ListenerManager{
 		config:     config,
 		eventStore: eventStore,
@@ -50,17 +54,75 @@ func NewListenerManager(config map[string]map[string]string, eventStore *voting.
 
 // Start starts the listener manager.
 // It will block until Stop is called.
-func (omgr *ListenerManager) Start() error {
+// If any one listener stops, all listeners are stopped and a non-nil error
+// is returned.
+func (omgr *ListenerManager) Start() (err error) {
 	ctx, cancel := context.WithCancel(context.Background()) // context that will be canceled when the manager shuts down
 	omgr.cancel = cancel
+	defer cancel()
+
 	// Listen for status changes
 	// Start oracles if the node is a validator and is caught up
 	// Stop the oracles, if the node is not a validator
-	// cancel function for the oracle instance
-	// if it is nil, then the oracle is not running
-	var listenerInstanceCancel context.CancelFunc
+	errChan := make(chan error, 1)
+	var listenerInstanceCancel context.CancelFunc // nil => listeners not running
+	startStop := func(isValidator bool) {
+		if listenerInstanceCancel == nil && isValidator {
+			// inner context to manage the listeners
+			// this context will be cancelled when the node loses its validator status
+			// it will also be cancelled when the listener manager is stopped
+			ctx2, cancel2 := context.WithCancel(ctx)
+			listenerInstanceCancel = cancel2
 
-	var errChan = make(chan error, 1)
+			omgr.logger.Info("Node is a validator and caught up with the network, starting listeners")
+
+			for name, start := range listeners.RegisteredListeners() {
+				go func(start listeners.ListenFunc, name string) {
+					defer cancel2() // stop others, like an error group
+					err := start(ctx2, &common.Service{
+						Logger:           omgr.logger.Named(name).Sugar(),
+						ExtensionConfigs: omgr.config,
+					}, &scopedKVEventStore{
+						ev: omgr.eventStore,
+						// we add a space to prevent collisions in the KV
+						// oracle names cannot have spaces
+						KV: omgr.eventStore.KV([]byte(name + " ")),
+					})
+					if err != nil {
+						omgr.logger.Error("==========================  Event listener stopped  ==========================",
+							zap.String("listener", name), zap.Error(err))
+						if !errors.Is(err, context.Canceled) {
+							errChan <- err
+						}
+					} else {
+						omgr.logger.Debug("Event listener stopped (cleanly)", zap.String("listener", name))
+					}
+				}(start, name)
+
+			}
+		} else if listenerInstanceCancel != nil && !isValidator {
+			// Stop the listeners if they are running
+			omgr.logger.Info("Node is no longer a validator, stopping listeners")
+			listenerInstanceCancel()
+			listenerInstanceCancel = nil
+		}
+	}
+
+	defer func() {
+		omgr.logger.Info("ListenerManager stopped.", zap.Error(err))
+	}()
+
+	containsMe := func(validators []*types.Validator) bool {
+		return slices.ContainsFunc(validators, func(v *types.Validator) bool {
+			return bytes.Equal(v.PubKey, omgr.pubKey)
+		})
+	}
+
+	// Tick until catch-up is complete...
+	syncCheck := time.NewTicker(500 * time.Millisecond)
+	defer syncCheck.Stop()
+	// ...then begin receiving the current validator set at each block.
+	var valChan <-chan []*types.Validator
 
 	for {
 		select {
@@ -68,60 +130,27 @@ func (omgr *ListenerManager) Start() error {
 			return nil
 		case err := <-errChan:
 			return err
-		case <-time.After(1 * time.Second):
-			// still in the catch up mode, do nothing
+		case validators := <-valChan:
+			startStop(containsMe(validators))
+			if syncCheck != nil {
+				syncCheck.Stop() // would be no-op after first time
+			}
+
+		case <-syncCheck.C:
+			// still in catch up mode, keep polling
 			if omgr.cometNode.IsCatchup() {
 				continue
 			}
 
+			// switch to the validators channel
+			syncCheck.Stop()
+			valChan = omgr.vstore.SubscribeValidators() // creates a new channel in txApp
+
 			validators, err := omgr.vstore.GetValidators(ctx)
 			if err != nil {
-				omgr.logger.Warn("failed to get validators", zap.Error(err))
 				return err
 			}
-
-			isValidator := false
-			for _, val := range validators {
-				if bytes.Equal(val.PubKey, omgr.pubKey) {
-					isValidator = true
-					break
-				}
-			}
-
-			if listenerInstanceCancel == nil && isValidator {
-				// inner context to manage the listeners
-				// this context will be cancelled when the node loses its validator status
-				// it will also be cancelled when the listener manager is stopped
-				ctx2, cancel2 := context.WithCancel(ctx)
-				listenerInstanceCancel = cancel2
-
-				omgr.logger.Info("Node is a validator and caught up with the network, starting listeners")
-
-				for name, start := range listeners.RegisteredListeners() {
-					go func(start listeners.ListenFunc, name string) {
-						err := start(ctx2, &common.Service{
-							Logger:           omgr.logger.Named(name).Sugar(),
-							ExtensionConfigs: omgr.config,
-						}, &scopedKVEventStore{
-							ev: omgr.eventStore,
-							// we add a space to prevent collisions in the KV
-							// oracle names cannot have spaces
-							KV: omgr.eventStore.KV([]byte(name + " ")),
-						})
-						if err != nil {
-							// if error is returned, shutdown manager
-							omgr.logger.Error("Oracle failed", zap.String("oracle", name), zap.Error(err))
-							errChan <- err
-						}
-					}(start, name)
-
-				}
-			} else if listenerInstanceCancel != nil && !isValidator {
-				// Stop the listeners if they are running
-				omgr.logger.Info("Node is no longer a validator, stopping listeners")
-				listenerInstanceCancel()
-				listenerInstanceCancel = nil
-			}
+			startStop(containsMe(validators))
 		}
 	}
 }
@@ -129,6 +158,9 @@ func (omgr *ListenerManager) Start() error {
 func (omgr *ListenerManager) Stop() {
 	omgr.cancel()
 }
+
+// scopedKVEventStore is for the EventStore input of listeners.ListenFunc
+var _ listeners.EventStore = (*scopedKVEventStore)(nil)
 
 // scopedKVEventStore scopes the event store's kv store to the listener's name
 type scopedKVEventStore struct {

--- a/test/cmd/ethlisten/.gitignore
+++ b/test/cmd/ethlisten/.gitignore
@@ -1,0 +1,2 @@
+ethlisten
+ethlisten.exe

--- a/test/cmd/ethlisten/main.go
+++ b/test/cmd/ethlisten/main.go
@@ -1,0 +1,98 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"os"
+	"os/signal"
+	"syscall"
+
+	ethLog "github.com/ethereum/go-ethereum/log"
+	deposits "github.com/kwilteam/kwil-db/extensions/listeners/eth_deposits"
+
+	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/core/log"
+)
+
+var (
+	endpoint     string
+	contractAddr string
+)
+
+func main() {
+	flag.StringVar(&endpoint, "ep", "", "provider's http url, schema is required (env: SEPOLIA_ENDPOINT)")
+	flag.StringVar(&contractAddr, "addr", "0x94e6a0aa8518b2be7abaf9e76bfbb48cab1545ad",
+		"contract address with deposit events emitted (default is the address at https://sepolia.etherscan.io/address/0x94e6a0aa8518b2be7abaf9e76bfbb48cab1545ad)")
+	flag.Parse()
+
+	if endpoint == "" {
+		endpoint = os.Getenv(`SEPOLIA_ENDPOINT`)
+		if endpoint == "" {
+			endpoint = "ws://127.0.0.1:8546"
+		}
+	}
+
+	signalChan := make(chan os.Signal, 1)
+	signal.Notify(signalChan, os.Interrupt, syscall.SIGTERM)
+	ctx, cancel := context.WithCancel(context.Background())
+	go func() {
+		<-signalChan
+		cancel()
+	}()
+
+	if err := mainReal(ctx); err != nil {
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
+	os.Exit(0)
+}
+
+func mainReal(ctx context.Context) error {
+	cfg := deposits.EthDepositConfig{
+		ContractAddress:      contractAddr,
+		RPCProvider:          endpoint,
+		ReconnectionInterval: 45,
+		MaxRetries:           30,
+		BlockSyncChunkSize:   1_000_000,
+		StartingHeight:       5_100_000,
+	}
+	extensionConfig := map[string]map[string]string{
+		deposits.ListenerName: cfg.Map(),
+	}
+	svc := &common.Service{
+		Logger:           log.NewStdOut(log.DebugLevel).Sugar(),
+		ExtensionConfigs: extensionConfig,
+	}
+	es := &memEvtStore{svc.Logger, make(map[string][]byte)}
+
+	rpcLogger := ethLog.NewTerminalHandlerWithLevel(os.Stdout, ethLog.LevelTrace, true)
+	ethLog.SetDefault(ethLog.NewLogger(rpcLogger))
+
+	return deposits.Start(ctx, svc, es)
+}
+
+// memEvtStore is for debugging. modify as needed.
+type memEvtStore struct {
+	logger log.SugaredLogger
+	kv     map[string][]byte
+}
+
+func (es *memEvtStore) Broadcast(ctx context.Context, eventType string, data []byte) error {
+	es.logger.S.Infof("mark for broadcast event %v, data %x", eventType, data)
+	return nil
+}
+
+func (es *memEvtStore) Set(ctx context.Context, key []byte, value []byte) error {
+	es.kv[string(key)] = value
+	return nil
+}
+
+func (es *memEvtStore) Get(ctx context.Context, key []byte) ([]byte, error) {
+	return es.kv[string(key)], nil
+}
+
+func (es *memEvtStore) Delete(ctx context.Context, key []byte) error {
+	delete(es.kv, string(key))
+	return nil
+}

--- a/test/integration/eth-deployer/deployer.go
+++ b/test/integration/eth-deployer/deployer.go
@@ -33,14 +33,14 @@ type Deployer struct {
 }
 
 // NewDeployer("ws://localhost:8545","dd23ca549a97cb330b011aebb674730df8b14acaee42d211ab45692699ab8ba5")
-func NewDeployer(endpoint string, pKey string, chainID int64) (*Deployer, error) {
+func NewDeployer(endpoint, secp256k1PrivKey string, chainID int64) (*Deployer, error) {
 	ctx := context.Background()
 	ethClient, err := ethclient.DialContext(ctx, endpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	privKey, err := ec.HexToECDSA(pKey)
+	privKey, err := ec.HexToECDSA(secp256k1PrivKey)
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -304,7 +304,7 @@ func (r *IntHelper) generateNodeConfig(homeDir string) {
 				StartingHeight:        0,
 				RequiredConfirmations: r.ethDeposit.confirmations, // TODO: remove this from the r.ethDeposit struct. it is not needed
 				ReconnectionInterval:  30,
-				MaxRetries:            2,
+				MaxRetries:            20,
 				BlockSyncChunkSize:    1000,
 			}
 

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -325,10 +325,10 @@ func TestKwildEthDepositOracleIntegration(t *testing.T) {
 			helper.Setup(ctx, allServices)
 
 			// get deployer
-			ctx2, cancel := context.WithCancel(ctx)
+			ctxMiner, cancel := context.WithCancel(ctx)
 			defer cancel()
 			deployer := helper.EthDeployer(false)
-			err := deployer.KeepMining(ctx2)
+			err := deployer.KeepMining(ctxMiner)
 			require.NoError(t, err)
 
 			// Get the user driver
@@ -382,10 +382,10 @@ func TestKwildEthDepositOracleExpiryIntegration(t *testing.T) {
 			helper := integration.NewIntHelper(t, opts...)
 			helper.Setup(ctx, append(allServices, "pg4", "node4"))
 
-			ctx2, cancel := context.WithCancel(ctx)
+			ctxMiner, cancel := context.WithCancel(ctx)
 			defer cancel()
 			byzDeployer := helper.EthDeployer(true)
-			err := byzDeployer.KeepMining(ctx2)
+			err := byzDeployer.KeepMining(ctxMiner)
 			require.NoError(t, err)
 
 			// Get the user driver
@@ -427,10 +427,10 @@ func TestKwildEthDepositOracleExpiryRefundIntegration(t *testing.T) {
 			helper := integration.NewIntHelper(t, opts...)
 			helper.Setup(ctx, append(allServices, "pg4", "node4"))
 
-			ctx2, cancel := context.WithCancel(ctx)
+			ctxMiner, cancel := context.WithCancel(ctx)
 			defer cancel()
 			byzDeployer := helper.EthDeployer(true)
-			err := byzDeployer.KeepMining(ctx2)
+			err := byzDeployer.KeepMining(ctxMiner)
 			require.NoError(t, err)
 
 			// Get the user driver


### PR DESCRIPTION
This PR resolves a few sticky issues with the eth oracle listener and eth rpc client.

- `retry()` is now cancellable so listener stop doesn't result in reconnect loop. The validator add/remove test with oracles enabled often resulted in this case.
- also use `ethclient.DialContext` (instead of `ethclient.Dial`) to cancel hung (re)connects
- re*connect* logic is left to the go-ethereum RPC client, which has automatic reconnect built-in.  The removed reconnect code was also duplicated in three separate spots.
- In the `ListenToBlocks` loop with `select`, use a `time.Ticker` instead of doing `case <-time.AfterFunc(d)`, which leaks timers since in the healthy state blocks will be the `case` that hits first.
- make `SubscribeValidators` method of `TxApp` to avoid polling `GetValidators` every seconds. This means less constant, albeit minor, resource use, plus the listener learns of it's promotion/demotion from the validator set immediately.  In the case of a validator being added, they will be more likely to vote promptly.  This adds a bit of extra complexity to `TxApp`, but it's not so bad considering the eliminated polling.
- various context and error handling fixes

This also adds a `test/cmd/ethlisten` CLI app for debugging and testing both the listener code and an operator's chosen RPC provider, event contract, etc. (their listener oracle config they'd specify for their validator).  This also gives some confidence in the robustness of the listener and RPC client code given network interruptions and rescans of missed blocks.

Note that in `ethlisten`, I've enabled `go-ethereum`'s global logger as such:

```
import ethLog "github.com/ethereum/go-ethereum/log"

...

	rpcLogger := ethLog.NewTerminalHandlerWithLevel(os.Stdout, ethLog.LevelTrace, true)
	ethLog.SetDefault(ethLog.NewLogger(rpcLogger))
```

which gives the app some helpful feedback about it's workings.  For example:

```
{"level":"debug","ts":1712098128.9844832,"caller":"eth_deposits/ethereum.go:174","msg":"New block","height":5616428}
{"level":"info","ts":1712098128.9846187,"caller":"eth_deposits/deposits.go:115","msg":"received new block height","height":5616428}
{"level":"info","ts":1712098129.1587024,"caller":"eth_deposits/deposits.go:163","msg":"processed events","from":5616428,"to":5616428,"events":0}
{"level":"debug","ts":1712098174.1805093,"caller":"eth_deposits/ethereum.go:189","msg":"No new blocks received, resubscribing"}
{"level":"warn","ts":1712098174.180555,"caller":"eth_deposits/ethereum.go:153","msg":"Resubscribing to Ethereum node","attempt":0}
DEBUG[04-02|17:49:49.026] RPC connection read error                err="read tcp [2603:8080:f02:1104:a71c:6c5:d183:2345]:49118->[2606:4700::6811:381d]:443: i/o timeout"
DEBUG[04-02|17:50:33.058] RPC client reconnected                   reading=false conn=
{"level":"debug","ts":1712098233.1304095,"caller":"eth_deposits/ethereum.go:189","msg":"No new blocks received, resubscribing"}
{"level":"warn","ts":1712098233.1304512,"caller":"eth_deposits/ethereum.go:153","msg":"Resubscribing to Ethereum node","attempt":0}
{"level":"debug","ts":1712098237.1773925,"caller":"eth_deposits/ethereum.go:174","msg":"New block","height":5616437}
{"level":"info","ts":1712098237.1774504,"caller":"eth_deposits/deposits.go:115","msg":"received new block height","height":5616437}
{"level":"info","ts":1712098237.4545577,"caller":"eth_deposits/deposits.go:163","msg":"processed events","from":5616429,"to":5616437,"events":0}
```

or with trace logging enabled, all activities:

```
{"level":"debug","ts":1712267316.9224107,"caller":"eth_deposits/ethereum.go:174","msg":"New block","height":5630101}
{"level":"info","ts":1712267316.9224565,"caller":"eth_deposits/deposits.go:115","msg":"received new block height","height":5630101}
TRACE[04-04|16:48:37.031] Handled RPC response                     reqid=1301 duration="4.596µs"
{"level":"info","ts":1712267317.0313444,"caller":"eth_deposits/deposits.go:163","msg":"processed events","from":5630101,"to":5630101,"events":0}
DEBUG[04-04|16:48:48.493] RPC connection read error                err="websocket: close 1001 (going away): CloudFlare WebSocket proxy restarting"
{"level":"error","ts":1712267328.4936526,"caller":"eth_deposits/ethereum.go:182","msg":"Ethereum subscription error","error":"websocket: close 1001 (going away): CloudFlare WebSocket proxy restarting","stacktrace":"github.com/kwilteam/kwil-db/extensions/listeners/eth_deposits.(*ethClient).ListenToBlocks\n\t/home/jon/kwil/git/kwil-db/extensions/listeners/eth_deposits/ethereum.go:182\ngithub.com/kwilteam/kwil-db/extensions/listeners/eth_deposits.Start\n\t/home/jon/kwil/git/kwil-db/extensions/listeners/eth_deposits/deposits.go:106\nmain.mainReal\n\t/home/jon/kwil/git/kwil-db/test/cmd/ethlisten/main.go:70\nmain.main\n\t/home/jon/kwil/git/kwil-db/test/cmd/ethlisten/main.go:42\nruntime.main\n\t/home/jon/go122/src/runtime/proc.go:271"}
{"level":"warn","ts":1712267328.493825,"caller":"eth_deposits/ethereum.go:153","msg":"Resubscribing to Ethereum node","attempt":0}
DEBUG[04-04|16:48:48.900] RPC client reconnected                   reading=false conn=
TRACE[04-04|16:48:48.995] Handled RPC response                     reqid=1302 duration="19.012µs"
{"level":"debug","ts":1712267340.7863016,"caller":"eth_deposits/ethereum.go:174","msg":"New block","height":5630103}
{"level":"info","ts":1712267340.7863505,"caller":"eth_deposits/deposits.go:115","msg":"received new block height","height":5630103}
TRACE[04-04|16:49:00.872] Handled RPC response                     reqid=1303 duration="3.116µs"
{"level":"info","ts":1712267340.8724594,"caller":"eth_deposits/deposits.go:163","msg":"processed events","from":5630102,"to":5630103,"events":0}
```

We might consider using it with `kwild`, but we'd 'need to wrap our logger for it to use and find an acceptable format (there are a few choices).  The above is just `ethlisten` test app.