### PR TITLE
[v0.7.4] func client wrap error

### DIFF
--- a/core/rpc/client/error.go
+++ b/core/rpc/client/error.go
@@ -10,7 +10,6 @@ import (
 
 // The following errors may be detected by consumers using errors.Is.
 var (
-	ErrInvalidSignature = errors.New("invalid signature")
 	// ErrUnauthorized is returned when the client is not authenticated
 	// It is the equivalent of http status code 401
 	ErrUnauthorized = errors.New("unauthorized")

--- a/core/rpc/client/function/http/client.go
+++ b/core/rpc/client/function/http/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -11,6 +12,8 @@ import (
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	httpFunction "github.com/kwilteam/kwil-db/core/rpc/http/function"
 )
+
+var ErrInvalidSignature = errors.New("invalid signature")
 
 type Client struct {
 	conn *httpFunction.APIClient
@@ -51,17 +54,21 @@ func (c *Client) VerifySignature(ctx context.Context, sender []byte, signature *
 			SignatureType:  signature.Type,
 		},
 	})
-	if err != nil {
+	if err != nil { // communication error
 		return err
 	}
 	defer res.Body.Close()
 
+	// server logic error
 	if result.Error_ != "" {
-		return errors.New(result.Error_)
+		return fmt.Errorf("%w: %s", ErrInvalidSignature, result.Error_)
 	}
 
+	// NOTE: Forget why I put both `valid` and `error` in the response.
+	// if `valid` is false, `error` should not be empty.
+	// This might be not needed, but I just keep it here.
 	if !result.Valid {
-		return errors.New("invalid signature")
+		return ErrInvalidSignature
 	}
 
 	return nil


### PR DESCRIPTION
This backports #673 to v0.7.

I guess we put this in v0.7.4?

core version should be bumped as well