### PR TITLE
docker: use 16.2 in compose

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,7 +12,7 @@ jobs:
 
     services:
       postgres:
-        image: kwildb/postgres:latest
+        image: kwildb/postgres:16.2-1
         env:
           POSTGRES_PORT: 5432
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/deployments/compose/kwil/docker-compose.yml
+++ b/deployments/compose/kwil/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 services:
   pg:
     container_name: postgres-kwild-single
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "15432:5432"
     restart: always
@@ -24,6 +24,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - pgkwil:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/create_user.sql

--- a/deployments/compose/postgres/docker-compose.yml
+++ b/deployments/compose/postgres/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   pg:
     container_name: postgres
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432:5432"
     restart: always
@@ -17,6 +17,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes: 
       - kwildb:/var/lib/postgresql/data
       - ./init.sql:/docker-entrypoint-initdb.d/create_user.sql

--- a/test/acceptance/docker-compose-dev.yml
+++ b/test/acceptance/docker-compose-dev.yml
@@ -50,7 +50,7 @@ services:
       retries: 10
 
   pg:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5454:5432"
     restart: always
@@ -63,6 +63,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:

--- a/test/acceptance/docker-compose.yml
+++ b/test/acceptance/docker-compose.yml
@@ -48,7 +48,7 @@ services:
       retries: 10
 
   pg:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -61,6 +61,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:

--- a/test/integration/docker-compose-dev.yml
+++ b/test/integration/docker-compose-dev.yml
@@ -44,7 +44,7 @@ services:
       retries: 10
 
   pg0:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -57,6 +57,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -107,7 +109,7 @@ services:
       retries: 10
 
   pg1:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -120,6 +122,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -171,7 +175,7 @@ services:
       retries: 10
 
   pg2:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -184,6 +188,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -237,7 +243,7 @@ services:
       retries: 10
 
   pg3:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -250,6 +256,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -300,7 +308,7 @@ services:
       retries: 10
 
   pg4:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -313,6 +321,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -363,7 +373,7 @@ services:
       retries: 10
 
   pg5:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -376,6 +386,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:

--- a/test/integration/docker-compose.yml.template
+++ b/test/integration/docker-compose.yml.template
@@ -46,7 +46,7 @@ services:
       retries: 10
 
   pg0:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -59,6 +59,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -111,7 +113,7 @@ services:
       retries: 10
 
   pg1:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -124,6 +126,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -176,7 +180,7 @@ services:
       retries: 10
 
   pg2:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -189,6 +193,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -244,7 +250,7 @@ services:
       retries: 10
 
   pg3:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -257,6 +263,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -309,7 +317,7 @@ services:
       retries: 10
 
   pg4:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -322,6 +330,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
@@ -374,7 +384,7 @@ services:
       retries: 10
 
   pg5:
-    image: postgres:16.1
+    image: postgres:16.2
     ports:
       - "5432"
     restart: always
@@ -387,6 +397,8 @@ services:
       -c max_wal_senders=10
       -c max_replication_slots=10
       -c max_prepared_transactions=2
+      -c track_commit_timestamp=true
+      -c wal_sender_timeout=0
     volumes:
       - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:


### PR DESCRIPTION
With the `kwildb/postgres` docker image updated in https://github.com/kwilteam/kwil-db/pull/605, this updates the CI to use that version explicitly.

Also use `postgres:16.2` in the compose service files, and update the command flags to match `kwildb/postgres:16.2-1`.
