### PR TITLE
added debug log for expired resolutions

### DIFF
--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -523,10 +523,14 @@ func (r *TxApp) processVotes(ctx context.Context, blockheight int64) error {
 			// we need to use each configured resolutions refund threshold
 			requiredPowerMap[resolution.Type] = requiredPower(ctx, r.currentTx, cfg.RefundThreshold, totalPower)
 		}
+		refunded := false
 		// if it has enough power, we will still refund
 		if resolution.ApprovedPower >= threshold {
+			refunded = true
 			credits.applyResolution(resolution)
 		}
+
+		r.log.Debug("expiring resolution", zap.String("type", resolution.Type), zap.String("id", resolution.ID.String()), zap.Bool("refunded", refunded))
 	}
 
 	allIds := append(finalizedIds, expiredIds...)


### PR DESCRIPTION
Adds a debug log for failed resolutions. We should backport this to v0.7, since it will be helpful for @outerlook who is implementing the Streamr oracle for Powerpod

