### PR TITLE
kwil-cli,transactions: add decode-tx command

### DIFF
--- a/cmd/common/display/message_test.go
+++ b/cmd/common/display/message_test.go
@@ -127,12 +127,16 @@ func getExampleTxQueryResponse() *transactions.TcTxQueryResponse {
 }
 
 func Example_respTxQuery_text() {
-	Print(&RespTxQuery{Msg: getExampleTxQueryResponse()}, nil, "text")
+	Print(&RespTxQuery{Msg: getExampleTxQueryResponse(), WithRaw: true}, nil, "text")
 	// Output:
 	// Transaction ID: 31303234
 	// Status: success
 	// Height: 10
 	// Log: This is log
+	// Raw: 0001f8e4f850b841cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e2534758008c736563703235366b315f6570f888a25468697320697320612074657374207472616e73616374696f6e20666f7220636c69b8540001f850b8397866363137616631636137373465626264366432336538666531326335366434316432356132326438316538386636376336633665653064348b6372656174655f75736572c8c783666f6f8233328765786563757465640a846173646686636f6e63617480
+	// WARNING! HASH MISMATCH:
+	// 	Requested 31303234
+	// 	Received  fe77ea3e9c86de9b6afcf8a27c38ac9ddf102086f8ac51263659525d1c39fbf0
 }
 
 func Example_respTxQuery_json() {
@@ -164,6 +168,42 @@ func Example_respTxQuery_json() {
 	//       "gas_used": 10,
 	//       "gas_wanted": 10
 	//     }
+	//   },
+	//   "error": ""
+	// }
+}
+
+func Example_respTxQuery_WithRaw_json() {
+	Print(&RespTxQuery{Msg: getExampleTxQueryResponse(), WithRaw: true}, nil, "json")
+	// Output:
+	// {
+	//   "result": {
+	//     "hash": "31303234",
+	//     "height": 10,
+	//     "tx": {
+	//       "signature": {
+	//         "sig": "yz/tf2/zblkFTASoMbIV5RQFJ1PuNT5v4x1LTvc2rNYVUSfbVV0wBroU/LTHm7rVbI5juBqYljGbsFOp4lNHWAA=",
+	//         "type": "secp256k1_ep"
+	//       },
+	//       "body": {
+	//         "desc": "This is a test transaction for cli",
+	//         "payload": "AAH4ULg5eGY2MTdhZjFjYTc3NGViYmQ2ZDIzZThmZTEyYzU2ZDQxZDI1YTIyZDgxZTg4ZjY3YzZjNmVlMGQ0i2NyZWF0ZV91c2VyyMeDZm9vgjMy",
+	//         "type": "execute",
+	//         "fee": "100",
+	//         "nonce": 10,
+	//         "chain_id": "asdf"
+	//       },
+	//       "serialization": "concat",
+	//       "sender": ""
+	//     },
+	//     "tx_result": {
+	//       "code": 0,
+	//       "log": "This is log",
+	//       "gas_used": 10,
+	//       "gas_wanted": 10
+	//     },
+	//     "raw": "0001f8e4f850b841cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e2534758008c736563703235366b315f6570f888a25468697320697320612074657374207472616e73616374696f6e20666f7220636c69b8540001f850b8397866363137616631636137373465626264366432336538666531326335366434316432356132326438316538386636376336633665653064348b6372656174655f75736572c8c783666f6f8233328765786563757465640a846173646686636f6e63617480",
+	//     "warning": "HASH MISMATCH: requested 31303234; received fe77ea3e9c86de9b6afcf8a27c38ac9ddf102086f8ac51263659525d1c39fbf0"
 	//   },
 	//   "error": ""
 	// }

--- a/cmd/kwil-admin/cmds/utils/query-tx.go
+++ b/cmd/kwil-admin/cmds/utils/query-tx.go
@@ -3,16 +3,14 @@ package utils
 import (
 	"context"
 	"encoding/hex"
-	"encoding/json"
-	"fmt"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
-	"github.com/kwilteam/kwil-db/core/types/transactions"
 	"github.com/spf13/cobra"
 )
 
 func queryTxCmd() *cobra.Command {
+	var raw bool
 	cmd := &cobra.Command{
 		Use:   "query-tx",
 		Short: "Query a transaction's status by hash.",
@@ -35,51 +33,13 @@ func queryTxCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			return display.PrintCmd(cmd, &display.RespTxQuery{Msg: res})
+			return display.PrintCmd(cmd, &display.RespTxQuery{Msg: res, WithRaw: raw})
 		},
 	}
+
+	cmd.Flags().BoolVarP(&raw, "raw", "R", false, "also display the bytes of the serialized transaction")
 
 	common.BindRPCFlags(cmd)
 
 	return cmd
-}
-
-// RespTxQuery is used to represent a transaction response in cli
-type RespTxQuery struct {
-	Msg *transactions.TcTxQueryResponse
-}
-
-func (r *RespTxQuery) MarshalJSON() ([]byte, error) {
-	return json.Marshal(struct {
-		Hash     string                         `json:"hash"` // HEX
-		Height   int64                          `json:"height"`
-		Tx       *transactions.Transaction      `json:"tx"`
-		TxResult transactions.TransactionResult `json:"tx_result"`
-	}{
-		Hash:     hex.EncodeToString(r.Msg.Hash),
-		Height:   r.Msg.Height,
-		Tx:       r.Msg.Tx,
-		TxResult: r.Msg.TxResult,
-	})
-}
-
-func (r *RespTxQuery) MarshalText() ([]byte, error) {
-	status := "failed"
-	if r.Msg.Height == -1 {
-		status = "pending"
-	} else if r.Msg.TxResult.Code == transactions.CodeOk.Uint32() {
-		status = "success"
-	}
-
-	msg := fmt.Sprintf(`Transaction ID: %s
-Status: %s
-Height: %d
-Log: %s`,
-		hex.EncodeToString(r.Msg.Hash),
-		status,
-		r.Msg.Height,
-		r.Msg.TxResult.Log,
-	)
-
-	return []byte(msg), nil
 }

--- a/cmd/kwil-cli/cmds/utils/decode.go
+++ b/cmd/kwil-cli/cmds/utils/decode.go
@@ -1,0 +1,75 @@
+package utils
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/hex"
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/core/types/transactions"
+)
+
+func decodeTx(txBts []byte) (*transaction, error) {
+	var tx transactions.Transaction
+	err := tx.UnmarshalBinary(txBts)
+	if err != nil {
+		return nil, err
+	}
+	return &transaction{
+		Raw: txBts,
+		Tx:  &tx,
+	}, nil
+}
+
+// fromStdIn returns a line from the input reader and trims leading and trailing
+// whitespace.
+func fromStdIn(in io.Reader) ([]byte, error) {
+	str, err := bufio.NewReader(in).ReadBytes('\n')
+	if err != nil {
+		return nil, err
+	}
+	return bytes.TrimSpace(str), nil
+}
+
+func decodeTxCmd() *cobra.Command {
+	var withPayload bool
+	var cmd = &cobra.Command{
+		Use:   "decode-tx",
+		Short: "Decodes a raw transaction.",
+		Long:  "Decodes a raw transaction. Given the bytes of a transaction in base64, give a structured output.",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var txStr string
+			var err error
+			if args[0] == "-" {
+				argReader := cmd.InOrStdin()
+				txStrB, err := fromStdIn(argReader)
+				if err != nil {
+					return display.PrintErr(cmd, err)
+				}
+				txStr = string(txStrB)
+			} else {
+				txStr = args[0]
+			}
+			txBts, err := hex.DecodeString(txStr)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			tx, err := decodeTx(txBts)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			tx.WithPayload = withPayload
+			return display.PrintCmd(cmd, tx)
+		},
+	}
+
+	cmd.Flags().BoolVar(&withPayload, "payload", false, "also show the payload, which may be large")
+
+	return cmd
+}

