### PR TITLE
tx broadcast debugging

### DIFF
--- a/cmd/kwil-cli/cmds/account/balance.go
+++ b/cmd/kwil-cli/cmds/account/balance.go
@@ -15,11 +15,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
-	confirmed bool
-)
-
 func balanceCmd() *cobra.Command {
+	var confirmed bool
 	cmd := &cobra.Command{
 		Use:   "balance",
 		Short: "Gets an account's balance and nonce",

--- a/cmd/kwil-cli/cmds/account/balance.go
+++ b/cmd/kwil-cli/cmds/account/balance.go
@@ -41,7 +41,7 @@ func balanceCmd() *cobra.Command {
 						return display.PrintErr(cmd, errors.New("empty account ID"))
 					}
 				}
-				acct, err := cl.GetAccount(ctx, acctID, types.AccountStatusLatest)
+				acct, err := cl.GetAccount(ctx, acctID, types.AccountStatusPending)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("get account failed: %w", err))
 				}

--- a/cmd/kwil-cli/cmds/account/balance.go
+++ b/cmd/kwil-cli/cmds/account/balance.go
@@ -15,6 +15,10 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	confirmed bool
+)
+
 func balanceCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "balance",
@@ -41,7 +45,11 @@ func balanceCmd() *cobra.Command {
 						return display.PrintErr(cmd, errors.New("empty account ID"))
 					}
 				}
-				acct, err := cl.GetAccount(ctx, acctID, types.AccountStatusPending)
+				status := types.AccountStatusPending
+				if confirmed {
+					status = types.AccountStatusLatest
+				}
+				acct, err := cl.GetAccount(ctx, acctID, status)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("get account failed: %w", err))
 				}
@@ -54,6 +62,8 @@ func balanceCmd() *cobra.Command {
 
 		},
 	}
+
+	cmd.Flags().BoolVar(&confirmed, "confirmed", false, "reflect only confirmed state (default reflects mempool / pending)")
 
 	return cmd
 }

