### PR TITLE
VoteBodyTx fixes

### DIFF
--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -654,11 +654,13 @@ func (r *TxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxsSize int6
 		ids = append(ids, event.ID())
 	}
 
+	// Filter out events which doesn't have resolutions or resolution body
 	doesNotHaveBody, err := voting.FilterExistsNoBody(ctx, readTx, ids...)
 	if err != nil {
 		return nil, err
 	}
 
+	// Filter out already processed resolutions
 	notProcessed, err := voting.FilterNotProcessed(ctx, readTx, doesNotHaveBody...)
 	if err != nil {
 		return nil, err

--- a/internal/voting/sql.go
+++ b/internal/voting/sql.go
@@ -129,7 +129,7 @@ const (
 	WHERE p.id IS NULL;`
 
 	// returnNoBody returns all resolutions that do not have a body passed in the input array
-	returnNoBody = `SELECT id FROM ` + votingSchemaName + `.resolutions WHERE id =ANY($1) AND body IS NULL;`
+	returnHasBody = `SELECT id FROM ` + votingSchemaName + `.resolutions WHERE id =ANY($1) AND body IS NOT NULL;`
 
 	// getResolutionsFullInfoByPower and getResolutionsFullInfoByExpiration are used to get the full info of a set of resolutions
 	// they should be updated together if their return values change

--- a/internal/voting/vote_test.go
+++ b/internal/voting/vote_test.go
@@ -262,12 +262,30 @@ func Test_Voting(t *testing.T) {
 
 				containsBody, err := voting.FilterExistsNoBody(ctx, db, types.NewUUIDV5([]byte("ss")))
 				require.NoError(t, err)
-				require.Empty(t, containsBody)
+				require.Equal(t, len(containsBody), 1)
 
 				processed, err := voting.FilterNotProcessed(ctx, db, types.NewUUIDV5([]byte("ss")))
 				require.NoError(t, err)
 
 				require.Equal(t, len(processed), 1)
+			},
+		},
+		{
+			name: "filter existing resolution bodies",
+			startingPower: map[string]int64{
+				"a": 100,
+			},
+			fn: func(t *testing.T, db sql.DB) {
+				ctx := context.Background()
+				// create a resolution
+				evtID := testEvent.ID()
+				err := voting.CreateResolution(ctx, db, testEvent, 10, []byte("a"))
+				require.NoError(t, err)
+
+				// filter for the resolution
+				containsBody, err := voting.FilterExistsNoBody(ctx, db, evtID)
+				require.NoError(t, err)
+				require.Empty(t, containsBody)
 			},
 		},
 	}


### PR DESCRIPTION
There is an issue with `FilterExistsNoBody` which is supposed to take list of event IDs and filter out the events/resolutions to which we already received a voteBody. But the API filters out only the ids for which the resolution and body exists. It doesn't return the event ids to which the resolutions are not created yet. This becomes more pronounced in a single-node deployments as we only do voteBody Transactions, so resolutions without body are never created, Essentially the extensions will not work in a single-node deployments.