--- a/cmd/kwil-cli/cmds/utils/message.go
+++ b/cmd/kwil-cli/cmds/utils/message.go
@@ -2,13 +2,95 @@ package utils
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"reflect"
 
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
 	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/kwilteam/kwil-db/core/types/transactions"
 )
+
+type transaction struct {
+	Raw         []byte
+	Tx          *transactions.Transaction
+	WithPayload bool
+}
+
+// remarshalPayload attempt to decode and remarshal the payload from RLP to JSON.
+func (t *transaction) remarshalPayload() (json.RawMessage, bool) {
+	payloadObject, err := transactions.UnmarshalPayload(t.Tx.Body.PayloadType, t.Tx.Body.Payload)
+	if err != nil {
+		return nil, false
+	}
+	payloadJSON, err := json.Marshal(payloadObject)
+	if err != nil {
+		return nil, false
+	}
+	return payloadJSON, true
+}
+
+func (t *transaction) MarshalJSON() ([]byte, error) {
+	if t.WithPayload {
+		payloadJSON, _ := t.remarshalPayload()
+		tx := struct {
+			Tx      *transactions.Transaction `json:"tx"`
+			Payload json.RawMessage           `json:"payload_decoded"`
+		}{
+			Tx:      t.Tx,
+			Payload: payloadJSON,
+		}
+		return json.MarshalIndent(tx, "", "  ")
+	}
+
+	// Decode a fresh Transaction instance and zero out the Payload.
+	tx, err := decodeTx(t.Raw)
+	if err != nil {
+		return nil, err
+	}
+	tx.Tx.Body.Payload = nil
+	return json.MarshalIndent(tx, "", "  ")
+}
+
+func (t *transaction) MarshalText() ([]byte, error) {
+	txHash := sha256.Sum256(t.Raw) // tmhash is sha256
+	msg := fmt.Sprintf(`Transaction ID: %x
+Sender: %s
+Description: %s
+Payload type: %s
+ChainID: %v
+Fee: %s
+Nonce: %d
+Signature type: %s
+Signature: %s
+`,
+		txHash,
+		hex.EncodeToString(t.Tx.Sender), // hex because it's an address or pubkey, probably address
+		t.Tx.Body.Description,
+		t.Tx.Body.PayloadType,
+		t.Tx.Body.ChainID,
+		t.Tx.Body.Fee,
+		t.Tx.Body.Nonce,
+		t.Tx.Signature.Type,
+		base64.StdEncoding.EncodeToString(t.Tx.Signature.Signature),
+	)
+
+	if t.WithPayload { // put it at the end regardless since it' can be big
+		// First try to decode the transaction (RLP), then create readable JSON
+		// for its display. If either fails, show it as base64.
+		payloadJSON, ok := t.remarshalPayload()
+		if !ok {
+			msg += "Payload (invalid): " + base64.StdEncoding.EncodeToString(t.Tx.Body.Payload) + "\n"
+		} else {
+			msg += "Payload (json): " + string(payloadJSON) + "\n"
+		}
+	}
+
+	return []byte(msg), nil
+}
 
 type respChainInfo struct {
 	Info *types.ChainInfo

--- a/cmd/kwil-cli/cmds/utils/tx_query.go
+++ b/cmd/kwil-cli/cmds/utils/tx_query.go
@@ -13,6 +13,7 @@ import (
 )
 
 func txQueryCmd() *cobra.Command {
+	var raw bool
 	cmd := &cobra.Command{
 		Use:   "query-tx <tx_id>",
 		Short: "Queries a transaction from the blockchain. Requires 1 argument: the hex encoded transaction id.",
@@ -29,11 +30,13 @@ func txQueryCmd() *cobra.Command {
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("error querying transaction: %w", err))
 				}
-				return display.PrintCmd(cmd, &display.RespTxQuery{Msg: msg})
+				return display.PrintCmd(cmd, &display.RespTxQuery{Msg: msg, WithRaw: raw})
 			})
 
 		},
 	}