--- a/cmd/kwil-cli/cmds/account/balance.go
+++ b/cmd/kwil-cli/cmds/account/balance.go
@@ -16,7 +16,7 @@ import (
 )
 
 func balanceCmd() *cobra.Command {
-	var confirmed bool
+	var pending bool
 	cmd := &cobra.Command{
 		Use:   "balance",
 		Short: "Gets an account's balance and nonce",
@@ -42,9 +42,9 @@ func balanceCmd() *cobra.Command {
 						return display.PrintErr(cmd, errors.New("empty account ID"))
 					}
 				}
-				status := types.AccountStatusPending
-				if confirmed {
-					status = types.AccountStatusLatest
+				status := types.AccountStatusLatest
+				if pending {
+					status = types.AccountStatusPending
 				}
 				acct, err := cl.GetAccount(ctx, acctID, status)
 				if err != nil {
@@ -60,7 +60,7 @@ func balanceCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().BoolVar(&confirmed, "confirmed", false, "reflect only confirmed state (default reflects mempool / pending)")
+	cmd.Flags().BoolVar(&pending, "pending", false, "reflect pending updates from mempool (default is confirmed only)")
 
 	return cmd
 }

--- a/cmd/kwild/server/utils.go
+++ b/cmd/kwild/server/utils.go
@@ -120,6 +120,15 @@ func (wc *wrappedCometBFTClient) BroadcastTx(ctx context.Context, tx []byte, syn
 		bcastFun = func(ctx context.Context, tx cmttypes.Tx) (*cmtCoreTypes.ResultBroadcastTx, error) {
 			res, err := wc.cl.BroadcastTxCommit(ctx, tx)
 			if err != nil {
+				if res != nil { // seriously, they do this
+					return &cmtCoreTypes.ResultBroadcastTx{
+						Code:      res.CheckTx.Code,
+						Data:      res.CheckTx.Data,
+						Log:       res.CheckTx.Log,
+						Codespace: res.CheckTx.Codespace,
+						Hash:      res.Hash,
+					}, err
+				}
 				return nil, err
 			}
 			if res.CheckTx.Code != abciTypes.CodeTypeOK {

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -752,6 +752,8 @@ func (a *AbciApp) prepareBlockTransactions(txs [][]byte, log *log.Logger, maxTxB
 		txSize := int64(len(txs[tx.is]))
 		if maxTxBytes < txSize {
 			// Ignore the rest of the transactions by this sender
+			a.log.Warn("transaction being excluded from block with insufficient remaining space",
+				zap.String("sender", hex.EncodeToString(tx.Sender)))
 			senders[sender] = true
 			break
 		}

--- a/internal/services/grpc/txsvc/v1/broadcast.go
+++ b/internal/services/grpc/txsvc/v1/broadcast.go
@@ -57,7 +57,7 @@ func (s *Service) Broadcast(ctx context.Context, req *txpb.BroadcastRequest) (*t
 	if err != nil {
 		logger.Error("failed to broadcast tx", zap.Error(err))
 		if res == nil { // they really do this to report hash on commit fail/timeout
-			return nil, status.Errorf(codes.Internal, "failed to broadcast transaction")
+			return nil, status.Errorf(codes.Unknown, "failed to broadcast transaction: %v", err)
 		} // else we have a result, and error is probably timeout
 		commitFail = true // we have res, but also treat as error.
 	}

--- a/internal/services/grpc/txsvc/v1/broadcast.go
+++ b/internal/services/grpc/txsvc/v1/broadcast.go
@@ -3,6 +3,7 @@ package txsvc
 import (
 	"context"
 	"encoding/hex"
+	"strings"
 
 	"github.com/kwilteam/kwil-db/core/rpc/client/user/grpc"
 	txpb "github.com/kwilteam/kwil-db/core/rpc/protobuf/tx/v1"
@@ -51,20 +52,32 @@ func (s *Service) Broadcast(ctx context.Context, req *txpb.BroadcastRequest) (*t
 	if req.Sync != nil {
 		sync = uint8(*req.Sync)
 	}
+	var commitFail bool
 	res, err := s.chainClient.BroadcastTx(ctx, encodedTx, sync)
 	if err != nil {
 		logger.Error("failed to broadcast tx", zap.Error(err))
-		return nil, status.Errorf(codes.Internal, "failed to broadcast transaction")
+		if res == nil { // they really do this to report hash on commit fail/timeout
+			return nil, status.Errorf(codes.Internal, "failed to broadcast transaction")
+		} // else we have a result, and error is probably timeout
+		commitFail = true // we have res, but also treat as error.
 	}
 	code, txHash := res.Code, res.Hash.Bytes()
 
-	if txCode := transactions.TxCode(code); txCode != transactions.CodeOk {
+	if txCode := transactions.TxCode(code); txCode != transactions.CodeOk || commitFail {
 		stat := &spb.Status{
 			Code:    int32(codes.InvalidArgument),
 			Message: "broadcast error",
 		}
+		if commitFail { // we have both res and err, probably a timeout
+			stat.Message = err.Error()
+			if strings.Contains(err.Error(), "timed out") { // not exported; doing our best
+				stat.Code = int32(codes.DeadlineExceeded)
+			} else {
+				stat.Code = int32(codes.Unknown)
+			}
+		}
 		if details, err := anypb.New(&txpb.BroadcastErrorDetails{
-			Code:    code, // e.g. invalid nonce, wrong chain, etc.
+			Code:    code, // e.g. invalid nonce, wrong chain, etc. or maybe OK if commit timed out
 			Hash:    hex.EncodeToString(txHash),
 			Message: res.Log,
 		}); err != nil {

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -90,7 +90,7 @@ func (d *KwilCliDriver) SupportBatch() bool {
 }
 
 func (d *KwilCliDriver) account(ctx context.Context, acctID []byte) (*types.Account, error) {
-	cmd := d.newKwilCliCmd("account", "balance", "--confirmed", hex.EncodeToString(acctID))
+	cmd := d.newKwilCliCmd("account", "balance", hex.EncodeToString(acctID))
 	out, err := mustRun(cmd, d.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get account balance: %w", err)

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -90,7 +90,7 @@ func (d *KwilCliDriver) SupportBatch() bool {
 }
 
 func (d *KwilCliDriver) account(ctx context.Context, acctID []byte) (*types.Account, error) {
-	cmd := d.newKwilCliCmd("account", "balance", hex.EncodeToString(acctID))
+	cmd := d.newKwilCliCmd("account", "balance", "--confirmed", hex.EncodeToString(acctID))
 	out, err := mustRun(cmd, d.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get account balance: %w", err)


### PR DESCRIPTION
This is https://github.com/kwilteam/kwil-db/pull/680, but for `main` and also with warning logged in `prepareBlockTransactions` if a transaction is held back for exceeding the block size limit (which is only likely in the case of lots of validator inserted txns).