### PR TITLE
http: strip trailing slashes from "BasePath"

### DIFF
--- a/core/rpc/client/function/http/client.go
+++ b/core/rpc/client/function/http/client.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"net/http"
 	"net/url"
+	"strings"
 
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	httpFunction "github.com/kwilteam/kwil-db/core/rpc/http/function"
@@ -32,7 +33,7 @@ func NewClient(target *url.URL, opts ...ClientOption) *Client {
 
 	cfg := httpFunction.NewConfiguration()
 	cfg.HTTPClient = clientOpts.client
-	cfg.BasePath = target.String()
+	cfg.BasePath = strings.TrimRight(target.String(), "/")
 	cfg.Host = target.Host
 	cfg.Scheme = target.Scheme
 

--- a/core/rpc/client/user/http/client.go
+++ b/core/rpc/client/user/http/client.go
@@ -43,7 +43,7 @@ func NewClient(target *url.URL, opts ...ClientOption) *Client {
 
 	cfg := httpTx.NewConfiguration()
 	cfg.HTTPClient = clientOpts.client
-	cfg.BasePath = target.String()
+	cfg.BasePath = strings.TrimRight(target.String(), "/")
 	cfg.Host = target.Host
 	cfg.Scheme = target.Scheme
 


### PR DESCRIPTION
The generated Swagger http clients require a URL to which an method's endpoint path is appended.  This is a problem if this base path has a trailing slash since the endpoint paths begin with a slash. The result is that kwild's server will report 404 not found, while kgw would try to clean the path but redirect with GET even for POST.

This change fixes our http client constructors to trim trailing slashes from the base URL.