### PR TITLE
ci: fix multi commits backport

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Backport Action
-        uses: kwilteam/backport-github-action@f7073a2287aefc1fa12685eb25a712ab5620445c #v9.3.1
+        uses: kwilteam/backport-github-action@b3eae3fb1be75da400e9d7094282dfcd9bc6ffa1 # kwil branch
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           auto_backport_label_prefix: backport-to-


### PR DESCRIPTION
I've update kwilteam/backport-github-action https://github.com/kwilteam/backport-github-action/commit/b3eae3fb1be75da400e9d7094282dfcd9bc6ffa1 so it has https://github.com/sorenlouv/backport/pull/493 merged, should have multi commits backport issue fixed