### PR TITLE
test: remove hard code gas enable for 'task dev:up'

### DIFF
--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -32,7 +32,6 @@ func TestLocalDevSetup(t *testing.T) {
 	helper := acceptance.NewActHelper(t)
 	cfg := helper.LoadConfig()
 	cfg.DockerComposeFile = "./docker-compose-dev.yml" // use the dev compose file
-	cfg.GasEnabled = true
 
 	helper.Setup(ctx)
 	helper.WaitUntilInterrupt()


### PR DESCRIPTION
This remove the code enable gas by default for `task dev:up`, if needed, we can set `KACT_GAS_ENABLED` env var to enable this on demand