+
+	cmd.Flags().BoolVarP(&raw, "raw", "R", false, "also display the bytes of the serialized transaction")
 
 	return cmd
 }

--- a/cmd/kwil-cli/cmds/utils/utils.go
+++ b/cmd/kwil-cli/cmds/utils/utils.go
@@ -16,6 +16,7 @@ func NewCmdUtils() *cobra.Command {
 		pingCmd(),
 		printConfigCmd(),
 		txQueryCmd(),
+		decodeTxCmd(),
 		chainInfoCmd(),
 		kgwAuthnCmd(),
 		newParseCmd(),


### PR DESCRIPTION
This adds the "utils decode-tx" command to kwil-cli. This is useful with the raw transaction bytes that are currently available from the cometbft RPC server at endpoint `/tx?hash=` or any other source while debugging.

This also adds an `UnmarshalPayload` function to core/types/transactions to allow creating a new instance of a Payload without having to know the concrete type associated with a PayloadType. This allows kwil-cli to easily interpret and display the decoded payload.  If this PR is ported to a release, I'd probably remove this decoding functionality.

## example

deploy:

```
$  ./kwil-cli database deploy -p ~/test_db-nomath.kf --chain-id "" --sync
TxHash: 5307f10f9f6852b7812670aae4ae886a36beb2cbb12ebe1241e986df986eab76
Status: success
Height: 2230
Log: success
```

use cometbft RPC server to get transaction by hash:

```
$  curl -s --insecure http://localhost:26657/tx?hash=0x5307f10f9f6852b7812670aae4ae886a36beb2cbb12ebe1241e986df986eab76 | jq '.'
{
  "jsonrpc": "2.0",
  "id": -1,
  "result": {
    "hash": "5307F10F9F6852B7812670AAE4AE886A36BEB2CBB12EBE1241E986DF986EAB76",
    "height": "2230",
    "index": 0,
    "tx_result": {
      "code": 0,
      "data": null,
      "log": "success",
      "info": "",
      "gas_wanted": "0",
      "gas_used": "0",
      "events": [],
      "codespace": ""
    },
    "tx": "AAH5CW34ULhBnUcv/+sc5Tpe5cnypcz7Bv4uyJuRc+KbwdLPx6WVNIFl6dmPEPXe9MOhLjvzVXEP/JSoMGet1Bl1VMHkjgBV2wGMc2VjcDI1NmsxX2Vw+Qj8gLkI1AAB+QjPhnRlc3RkYoDA+QFM+HqFdXNlcnP4cOOCaWTFg2ludIDZzYtQUklNQVJZX0tFWYDKiE5PVF9OVUxMgOCIdXNlcm5hbWXGhHRleHSAz86HREVGQVVMVIUnc2RzJ9GDYWdlxYNpbnSAxsWDTUlOMNiGd2FsbGV0xoR0ZXh0gMnIhlVOSVFVRYDAwPjOhXBvc3Rz+GXjgmlkxYNpbnSA2c2LUFJJTUFSWV9LRVmAyohOT1RfTlVMTIDPh3VzZXJfaWTFg2ludIDAzoV0aXRsZcaEdGV4dIDA4Ydjb250ZW50xoR0ZXh0gNHQik1BWF9MRU5HVEiEMTAwMOrpjHVuaXF1ZV9pbmRleM6HdXNlcl9pZIV0aXRsZYxVTklRVUVfQlRSRUX19MiHdXNlcl9pZMOCaWSFdXNlcnPgz4ZERUxFVEWHQ0FTQ0FERc+GVVBEQVRFh0NBU0NBREX5B3P4gItjcmVhdGVfdXNlcsDTgyRpZIkkdXNlcm5hbWWEJGFnZQHAuFtJTlNFUlQgSU5UTyAidXNlcnMiIChpZCwgdXNlcm5hbWUsIGFnZSwgd2FsbGV0KQogICAgVkFMVUVTICgkaWQsICR1c2VybmFtZSwgJGFnZSwgQGNhbGxlcik7+IKLdXBkYXRlX3VzZXLA04MkaWSJJHVzZXJuYW1lhCRhZ2UBwLhdVVBEQVRFIFt1c2Vyc10KICAgIFNFVCBpZCA9ICRpZCwgdXNlcm5hbWUgPSAkdXNlcm5hbWUsIGFnZSA9ICRhZ2UKICAgIFdIRVJFIHdhbGxldCA9IEBjYWxsZXI7+GePdXBkYXRlX3VzZXJuYW1lwMqJJHVzZXJuYW1lAcC4R1VQREFURSBgdXNlcnNgCiAgICBTRVQgdXNlcm5hbWUgPSAkdXNlcm5hbWUKICAgIFdIRVJFIHdhbGxldCA9IEBjYWxsZXI7+D6LZGVsZXRlX3VzZXLAwAHArURFTEVURSBGUk9NIHVzZXJzCiAgICBXSEVSRSB3YWxsZXQgPSBAY2FsbGVyO/hekWRlbGV0ZV91c2VyX2J5X2lkwMSDJGlkAcaFT1dORVK4PERFTEVURSBGUk9NICJ1c2VycyIKICAgIFdIRVJFIGlkID0gJGlkIEFORCB3YWxsZXQgPSBAY2FsbGVyO/i2i2NyZWF0ZV9wb3N0wNSDJGlkhiR0aXRsZYgkY29udGVudAHAuJBJTlNFUlQgSU5UTyBwb3N0cyAoaWQsIHVzZXJfaWQsIHRpdGxlLCBjb250ZW50KQogICAgVkFMVUVTICgkaWQsICgKICAgICAgICBTRUxFQ1QgaWQgRlJPTSB1c2VycyBXSEVSRSB3YWxsZXQgPSBAY2FsbGVyCiAgICApLCAkdGl0bGUsICRjb250ZW50KTv4Zo1kZWxldGVfbmVzdGVkwMABwLhSZGVsZXRlX3VzZXIoKTsgLy8gZW5zdXJlIGl0IHBhcnNlcyBhcyBhbiBhY3Rpb24gY2FsbCwgbm90IGEgU1FMIHN0YXRlbWVudCAoREVMRVRFKfiVi2RlbGV0ZV9wb3N0wMSDJGlkAcC4f0RFTEVURSBGUk9NIHBvc3RzCiAgICBXSEVSRSBpZCA9ICRpZCBBTkQgdXNlcl9pZCA9ICgKICAgICAgICBTRUxFQ1QgaWQKICAgICAgICBGUk9NIHVzZXJzCiAgICAgICAgV0hFUkUgd2FsbGV0ID0gQGNhbGxlcgogICAgKTv4VZJnZXRfdXNlcl9ieV93YWxsZXTAyYgkYWRkcmVzcwHAtFNFTEVDVCAqCiAgICBGUk9NIHVzZXJzCiAgICBXSEVSRSB3YWxsZXQgPSAkYWRkcmVzczvoimxpc3RfdXNlcnPAwAHAmFNFTEVDVCAqCiAgICBGUk9NIHVzZXJzO/hgmGdldF91c2VyX3Bvc3RzX2J5X3VzZXJpZMDEgyRpZAHAuD1TRUxFQ1QgdGl0bGUsIGNvbnRlbnQKICAgIEZST00gcG9zdHMKICAgIFdIRVJFIHVzZXJfaWQgPSAkaWQ7+KiOZ2V0X3VzZXJfcG9zdHPAyokkdXNlcm5hbWUBwLiJU0VMRUNUIHRpdGxlLCBjb250ZW50CiAgICBGUk9NIHBvc3RzCiAgICBXSEVSRSB1c2VyX2lkID0gKAogICAgICAgIFNFTEVDVCBpZAogICAgICAgIEZST00gdXNlcnMKICAgICAgICBXSEVSRSB1c2VybmFtZSA9ICR1c2VybmFtZQogICAgKTv4QohnZXRfcG9zdMDEgyRpZAHFhFZJRVerU0VMRUNUICoKICAgIEZST00gcG9zdHMKICAgIFdIRVJFIGlkID0gJGlkO/hAjG11bHRpX3NlbGVjdMDAAcCuU0VMRUNUICogRlJPTSBwb3N0czsKCiAgICBTRUxFQ1QgKiBGUk9NIHVzZXJzO/hCim93bmVyX29ubHnTkkBrZ3coYXV0aG49J3RydWUnKcABy4VPV05FUoRWSUVXlHNlbGVjdCAnb3duZXIgb25seSc7+L6TY3JlYXRlX3Bvc3RfcHJpdmF0ZcDUgyRpZIYkdGl0bGWIJGNvbnRlbnSAwLiQSU5TRVJUIElOVE8gcG9zdHMgKGlkLCB1c2VyX2lkLCB0aXRsZSwgY29udGVudCkKICAgIFZBTFVFUyAoJGlkLCAoCiAgICAgICAgU0VMRUNUIGlkIEZST00gdXNlcnMgV0hFUkUgd2FsbGV0ID0gQGNhbGxlcgogICAgKSwgJHRpdGxlLCAkY29udGVudCk7+FeSY3JlYXRlX3Bvc3RfbmVzdGVkwNSDJGlkhiR0aXRsZYgkY29udGVudAHAq2NyZWF0ZV9wb3N0X3ByaXZhdGUoJGlkLCAkdGl0bGUsICRjb250ZW50KTv4PIphdXRobl9vbmx505JAa2d3KGF1dGhuPSd0cnVlJynAAcWEVklFV5RzZWxlY3QgJ2F1dGhuIG9ubHknO8CNZGVwbG95X3NjaGVtYYAJk2t3aWwtY2hhaW4tems4TkR5bDKGY29uY2F0lNwY9Jk+k7UEhuPlTifZHVfO4doH"
  }
}

```

decode with `kwil-cli utils decode-tx` (without `--payload`)

```
$  ./kwil-cli utils decode-tx "AAH5CW34ULhBnUcv/+sc5Tpe5cnypcz7Bv4uyJuRc+KbwdLPx6WVNIFl6dmPEPXe9MOhLjvzVXEP/JSoMGet1Bl1VMHkjgBV2wGMc2VjcDI..."
Transaction ID: 5307f10f9f6852b7812670aae4ae886a36beb2cbb12ebe1241e986df986eab76
Sender: dc18f4993e93b50486e3e54e27d91d57cee1da07
Description: 
Payload type: deploy_schema
ChainID: kwil-chain-zk8NDyl2
Fee: 0
Nonce: 9
Signature type: secp256k1_ep
Signature: nUcv/+sc5Tpe5cnypcz7Bv4uyJuRc+KbwdLPx6WVNIFl6dmPEPXe9MOhLjvzVXEP/JSoMGet1Bl1VMHkjgBV2wE=
```

with `--payload` the output:

```
Transaction ID: 5307f10f9f6852b7812670aae4ae886a36beb2cbb12ebe1241e986df986eab76
Sender: dc18f4993e93b50486e3e54e27d91d57cee1da07
Description: 
Payload type: deploy_schema
ChainID: kwil-chain-zk8NDyl2
Fee: 0
Nonce: 9
Signature type: secp256k1_ep
Signature: nUcv/+sc5Tpe5cnypcz7Bv4uyJuRc+KbwdLPx6WVNIFl6dmPEPXe9MOhLjvzVXEP/JSoMGet1Bl1VMHkjgBV2wE=
Payload (json): {"Name":"testdb","Owner":"","Extensions":[],"Tables":[{"Name":"users","Columns":[{"Name":"id","Type":{"Name":"int","IsArray":false},"Attributes":[{"Type":"PRIMARY_KEY","Value":""},{"Type":"NOT_NULL","Value":""}]},{"Name":"username","Type":{"Name":"text","IsArray":false},"Attributes":[{"Type":"DEFAULT","Value":"'sds'"}]},{"Name":"age","Type":{"Name":"int","IsArray":false},"Attributes":[{"Type":"MIN","Value":"0"}]},{"Name":"wallet","Type":{"Name":"text","IsArray":false},"Attributes":[{"Type":"UNIQUE","Value":""}]}],"Indexes":[],"ForeignKeys":[]},{"Name":"posts","Columns":[{"Name":"id","Type":{"Name":"int","IsArray":false},"Attributes":[{"Type":"PRIMARY_KEY","Value":""},{"Type":"NOT_NULL","Value":""}]},{"Name":"user_id","Type":{"Name":"int","IsArray":false},"Attributes":[]},{"Name":"title","Type":{"Name":"text","IsArray":false},"Attributes":[]},{"Name":"content","Type":{"Name":"text","IsArray":false},"Attributes":[{"Type":"MAX_LENGTH","Value":"1000"}]}],"Indexes":[{"Name":"unique_index","Columns":["user_id","title"],"Type":"UNIQUE_BTREE"}],"ForeignKeys":[{"ChildKeys":["user_id"],"ParentKeys":["id"],"ParentTable":"users","Actions":[{"On":"DELETE","Do":"CASCADE"},{"On":"UPDATE","Do":"CASCADE"}]}]}],"Actions":[{"Name":"create_user","Annotations":[],"Parameters":["$id","$username","$age"],"Public":true,"Modifiers":[],"Body":"INSERT INTO \"users\" (id, username, age, wallet)\n    VALUES ($id, $username, $age, @caller);"},{"Name":"update_user","Annotations":[],"Parameters":["$id","$username","$age"],"Public":true,"Modifiers":[],"Body":"UPDATE [users]\n    SET id = $id, username = $username, age = $age\n    WHERE wallet = @caller;"},{"Name":"update_username","Annotations":[],"Parameters":["$username"],"Public":true,"Modifiers":[],"Body":"UPDATE `users`\n    SET username = $username\n    WHERE wallet = @caller;"},{"Name":"delete_user","Annotations":[],"Parameters":[],"Public":true,"Modifiers":[],"Body":"DELETE FROM users\n    WHERE wallet = @caller;"},{"Name":"delete_user_by_id","Annotations":[],"Parameters":["$id"],"Public":true,"Modifiers":["OWNER"],"Body":"DELETE FROM \"users\"\n    WHERE id = $id AND wallet = @caller;"},{"Name":"create_post","Annotations":[],"Parameters":["$id","$title","$content"],"Public":true,"Modifiers":[],"Body":"INSERT INTO posts (id, user_id, title, content)\n    VALUES ($id, (\n        SELECT id FROM users WHERE wallet = @caller\n    ), $title, $content);"},{"Name":"delete_nested","Annotations":[],"Parameters":[],"Public":true,"Modifiers":[],"Body":"delete_user(); // ensure it parses as an action call, not a SQL statement (DELETE)"},{"Name":"delete_post","Annotations":[],"Parameters":["$id"],"Public":true,"Modifiers":[],"Body":"DELETE FROM posts\n    WHERE id = $id AND user_id = (\n        SELECT id\n        FROM users\n        WHERE wallet = @caller\n    );"},{"Name":"get_user_by_wallet","Annotations":[],"Parameters":["$address"],"Public":true,"Modifiers":[],"Body":"SELECT *\n    FROM users\n    WHERE wallet = $address;"},{"Name":"list_users","Annotations":[],"Parameters":[],"Public":true,"Modifiers":[],"Body":"SELECT *\n    FROM users;"},{"Name":"get_user_posts_by_userid","Annotations":[],"Parameters":["$id"],"Public":true,"Modifiers":[],"Body":"SELECT title, content\n    FROM posts\n    WHERE user_id = $id;"},{"Name":"get_user_posts","Annotations":[],"Parameters":["$username"],"Public":true,"Modifiers":[],"Body":"SELECT title, content\n    FROM posts\n    WHERE user_id = (\n        SELECT id\n        FROM users\n        WHERE username = $username\n    );"},{"Name":"get_post","Annotations":[],"Parameters":["$id"],"Public":true,"Modifiers":["VIEW"],"Body":"SELECT *\n    FROM posts\n    WHERE id = $id;"},{"Name":"multi_select","Annotations":[],"Parameters":[],"Public":true,"Modifiers":[],"Body":"SELECT * FROM posts;\n\n    SELECT * FROM users;"},{"Name":"owner_only","Annotations":["@kgw(authn='true')"],"Parameters":[],"Public":true,"Modifiers":["OWNER","VIEW"],"Body":"select 'owner only';"},{"Name":"create_post_private","Annotations":[],"Parameters":["$id","$title","$content"],"Public":false,"Modifiers":[],"Body":"INSERT INTO posts (id, user_id, title, content)\n    VALUES ($id, (\n        SELECT id FROM users WHERE wallet = @caller\n    ), $title, $content);"},{"Name":"create_post_nested","Annotations":[],"Parameters":["$id","$title","$content"],"Public":true,"Modifiers":[],"Body":"create_post_private($id, $title, $content);"},{"Name":"authn_only","Annotations":["@kgw(authn='true')"],"Parameters":[],"Public":true,"Modifiers":["VIEW"],"Body":"select 'authn only';"}],"Procedures":[]}
```

using `--output json` and `--payload`, the output is:

```json
{
  "result": {
    "tx": {
      "signature": {
        "signature_bytes": "nUcv/+sc5Tpe5cnypcz7Bv4uyJuRc+KbwdLPx6WVNIFl6dmPEPXe9MOhLjvzVXEP/JSoMGet1Bl1VMHkjgBV2wE=",
        "signature_type": "secp256k1_ep"
      },
      "body": {
        "desc": "",
        "payload": "AAH5CM+GdGVzdGRigMD5AUz4eoV1c2Vyc/hw44JpZMWDaW50gNnNi1BSSU1BUllfS0VZgMqITk9UX05VTEyA4Ih1c2VybmFtZcaEdGV4dIDPzodERUZBVUxUhSdzZHMn0YNhZ2XFg2ludIDGxYNNSU4w2IZ3YWxsZXTGhHRleHSAyciGVU5JUVVFgMDA+M6FcG9zdHP4ZeOCaWTFg2ludIDZzYtQUklNQVJZX0tFWYDKiE5PVF9OVUxMgM+HdXNlcl9pZMWDaW50gMDOhXRpdGxlxoR0ZXh0gMDhh2NvbnRlbnTGhHRleHSA0dCKTUFYX0xFTkdUSIQxMDAw6umMdW5pcXVlX2luZGV4zod1c2VyX2lkhXRpdGxljFVOSVFVRV9CVFJFRfX0yId1c2VyX2lkw4JpZIV1c2Vyc+DPhkRFTEVURYdDQVNDQURFz4ZVUERBVEWHQ0FTQ0FERfkHc/iAi2NyZWF0ZV91c2VywNODJGlkiSR1c2VybmFtZYQkYWdlAcC4W0lOU0VSVCBJTlRPICJ1c2VycyIgKGlkLCB1c2VybmFtZSwgYWdlLCB3YWxsZXQpCiAgICBWQUxVRVMgKCRpZCwgJHVzZXJuYW1lLCAkYWdlLCBAY2FsbGVyKTv4got1cGRhdGVfdXNlcsDTgyRpZIkkdXNlcm5hbWWEJGFnZQHAuF1VUERBVEUgW3VzZXJzXQogICAgU0VUIGlkID0gJGlkLCB1c2VybmFtZSA9ICR1c2VybmFtZSwgYWdlID0gJGFnZQogICAgV0hFUkUgd2FsbGV0ID0gQGNhbGxlcjv4Z491cGRhdGVfdXNlcm5hbWXAyokkdXNlcm5hbWUBwLhHVVBEQVRFIGB1c2Vyc2AKICAgIFNFVCB1c2VybmFtZSA9ICR1c2VybmFtZQogICAgV0hFUkUgd2FsbGV0ID0gQGNhbGxlcjv4PotkZWxldGVfdXNlcsDAAcCtREVMRVRFIEZST00gdXNlcnMKICAgIFdIRVJFIHdhbGxldCA9IEBjYWxsZXI7+F6RZGVsZXRlX3VzZXJfYnlfaWTAxIMkaWQBxoVPV05FUrg8REVMRVRFIEZST00gInVzZXJzIgogICAgV0hFUkUgaWQgPSAkaWQgQU5EIHdhbGxldCA9IEBjYWxsZXI7+LaLY3JlYXRlX3Bvc3TA1IMkaWSGJHRpdGxliCRjb250ZW50AcC4kElOU0VSVCBJTlRPIHBvc3RzIChpZCwgdXNlcl9pZCwgdGl0bGUsIGNvbnRlbnQpCiAgICBWQUxVRVMgKCRpZCwgKAogICAgICAgIFNFTEVDVCBpZCBGUk9NIHVzZXJzIFdIRVJFIHdhbGxldCA9IEBjYWxsZXIKICAgICksICR0aXRsZSwgJGNvbnRlbnQpO/hmjWRlbGV0ZV9uZXN0ZWTAwAHAuFJkZWxldGVfdXNlcigpOyAvLyBlbnN1cmUgaXQgcGFyc2VzIGFzIGFuIGFjdGlvbiBjYWxsLCBub3QgYSBTUUwgc3RhdGVtZW50IChERUxFVEUp+JWLZGVsZXRlX3Bvc3TAxIMkaWQBwLh/REVMRVRFIEZST00gcG9zdHMKICAgIFdIRVJFIGlkID0gJGlkIEFORCB1c2VyX2lkID0gKAogICAgICAgIFNFTEVDVCBpZAogICAgICAgIEZST00gdXNlcnMKICAgICAgICBXSEVSRSB3YWxsZXQgPSBAY2FsbGVyCiAgICApO/hVkmdldF91c2VyX2J5X3dhbGxldMDJiCRhZGRyZXNzAcC0U0VMRUNUICoKICAgIEZST00gdXNlcnMKICAgIFdIRVJFIHdhbGxldCA9ICRhZGRyZXNzO+iKbGlzdF91c2Vyc8DAAcCYU0VMRUNUICoKICAgIEZST00gdXNlcnM7+GCYZ2V0X3VzZXJfcG9zdHNfYnlfdXNlcmlkwMSDJGlkAcC4PVNFTEVDVCB0aXRsZSwgY29udGVudAogICAgRlJPTSBwb3N0cwogICAgV0hFUkUgdXNlcl9pZCA9ICRpZDv4qI5nZXRfdXNlcl9wb3N0c8DKiSR1c2VybmFtZQHAuIlTRUxFQ1QgdGl0bGUsIGNvbnRlbnQKICAgIEZST00gcG9zdHMKICAgIFdIRVJFIHVzZXJfaWQgPSAoCiAgICAgICAgU0VMRUNUIGlkCiAgICAgICAgRlJPTSB1c2VycwogICAgICAgIFdIRVJFIHVzZXJuYW1lID0gJHVzZXJuYW1lCiAgICApO/hCiGdldF9wb3N0wMSDJGlkAcWEVklFV6tTRUxFQ1QgKgogICAgRlJPTSBwb3N0cwogICAgV0hFUkUgaWQgPSAkaWQ7+ECMbXVsdGlfc2VsZWN0wMABwK5TRUxFQ1QgKiBGUk9NIHBvc3RzOwoKICAgIFNFTEVDVCAqIEZST00gdXNlcnM7+EKKb3duZXJfb25sedOSQGtndyhhdXRobj0ndHJ1ZScpwAHLhU9XTkVShFZJRVeUc2VsZWN0ICdvd25lciBvbmx5Jzv4vpNjcmVhdGVfcG9zdF9wcml2YXRlwNSDJGlkhiR0aXRsZYgkY29udGVudIDAuJBJTlNFUlQgSU5UTyBwb3N0cyAoaWQsIHVzZXJfaWQsIHRpdGxlLCBjb250ZW50KQogICAgVkFMVUVTICgkaWQsICgKICAgICAgICBTRUxFQ1QgaWQgRlJPTSB1c2VycyBXSEVSRSB3YWxsZXQgPSBAY2FsbGVyCiAgICApLCAkdGl0bGUsICRjb250ZW50KTv4V5JjcmVhdGVfcG9zdF9uZXN0ZWTA1IMkaWSGJHRpdGxliCRjb250ZW50AcCrY3JlYXRlX3Bvc3RfcHJpdmF0ZSgkaWQsICR0aXRsZSwgJGNvbnRlbnQpO/g8imF1dGhuX29ubHnTkkBrZ3coYXV0aG49J3RydWUnKcABxYRWSUVXlHNlbGVjdCAnYXV0aG4gb25seSc7wA==",
        "type": "deploy_schema",
        "fee": 0,
        "nonce": 9,
        "chain_id": "kwil-chain-zk8NDyl2"
      },
      "serialization": "concat",
      "sender": "3Bj0mT6TtQSG4+VOJ9kdV87h2gc="
    },
    "payload_decoded": {
      "Name": "testdb",
      "Owner": "",
      "Extensions": [],
      "Tables": [
        {
          "Name": "users",
          "Columns": [
            {
              "Name": "id",
              "Type": {
                "Name": "int",
                "IsArray": false
              },
              "Attributes": [
                {
                  "Type": "PRIMARY_KEY",
                  "Value": ""
                },
...
```