### PR TITLE
function client: VerifySignature return wrapped error

### DIFF
--- a/core/rpc/client/error.go
+++ b/core/rpc/client/error.go
@@ -10,7 +10,6 @@ import (
 
 // The following errors may be detected by consumers using errors.Is.
 var (
-	ErrInvalidSignature = errors.New("invalid signature")
 	// ErrUnauthorized is returned when the client is not authenticated
 	// It is the equivalent of http status code 401
 	ErrUnauthorized = errors.New("unauthorized")

--- a/core/rpc/client/function/http/client.go
+++ b/core/rpc/client/function/http/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	httpFunction "github.com/kwilteam/kwil-db/core/rpc/http/function"
 )
+
+var ErrInvalidSignature = errors.New("invalid signature")
 
 type Client struct {
 	conn *httpFunction.APIClient
@@ -51,17 +54,21 @@ func (c *Client) VerifySignature(ctx context.Context, sender []byte, signature *
 			SignatureType:  signature.Type,
 		},
 	})
-	if err != nil {
+	if err != nil { // communication error
 		return err
 	}
 	defer res.Body.Close()
 
+	// server logic error
 	if result.Error_ != "" {
-		return errors.New(result.Error_)
+		return fmt.Errorf("%w: %s", ErrInvalidSignature, result.Error_)
 	}
 
+	// NOTE: Forget why I put both `valid` and `error` in the response.
+	// if `valid` is false, `error` should not be empty.
+	// This might be not needed, but I just keep it here.
 	if !result.Valid {
-		return errors.New("invalid signature")
+		return ErrInvalidSignature
 	}
 
 	return nil


### PR DESCRIPTION
Return a wrapped error in `VerifySignature`, so an app can easily distinguish communication error from server logic error.

A example in kgw https://github.com/kwilteam/kgw/blob/023575d8605fa3e1ddc8d48cb3a8953b57b5430e/utils.go#L149, kgw naively just does string match to determine if it's a server logic error. But for authenticator related errors, this won't work.

This should be backported to v0.7 and v0.6