### PR TITLE
engine,pg: fix ad hoc query prepared statement

### DIFF
--- a/internal/engine/execution/global.go
+++ b/internal/engine/execution/global.go
@@ -327,6 +327,7 @@ func (g *GlobalContext) Execute(ctx context.Context, tx sql.DB, dbid, query stri
 	}
 
 	args := orderAndCleanValueMap(values, parsed.ParameterOrder)
+	args = append([]any{pg.QueryModeExec}, args...)
 
 	return tx.Execute(ctx, parsed.Statement, args...)
 }


### PR DESCRIPTION
```
Named (in postgres) prepared statements can fail if the table
definitions later change.  Since the default query mode creates and
persists them, query can fail unexpectedly, requiring a retry.

The mode QueryModeExec prevents this issue by not creating named
prepared statements that can become invalid.

This change uses the same query mode used by action call/execution to be
used for ad hoc queries.

This also adds the QueryModeDescribeExec mode to the QueryMode
enumeration since it may be a better default in other cases, perhaps
for kwild in the future.  This is because it does not have the
undesirable named statement behavior, but it can still rely on postgres'
Parse/Describe protocol to do argument type determination. The down side
of this mode is that it requires two round trips, while the slightly
simpler QueryModeExec does not.
```