### PR TITLE
core: gateway client authn precheck

### DIFF
--- a/core/gatewayclient/client.go
+++ b/core/gatewayclient/client.go
@@ -177,12 +177,6 @@ func (c *GatewayClient) authenticate(ctx context.Context) error {
 			kgwAuthVersion, authParam.Version)
 	}
 
-	// returned from kgw in https://github.com/kwilteam/kgw/pull/42
-	if authParam.URI != "" && authParam.URI != authURI {
-		return fmt.Errorf("authn uri mismatch: configured '%s' != remote '%s'",
-			authURI, authParam.URI)
-	}
-
 	msg := composeGatewayAuthMessage(authParam, targetDomain, authURI, kgwAuthVersion, c.Client.ChainID())
 
 	if c.Signer == nil {

--- a/core/types/gateway/gateway.go
+++ b/core/types/gateway/gateway.go
@@ -18,4 +18,9 @@ type GatewayAuthParameter struct {
 	Statement      string `json:"statement"` // optional
 	IssueAt        string `json:"issue_at"`
 	ExpirationTime string `json:"expiration_time"`
+	// client can use those to precheck before signing
+	ChainID string `json:"chain_id"` // the chain id of the gateway
+	Domain  string `json:"domain"`   // the domain of the gateway
+	Version string `json:"version"`  // the authn version used by the gateway
+	URI     string `json:"uri"`      // the endpoint used for authn
 }


### PR DESCRIPTION
This applies authn precheck logic.
It is done by KGW https://github.com/kwilteam/kgw/commit/c10a50d009ee293a02988ec3f7e911da51fca4a3 returns extra domain/chainID/version info that it uses for composing message and verify signature. gateway client here will check if those are same before do the signing.

An example output:
```
# before
$ .build/kwil-cli database call --action owner_only --name testdb --kwil-provider http://127.0.0.1:8090/ --authenticate
http://127.0.0.1:8090/ wants you to sign in with your account:

I accept the Terms of Service: https://yourdoamin.com/tos

URI: http://127.0.0.1:8090/auth
Version: 1
Chain ID: kwil-test-chain
Nonce: 4bf1ca947380742134e3
Issue At: 2024-04-12T16:45:32Z
Expiration Time: 2024-04-12T16:46:02Z

Do you want to sign this message?: y
error calling action: authenticate error: gateway auth: invalid signature: expected address c89d42189f0450c2b2c3c61f58ec5d628176a1e7, received 0014313051c092a89932f042ef296bf7c4179991

# after
$ .build/kwil-cli database call --action owner_only --name testdb --kwil-provider http://127.0.0.1:8090/ --authenticate
error calling action: authenticate error: domain mismatch: configured 'http://127.0.0.1:8090' != remote http://localhost:8090
```

This should be backported to v0.7 and v0.6