### PR TITLE
[EXPERIMENT] retry in WrapClient if error is connect or net failure rather than app error

### DIFF
--- a/cmd/kwil-cli/cmds/common/roundtripper.go
+++ b/cmd/kwil-cli/cmds/common/roundtripper.go
@@ -41,7 +41,7 @@ func DialClient(ctx context.Context, cmd *cobra.Command, flags uint8, fn RoundTr
 
 	needPrivateKey := flags&WithoutPrivateKey == 0
 
-	clientConfig := clientType.Options{}
+	clientConfig := clientType.Options{} // note for debugging: Logger: log.NewStdOut(log.DebugLevel)
 	if conf.PrivateKey != nil {
 		clientConfig.Signer = &auth.EthPersonalSigner{Key: *conf.PrivateKey}
 		if needPrivateKey { // only check chain ID if signing something

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -109,6 +109,7 @@ CHAIN_INFO:
 			case <-ctx.Done():
 				return nil, ctx.Err()
 			}
+			c.logger.Info("retrying chain_info")
 			goto CHAIN_INFO
 		}
 

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -13,6 +13,7 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"syscall"
 	"time"
 
 	"github.com/cstockton/go-conv"
@@ -99,7 +100,10 @@ CHAIN_INFO:
 		var syscallErr *os.SyscallError
 		if errors.As(err, &syscallErr) {
 			c.logger.Warnf("*os.SyscallError %v (%T)", syscallErr, syscallErr.Err)
-			// if eno, ok := syscallErr.Err.(syscall.Errno); ok { ... }
+			if eno, ok := syscallErr.Err.(syscall.Errno); ok && eno == syscall.ECONNRESET {
+				c.logger.Warn("connection reset", zap.Error(err))
+				retry = true
+			}
 			// don't retry all of this type, just for debugging
 		}
 

--- a/core/types/client/opts.go
+++ b/core/types/client/opts.go
@@ -25,6 +25,10 @@ type Options struct {
 
 	// Silence silences warnings logged from the client.
 	Silence bool
+
+	// RetryHandshake indicates if the initial RPC to the provider during client
+	// construction should be allowed to retry on certain possibly transient errors.
+	RetryHandshake bool
 }
 
 // Apply applies the passed options to the receiver.


### PR DESCRIPTION
We have frequent errors from `chain_info` when doing `core/client.WrapClient` to establish the initial connection.  This is a test to see if we can catch some of these transient errors that probably come from trying to connect too soon.

DO NOT MERGE