### PR TITLE
# Load env variables into KwildConfig

### DIFF
--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -23,6 +23,7 @@ import (
 	"github.com/kwilteam/kwil-db/internal/version"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func RootCmd() *cobra.Command {
@@ -89,6 +90,7 @@ func RootCmd() *cobra.Command {
 	flagSet := cmd.Flags()
 	flagSet.SortFlags = false
 	config.AddConfigFlags(flagSet, flagCfg)
+	viper.BindPFlags(flagSet)
 
 	flagSet.BoolVarP(&autoGen, "autogen", "a", false,
 		"auto generate private key, genesis file, and config file if not exist")


### PR DESCRIPTION
Env variables are not supported since we renamed the cmd line flags to have hyphens or dashes instead of underscores. Whereas the struct tags remained to use dashes to support config file parsing. Therefore manual binding is needed to map the env variables correctly to the structures. 