### PR TITLE
[v0.7.2] use core/v0.1.2 for release

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jackc/pgx/v5 v5.5.2
 	github.com/jpillora/backoff v1.0.0
 	github.com/kwilteam/kuneiform v0.6.1
-	github.com/kwilteam/kwil-db/core v0.1.1
+	github.com/kwilteam/kwil-db/core v0.1.2
 	github.com/kwilteam/kwil-db/parse v0.1.2
 	github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7
 	github.com/manifoldco/promptui v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/kwilteam/action-grammar-go v0.1.1 h1:0NeWrIN0B+pQMyiTwW/kWtqLWl7P4Exm
 github.com/kwilteam/action-grammar-go v0.1.1/go.mod h1:hHGHtnrJpASW9P+F7pdr/EP2M1Hxy1N9Wx/TmjVdV6I=
 github.com/kwilteam/kuneiform v0.6.1 h1:L235Dit/Fmq3wZxvpPySavWTxGO2TgDMvFoUAH/rHRA=
 github.com/kwilteam/kuneiform v0.6.1/go.mod h1:LrwGyaTqTZY1Mcv4hXIJ9t8IfdOf+ZowRdCDXHtiIqU=
-github.com/kwilteam/kwil-db/core v0.1.1 h1:t570x+VoTuCorUWBRF3P3NgBx1LUxOSXDN08CpNyt80=
-github.com/kwilteam/kwil-db/core v0.1.1/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
+github.com/kwilteam/kwil-db/core v0.1.2 h1:rQ5ZpZZbEJFLGKfft3IyZyTu51Gu6hYThFQuKDmd6n4=
+github.com/kwilteam/kwil-db/core v0.1.2/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
 github.com/kwilteam/kwil-db/parse v0.1.2 h1:RE8vzX+hZlDCz329hpoP7Az/v2BxfWZUQQQMkEVRWng=
 github.com/kwilteam/kwil-db/parse v0.1.2/go.mod h1:lGzcCdSvjVrJj71nPuDQRYfF9Jnqj94wFPHEbbDq0+Y=
 github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7 h1:YiPBu0pOeYOtOVfwKQqdWB07SUef9LvngF4bVFD+x34=

--- a/test/go.mod
+++ b/test/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.13.8
 	github.com/kwilteam/kuneiform v0.6.1
 	github.com/kwilteam/kwil-db v0.7.0-rc.1.0.20240311161520-7a09c4734cf1
-	github.com/kwilteam/kwil-db/core v0.1.1
+	github.com/kwilteam/kwil-db/core v0.1.2
 	github.com/stretchr/testify v1.8.4
 	github.com/testcontainers/testcontainers-go v0.27.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.27.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -478,8 +478,8 @@ github.com/kwilteam/kuneiform v0.6.1 h1:L235Dit/Fmq3wZxvpPySavWTxGO2TgDMvFoUAH/r
 github.com/kwilteam/kuneiform v0.6.1/go.mod h1:LrwGyaTqTZY1Mcv4hXIJ9t8IfdOf+ZowRdCDXHtiIqU=
 github.com/kwilteam/kwil-db v0.7.0-rc.1.0.20240311161520-7a09c4734cf1 h1:qUHhU1aXhYMXP1/chPJ74yumbrb2yMZyePJOA9NSBYs=
 github.com/kwilteam/kwil-db v0.7.0-rc.1.0.20240311161520-7a09c4734cf1/go.mod h1:xIk93gboSBmiNKNzC/exXBMv6qRY00J095Us2OwteSg=
-github.com/kwilteam/kwil-db/core v0.1.1 h1:t570x+VoTuCorUWBRF3P3NgBx1LUxOSXDN08CpNyt80=
-github.com/kwilteam/kwil-db/core v0.1.1/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
+github.com/kwilteam/kwil-db/core v0.1.2 h1:rQ5ZpZZbEJFLGKfft3IyZyTu51Gu6hYThFQuKDmd6n4=
+github.com/kwilteam/kwil-db/core v0.1.2/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
 github.com/kwilteam/kwil-db/parse v0.1.2 h1:RE8vzX+hZlDCz329hpoP7Az/v2BxfWZUQQQMkEVRWng=
 github.com/kwilteam/kwil-db/parse v0.1.2/go.mod h1:lGzcCdSvjVrJj71nPuDQRYfF9Jnqj94wFPHEbbDq0+Y=
 github.com/kwilteam/sql-grammar-go v0.1.0 h1:rSS7DER9PWVDmFwNyoInG5oXrn+E9UrZkjref84L4Qk=


### PR DESCRIPTION
AFAIK, this is the final step for `v0.7.2`

Reminder: there are no `replace` statements in releases, so this tag-then-update-dependents flow is needed.