### PR TITLE
[v0.7.5]  update gomod for core module version bump

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/jackc/pgx/v5 v5.5.2
 	github.com/jpillora/backoff v1.0.0
 	github.com/kwilteam/kuneiform v0.6.1
-	github.com/kwilteam/kwil-db/core v0.1.2
+	github.com/kwilteam/kwil-db/core v0.1.3
 	github.com/kwilteam/kwil-db/parse v0.1.2
 	github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7
 	github.com/manifoldco/promptui v0.9.0

--- a/go.sum
+++ b/go.sum
@@ -276,8 +276,8 @@ github.com/kwilteam/action-grammar-go v0.1.1 h1:0NeWrIN0B+pQMyiTwW/kWtqLWl7P4Exm
 github.com/kwilteam/action-grammar-go v0.1.1/go.mod h1:hHGHtnrJpASW9P+F7pdr/EP2M1Hxy1N9Wx/TmjVdV6I=
 github.com/kwilteam/kuneiform v0.6.1 h1:L235Dit/Fmq3wZxvpPySavWTxGO2TgDMvFoUAH/rHRA=
 github.com/kwilteam/kuneiform v0.6.1/go.mod h1:LrwGyaTqTZY1Mcv4hXIJ9t8IfdOf+ZowRdCDXHtiIqU=
-github.com/kwilteam/kwil-db/core v0.1.2 h1:rQ5ZpZZbEJFLGKfft3IyZyTu51Gu6hYThFQuKDmd6n4=
-github.com/kwilteam/kwil-db/core v0.1.2/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
+github.com/kwilteam/kwil-db/core v0.1.3 h1:U3baWiqlY0Qcv6+fPFljHdKwN+vvLqu16K2HiUojxHY=
+github.com/kwilteam/kwil-db/core v0.1.3/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
 github.com/kwilteam/kwil-db/parse v0.1.2 h1:RE8vzX+hZlDCz329hpoP7Az/v2BxfWZUQQQMkEVRWng=
 github.com/kwilteam/kwil-db/parse v0.1.2/go.mod h1:lGzcCdSvjVrJj71nPuDQRYfF9Jnqj94wFPHEbbDq0+Y=
 github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7 h1:YiPBu0pOeYOtOVfwKQqdWB07SUef9LvngF4bVFD+x34=

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0.7.3"
+const kwilVersion = "0.7.5"
 
 // KwildVersion may be set at compile time by:
 //

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -32,7 +32,6 @@ func TestLocalDevSetup(t *testing.T) {
 	helper := acceptance.NewActHelper(t)
 	cfg := helper.LoadConfig()
 	cfg.DockerComposeFile = "./docker-compose-dev.yml" // use the dev compose file
-	cfg.GasEnabled = true
 
 	helper.Setup(ctx)
 	helper.WaitUntilInterrupt()

--- a/test/go.mod
+++ b/test/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/ethereum/go-ethereum v1.13.8
 	github.com/kwilteam/kuneiform v0.6.1
 	github.com/kwilteam/kwil-db v0.7.0-rc.1.0.20240311161520-7a09c4734cf1
-	github.com/kwilteam/kwil-db/core v0.1.2
+	github.com/kwilteam/kwil-db/core v0.1.3
 	github.com/stretchr/testify v1.8.4
 	github.com/testcontainers/testcontainers-go v0.27.0
 	github.com/testcontainers/testcontainers-go/modules/compose v0.27.0

--- a/test/go.sum
+++ b/test/go.sum
@@ -478,8 +478,8 @@ github.com/kwilteam/kuneiform v0.6.1 h1:L235Dit/Fmq3wZxvpPySavWTxGO2TgDMvFoUAH/r
 github.com/kwilteam/kuneiform v0.6.1/go.mod h1:LrwGyaTqTZY1Mcv4hXIJ9t8IfdOf+ZowRdCDXHtiIqU=
 github.com/kwilteam/kwil-db v0.7.0-rc.1.0.20240311161520-7a09c4734cf1 h1:qUHhU1aXhYMXP1/chPJ74yumbrb2yMZyePJOA9NSBYs=
 github.com/kwilteam/kwil-db v0.7.0-rc.1.0.20240311161520-7a09c4734cf1/go.mod h1:xIk93gboSBmiNKNzC/exXBMv6qRY00J095Us2OwteSg=
-github.com/kwilteam/kwil-db/core v0.1.2 h1:rQ5ZpZZbEJFLGKfft3IyZyTu51Gu6hYThFQuKDmd6n4=
-github.com/kwilteam/kwil-db/core v0.1.2/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
+github.com/kwilteam/kwil-db/core v0.1.3 h1:U3baWiqlY0Qcv6+fPFljHdKwN+vvLqu16K2HiUojxHY=
+github.com/kwilteam/kwil-db/core v0.1.3/go.mod h1:RA50TUJ1LUMVdIWyrr0pVqfI7mqMGQyVLYvvFUbKkNk=
 github.com/kwilteam/kwil-db/parse v0.1.2 h1:RE8vzX+hZlDCz329hpoP7Az/v2BxfWZUQQQMkEVRWng=
 github.com/kwilteam/kwil-db/parse v0.1.2/go.mod h1:lGzcCdSvjVrJj71nPuDQRYfF9Jnqj94wFPHEbbDq0+Y=
 github.com/kwilteam/sql-grammar-go v0.1.0 h1:rSS7DER9PWVDmFwNyoInG5oXrn+E9UrZkjref84L4Qk=


### PR DESCRIPTION
This pr is going to update go.mod which deps on core/v0.1.3(to tag, I'll tag it once I'm sure no more changes will be made to core module).