### PR TITLE
parse,tasks: reenable parse unit tests and tidy

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -69,8 +69,8 @@ jobs:
 
       - name: Compile packages, apps, and specs
         run: | # enter workspace mode to do this on one line
-          go work init && go work use . ./test ./core
-          go build -mod=readonly ./... ./core/... ./test/specifications/
+          go work init . ./test ./core ./parse
+          go build -mod=readonly ./... ./core/... ./parse/... ./test/specifications/
 
       - name: Lint
         uses: golangci/golangci-lint-action@v4.0.0
@@ -78,7 +78,7 @@ jobs:
           install-mode: "binary"
           version: "latest"
           skip-pkg-cache: true
-          args: ./... ./core/... ./test/... --timeout=10m --config=.golangci.yml --skip-dirs ./core/rpc/protobuf
+          args: ./... ./core/... ./parse/... ./test/... --timeout=10m --config=.golangci.yml --skip-dirs ./core/rpc/protobuf
 
       # unit test
       - name: Run unit test

--- a/.github/workflows/kgw-test-reuse.yaml
+++ b/.github/workflows/kgw-test-reuse.yaml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Init workspace
         run: |
-          go work init && go work use . ./test ./core
+          go work init . ./test ./parse ./core
 
       - name: Generate go vendor
         run: | # should build the vendor using `go work vendor`?

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -61,6 +61,7 @@ tasks:
       # and from bottom to top in terms of dependencies.
       - |
         (cd core; go mod tidy)
+        (cd parse; go mod tidy)
         go mod tidy
         (cd test; go mod tidy)
 
@@ -247,12 +248,14 @@ tasks:
     desc: Run unit tests
     cmds:
       - go test ./core/... -tags=ext_test -count=1
+      - CGO_ENABLED=1 go test ./parse/... -tags=ext_test -count=1
       - CGO_ENABLED=1 go test ./... -tags=ext_test,pglive -count=1 -p=1 # no parallel for now because several try to use one pg database
 
   test:unit:race:
     desc: Run unit tests with the race detector
     cmds:
       - go test ./core/... -tags=ext_test -count=1 -race
+      - CGO_ENABLED=1 go test ./parse/... -tags=ext_test -count=1 -race
       - CGO_ENABLED=1 go test ./... -tags=ext_test -count=1 -race
 
   test:it:

--- a/parse/kuneiform/parser_test.go
+++ b/parse/kuneiform/parser_test.go
@@ -238,19 +238,77 @@ func Test_Parse(t *testing.T) {
 			kf: `
 			database mydb;
 
+			table other_users {
+				id int primary key,
+				username text not null unique minlen(5) maxlen(32),
+				age int max(100) min(18) default(18)
+			}
+
 			table users {
 				id int primary key,
 				username text not null unique minlen(5) maxlen(32),
 				age int max(100) min(18) default(18),
 				bts blob default(0x00),
-				foreign key (id) references other_uses (id) on delete cascade on update set null,
-				foreign key (username) references other_uses (username) on delete set default on update no action,
-				foreign key (age) references other_uses (age) on delete restrict
+				foreign key (id) references other_users (id) on delete cascade on update set null,
+				foreign key (username) references other_users (username) on delete set default on update no action,
+				foreign key (age) references other_users (age) on delete restrict
 			}
 			`,
 			want: &types.Schema{
 				Name: "mydb",
 				Tables: []*types.Table{
+					{
+						Name: "other_users",
+						Columns: []*types.Column{
+							{
+								Name: "id",
+								Type: types.IntType,
+								Attributes: []*types.Attribute{
+									{
+										Type: types.PRIMARY_KEY,
+									},
+								},
+							},
+							{
+								Name: "username",
+								Type: types.TextType,
+								Attributes: []*types.Attribute{
+									{
+										Type: types.NOT_NULL,
+									},
+									{
+										Type: types.UNIQUE,
+									},
+									{
+										Type:  types.MIN_LENGTH,
+										Value: "5",
+									},
+									{
+										Type:  types.MAX_LENGTH,
+										Value: "32",
+									},
+								},
+							},
+							{
+								Name: "age",
+								Type: types.IntType,
+								Attributes: []*types.Attribute{
+									{
+										Type:  types.MAX,
+										Value: "100",
+									},
+									{
+										Type:  types.MIN,
+										Value: "18",
+									},
+									{
+										Type:  types.DEFAULT,
+										Value: "18",
+									},
+								},
+							},
+						},
+					},
 					{
 						Name: "users",
 						Columns: []*types.Column{
@@ -315,7 +373,7 @@ func Test_Parse(t *testing.T) {
 						ForeignKeys: []*types.ForeignKey{
 							{
 								ChildKeys:   []string{"id"},
-								ParentTable: "other_uses",
+								ParentTable: "other_users",
 								ParentKeys:  []string{"id"},
 								Actions: []*types.ForeignKeyAction{
 									{
@@ -330,7 +388,7 @@ func Test_Parse(t *testing.T) {
 							},
 							{
 								ChildKeys:   []string{"username"},
-								ParentTable: "other_uses",
+								ParentTable: "other_users",
 								ParentKeys:  []string{"username"},
 								Actions: []*types.ForeignKeyAction{
 									{
@@ -345,7 +403,7 @@ func Test_Parse(t *testing.T) {
 							},
 							{
 								ChildKeys:   []string{"age"},
-								ParentTable: "other_uses",
+								ParentTable: "other_users",
 								ParentKeys:  []string{"age"},
 								Actions: []*types.ForeignKeyAction{
 									{


### PR DESCRIPTION
This re-enables unit tests and mod tidy for the reborn `parse` module.

On doing so, there is a failing unit test (`Test_Parse/all_possible_constraints` in `parse/kuniform`):

```
--- FAIL: Test_Parse (0.00s)
    --- FAIL: Test_Parse/all_possible_constraints (0.00s)
        parser_test.go:505: 
            	Error Trace:	/home/jon/kwil/git/kwil-db/parse/kuneiform/parser_test.go:505
            	Error:      	Received unexpected error:
            	            	parent table other_uses not found
            	Test:       	Test_Parse/all_possible_constraints
```

I've updated parse/kuneiform/parser_test.go with a make-it-pass mindset, but this is a very naive resolution.  I'm not sure why this test passed before or what the correct resolution is.  I do recall that the `Clean` methods now take a list of tables, which I think is for typing, but I'm not positive.  @brennanjl Suggested changes to fix this unit test, assuming what I did is incorrect?