### PR TITLE
change kwil-cli config and flags 

### DIFF
--- a/cmd/kwil-cli/cmds/common/roundtripper.go
+++ b/cmd/kwil-cli/cmds/common/roundtripper.go
@@ -35,8 +35,8 @@ func DialClient(ctx context.Context, cmd *cobra.Command, flags uint8, fn RoundTr
 		return err
 	}
 
-	if conf.GrpcURL == "" {
-		return fmt.Errorf("kwil provider url is required")
+	if conf.Provider == "" {
+		return fmt.Errorf("rpc provider url is required")
 	}
 
 	needPrivateKey := flags&WithoutPrivateKey == 0
@@ -53,7 +53,7 @@ func DialClient(ctx context.Context, cmd *cobra.Command, flags uint8, fn RoundTr
 
 	// if not using the gateway, then we can simply create a regular client and return
 	if flags&UsingGateway == 0 {
-		client, err := client.NewClient(ctx, conf.GrpcURL, &clientConfig)
+		client, err := client.NewClient(ctx, conf.Provider, &clientConfig)
 		if err != nil {
 			return err
 		}
@@ -63,7 +63,7 @@ func DialClient(ctx context.Context, cmd *cobra.Command, flags uint8, fn RoundTr
 
 	// if we reach here, we are talking to a gateway
 
-	client, err := gatewayclient.NewClient(ctx, conf.GrpcURL, &gatewayclient.GatewayOptions{
+	client, err := gatewayclient.NewClient(ctx, conf.Provider, &gatewayclient.GatewayOptions{
 		Options: clientConfig,
 		AuthSignFunc: func(message string, signer auth.Signer) (*auth.Signature, error) {
 			assumeYes, err := GetAssumeYesFlag(cmd)

--- a/cmd/kwil-cli/cmds/configure/configure.go
+++ b/cmd/kwil-cli/cmds/configure/configure.go
@@ -15,7 +15,7 @@ var configureLong = `Configure the Kwil CLI with persistent global settings.
 
 This command will prompt you for the following settings:
 
-- Kwil RPC URL: the gRPC URL of the Kwil node you wish to connect to.
+- Kwil RPC provider URL: the RPC URL of the Kwil node you wish to connect to.
 - Kwil Chain ID: the chain ID of the Kwil node you wish to connect to.  If left empty, the Kwil node will provide this value.
 - Private Key: the private key to use for signing transactions.  If left empty, the Kwil CLI will not sign transactions.`
 
@@ -38,7 +38,7 @@ func NewCmdConfigure() *cobra.Command {
 			}
 
 			err = runErrs(conf,
-				promptGRPCURL,
+				promptRPCProvider,
 				promptChainID,
 				promptPrivateKey,
 			)
@@ -65,17 +65,17 @@ func runErrs(conf *config.KwilCliConfig, fns ...func(*config.KwilCliConfig) erro
 	return nil
 }
 
-func promptGRPCURL(conf *config.KwilCliConfig) error {
+func promptRPCProvider(conf *config.KwilCliConfig) error {
 	prompt := &common.Prompter{
-		Label:   "Kwil RPC URL",
-		Default: conf.GrpcURL,
+		Label:   "Kwil RPC provider URL",
+		Default: conf.Provider,
 	}
 	res, err := prompt.Run()
 	if err != nil {
 		return err
 	}
 
-	conf.GrpcURL = res
+	conf.Provider = res
 
 	return nil
 }

--- a/cmd/kwil-cli/cmds/utils/message_test.go
+++ b/cmd/kwil-cli/cmds/utils/message_test.go
@@ -49,12 +49,12 @@ func Example_respKwilCliConfig_text() {
 		cfg: &config.KwilCliConfig{
 			PrivateKey: pk,
 			ChainID:    "chainid123",
-			GrpcURL:    "localhost:9090",
+			Provider:   "localhost:9090",
 		},
 	}, nil, "text")
 	// Output:
 	// PrivateKey: ***
-	// GrpcURL: localhost:9090
+	// Provider: localhost:9090
 	// ChainID: chainid123
 }
 
@@ -68,14 +68,14 @@ func Example_respKwilCliConfig_json() {
 		cfg: &config.KwilCliConfig{
 			PrivateKey: pk,
 			ChainID:    "chainid123",
-			GrpcURL:    "localhost:9090",
+			Provider:   "localhost:9090",
 		},
 	}, nil, "json")
 	// Output:
 	// {
 	//   "result": {
 	//     "private_key": "***",
-	//     "grpc_url": "localhost:9090",
+	//     "provider": "localhost:9090",
 	//     "chain_id": "chainid123"
 	//   },
 	//   "error": ""

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -11,27 +11,19 @@ import (
 var cliCfg = DefaultKwilCliPersistedConfig()
 
 const (
-	defaultConfigDirName      = ".kwil_cli"
+	defaultConfigDirName      = ".kwil-cli"
 	defaultConfigFileName     = "config.json"
 	AlternativeConfigHomePath = "/tmp"
 
 	// NOTE: these flags below are also used as viper key names
 	globalPrivateKeyFlag = "private-key"
-	// globalProviderFlag historically there was a chain-provider flag,
-	// we could/should change this flag to `provider`
-	// also since the config file is using `grpc_url`, should change too
-	// TODO: this is a breaking change
-	globalProviderFlag = "kwil-provider"
-	globalChainIDFlag  = "chain-id"
-	globalOutputFlag   = "output"
-	globalTlsCertFlag  = "tls-cert-file"
+	globalProviderFlag   = "provider"
+	globalChainIDFlag    = "chain-id"
 	// NOTE: viper key name are used for viper related operations
 	// here they are same `mapstructure` names defined in the config struct
 	viperPrivateKeyName = "private_key"
-	viperProviderName   = "grpc_url"
+	viperProviderName   = "provider"
 	viperChainID        = "chain_id"
-	viperTlsCertName    = "tls_cert_file"
-	viperOutputName     = "output"
 )
 
 var defaultConfigFile string
@@ -51,7 +43,7 @@ func init() {
 func BindGlobalFlags(fs *pflag.FlagSet) {
 	// Bind flags to environment variables
 	fs.String(globalPrivateKeyFlag, cliCfg.PrivateKey, "the private key of the wallet that will be used for signing")
-	fs.String(globalProviderFlag, cliCfg.GrpcURL, "the Kwil provider HTTP endpoint")
+	fs.String(globalProviderFlag, cliCfg.Provider, "the Kwil rpc provider HTTP endpoint")
 	fs.String(globalChainIDFlag, cliCfg.ChainID, "the expected/intended Kwil Chain ID")
 
 	// Bind flags to viper, named by the flag name

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -52,7 +52,7 @@ func NewKwilCliDriver(cliBin, rpcUrl, privKey, chainID string, identity []byte, 
 
 // newKwilCliCmd returns a new exec.Cmd for kwil-cli
 func (d *KwilCliDriver) newKwilCliCmd(args ...string) *exec.Cmd {
-	args = append(args, "--kwil-provider", d.rpcUrl)
+	args = append(args, "--provider", d.rpcUrl)
 	args = append(args, "--private-key", d.privKey)
 	args = append(args, "--chain-id", d.chainID)
 	args = append(args, "--output", "json")
@@ -70,7 +70,7 @@ func (d *KwilCliDriver) newKwilCliCmd(args ...string) *exec.Cmd {
 func (d *KwilCliDriver) newKwilCliCmdWithYes(args ...string) *exec.Cmd {
 	args = append([]string{"yes |", d.cliBin}, args...)
 
-	args = append(args, "--kwil-provider", d.rpcUrl)
+	args = append(args, "--provider", d.rpcUrl)
 	args = append(args, "--private-key", d.privKey)
 	args = append(args, "--chain-id", d.chainID)
 	args = append(args, "--output", "json")


### PR DESCRIPTION
BREAKING CHANGE:
- change flags `kwil-provider` to `provider`
- change config field `grpc_url` to `provider`
- change default config folder from `~/.kwil_cli` to `~/.kwil-cli`
