### PR TITLE
skip CI on some file changes

### DIFF
--- a/.github/filters.yaml
+++ b/.github/filters.yaml
@@ -1,0 +1,18 @@
+code:
+  - added|modified: 'go.mod'
+  - added|modified: '.github/filters.yaml'
+  - added|modified: '.github/workflows/ci.yaml'
+  - added|modified: 'build/package/docker/kwild.dockerfile'
+  - added|modified: 'cmd/**'
+  - added|modified: 'common/**'
+  - added|modified: 'core/**/*.go'
+  - added|modified: 'core/!(*.md)'
+  - added|modified: 'core/client/!(*.md)'
+  - added|modified: 'core/client/!(example/**)/**' # this is really weird shit
+  - added|modified: 'core/gatewayclient/!(*.md)'
+  - added|modified: 'core/gatewayclient/!(example/**)/**'
+  - added|modified: 'internal/**'
+  - added|modified: 'parse/**'
+  - added|modified: 'scripts/**/*'
+  - added|modified: 'test/**/*'
+  - 'test/!(stress/**)/**'

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -9,7 +9,7 @@ jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'backport-to-')
+    if: contains(github.event.pull_request.labels.*.name, 'backport-to-')
     steps:
       - name: Backport Action
         uses: kwilteam/backport-github-action@b3eae3fb1be75da400e9d7094282dfcd9bc6ffa1 # kwil branch

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -3,12 +3,44 @@ name: CI
 on:
   pull_request:
     types: [ opened, synchronize, reopened, ready_for_review ]
+    branches:
+      - main
+      - release*
+  # path filter won't work bcz PR status check will be 'pending' if workflow is
+  # skipped due to path filtering, i.e. blocked
+  #paths:
+
   workflow_dispatch:
 
 jobs:
-  test:
+  # JOB to run change detection
+  changes:
     runs-on: ubuntu-latest
-    if: ${{ !github.event.pull_request.draft }} # only run on non-draft PRs
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      run: ${{ steps.filter.outputs.code }}
+    steps:
+      # For pull requests it's not necessary to checkout the code
+      # but it's useful to see the effect of the path filter in current PR
+      - uses: actions/checkout@v4
+        with:
+          # This may save additional git fetch roundtrip if
+          # merge-base is found within latest 20 commits
+          fetch-depth: 20
+      - uses: dorny/paths-filter@v3.0.2
+        id: filter
+        with:
+          # Path to file where filters are defined
+          filters: .github/filters.yaml
+          #predicate-quantifier: 'every' # check dorny/paths-filter#225
+
+  test:
+    needs: changes
+    #  only run only if there are changes and non-draft PRs
+    if: ${{ needs.changes.outputs.run == 'true' && !github.event.pull_request.draft}}
+    runs-on: ubuntu-latest
 
     services:
       postgres:

--- a/.github/workflows/kgw-test-reuse.yaml
+++ b/.github/workflows/kgw-test-reuse.yaml
@@ -181,6 +181,14 @@ jobs:
         run: |
           docker pull kwilbrennan/extensions-math:multi-arch --platform linux/amd64
 
+      - name: Run integration test on REST API
+        run: |
+          testUserID=$(id -u)
+          testGroupID=$(id -g)
+          cp test/integration/docker-compose.override.yml.example test/integration/docker-compose.override.yml
+          sed -i "s/\${UID}:\${GID}/${testUserID}:${testGroupID}/g" test/integration/docker-compose.override.yml
+          KIT_LOG_LEVEL=warn task test:it:nb -- -drivers http
+
       - name: Run kgw integration test
         run: |
           testUserID=$(id -u)

--- a/.github/workflows/kgw-test-reuse.yaml
+++ b/.github/workflows/kgw-test-reuse.yaml
@@ -24,7 +24,30 @@ on:
         required: true
 
 jobs:
+  # JOB to run change detection
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: read
+    # Set job outputs to values from filter step
+    outputs:
+      run: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          # This may save additional git fetch roundtrip if
+          # merge-base is found within latest 20 commits
+          fetch-depth: 20
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: .github/filters.yaml
+          #predicate-quantifier: 'every'
+
   kgw-test:
+    needs: changes
+    #  only run only if there are changes, or manually triggered
+    if: ${{ needs.changes.outputs.run == 'true' || github.event_name == 'workflow_dispatch'}}
     runs-on: ubuntu-latest
     steps:
       - name: Show references

--- a/.github/workflows/kgw-test-reuse.yaml
+++ b/.github/workflows/kgw-test-reuse.yaml
@@ -38,7 +38,7 @@ jobs:
           # This may save additional git fetch roundtrip if
           # merge-base is found within latest 20 commits
           fetch-depth: 20
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v3.0.2
         id: filter
         with:
           filters: .github/filters.yaml

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -19,7 +19,7 @@ var remote = flag.Bool("remote", false, "test against remote node")
 
 // NOTE: `-parallel` is a flag that is already used by `go test`
 var parallelMode = flag.Bool("parallel-mode", false, "run tests in parallelMode mode")
-var drivers = flag.String("drivers", "jsonrpc,http,cli", "comma separated list of drivers to run")
+var drivers = flag.String("drivers", "jsonrpc,cli", "comma separated list of drivers to run")
 
 func TestLocalDevSetup(t *testing.T) {
 	if !*dev {

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -18,7 +18,7 @@ var dev = flag.Bool("dev", false, "run for development purpose (no tests)")
 
 var spamTest = flag.Bool("spam", false, "run the spam test that requires a special docker image to be built")
 
-var drivers = flag.String("drivers", "jsonrpc,http,cli", "comma separated list of drivers to run")
+var drivers = flag.String("drivers", "jsonrpc,cli", "comma separated list of drivers to run")
 
 // NOTE: `-parallel` is a flag that is already used by `go test`
 var parallelMode = flag.Bool("parallel-mode", false, "run tests in parallel mode")


### PR DESCRIPTION
As our CI running time is now taking average 25 mins, we need to offload some unnecessary CI runs.

This add path filter to skip CI on certain file changes.

We use https://github.com/dorny/paths-filter, as the builtin [path filter](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/troubleshooting-required-status-checks#handling-skipped-but-required-checks) won't fit in our use case