### PR TITLE
transactions: fix fee marshaling

### DIFF
--- a/cmd/common/display/message_test.go
+++ b/cmd/common/display/message_test.go
@@ -151,7 +151,7 @@ func Example_respTxQuery_json() {
 	//         "desc": "This is a test transaction for cli",
 	//         "payload": "AAH4ULg5eGY2MTdhZjFjYTc3NGViYmQ2ZDIzZThmZTEyYzU2ZDQxZDI1YTIyZDgxZTg4ZjY3YzZjNmVlMGQ0i2NyZWF0ZV91c2VyyMeDZm9vgjMy",
 	//         "type": "execute_action",
-	//         "fee": 100,
+	//         "fee": "100",
 	//         "nonce": 10,
 	//         "chain_id": "asdf"
 	//       },
@@ -180,7 +180,7 @@ func Test_TxHashAndExecResponse(t *testing.T) {
 	expectJson := `{"tx_hash":"0102030405","exec_result":{"hash":"0102030405","height":10,"tx":` +
 		`{` +
 		`"signature":{"sig":"yz/tf2/zblkFTASoMbIV5RQFJ1PuNT5v4x1LTvc2rNYVUSfbVV0wBroU/LTHm7rVbI5juBqYljGbsFOp4lNHWAA=","type":"secp256k1_ep"},` +
-		`"body":{"desc":"This is a test transaction for cli","payload":"AAH4ULg5eGY2MTdhZjFjYTc3NGViYmQ2ZDIzZThmZTEyYzU2ZDQxZDI1YTIyZDgxZTg4ZjY3YzZjNmVlMGQ0i2NyZWF0ZV91c2VyyMeDZm9vgjMy","type":"execute_action","fee":100,"nonce":10,"chain_id":"asdf"},` +
+		`"body":{"desc":"This is a test transaction for cli","payload":"AAH4ULg5eGY2MTdhZjFjYTc3NGViYmQ2ZDIzZThmZTEyYzU2ZDQxZDI1YTIyZDgxZTg4ZjY3YzZjNmVlMGQ0i2NyZWF0ZV91c2VyyMeDZm9vgjMy","type":"execute_action","fee":"100","nonce":10,"chain_id":"asdf"},` +
 		`"serialization":"concat","sender":""},` +
 		`"tx_result":{"code":0,"log":"This is log","gas_used":10,"gas_wanted":10}}` +
 		`}`

--- a/core/rpc/json/commands.go
+++ b/core/rpc/json/commands.go
@@ -95,5 +95,5 @@ type QueryRequest struct {
 
 // TxQueryRequest contains the request parameters for MethodTxQuery.
 type TxQueryRequest struct {
-	TxHash []byte `json:"tx_hash,omitempty"`
+	TxHash types.HexBytes `json:"tx_hash,omitempty"`
 }

--- a/core/rpc/json/function/func.go
+++ b/core/rpc/json/function/func.go
@@ -17,7 +17,7 @@ const (
 type VerifySignatureRequest struct {
 	Signature *TxSignature   `json:"signature,omitempty"`
 	Sender    types.HexBytes `json:"sender,omitempty"`
-	Msg       types.HexBytes `json:"msg,omitempty"`
+	Msg       []byte         `json:"msg,omitempty"`
 }
 
 type TxSignature struct {

--- a/core/rpc/json/responses.go
+++ b/core/rpc/json/responses.go
@@ -26,7 +26,7 @@ type AccountResponse struct {
 
 // BroadcastResponse contains the response object for MethodBroadcast.
 type BroadcastResponse struct {
-	TxHash []byte `json:"tx_hash,omitempty"`
+	TxHash types.HexBytes `json:"tx_hash,omitempty"`
 }
 
 type Result struct { // for other types, but embedding it is kinda annoying when instantiating
@@ -67,16 +67,8 @@ type EstimatePriceResponse struct {
 
 // TxQueryResponse contains the response object for MethodTxQuery.
 type TxQueryResponse struct { // transactions.TcTxQueryResponse but pointers
-	Hash     []byte                          `json:"hash,omitempty"`
+	Hash     types.HexBytes                  `json:"hash,omitempty"`
 	Height   int64                           `json:"height,omitempty"`
 	Tx       *transactions.Transaction       `json:"tx,omitempty"`
 	TxResult *transactions.TransactionResult `json:"tx_result,omitempty"`
 }
-
-// for admin service (TODO):
-// NodeInfoResponse contains the response object for MethodSchema.
-// type NodeInfoResponse struct {
-// 	NodeID     string `json:"node_id,omitempty"`
-// 	PublicKey  []byte `json:"public_key,omitempty"`
-// 	P2PAddress string `json:"p2p_address,omitempty"`
-// }

--- a/core/types/transactions/transaction_test.go
+++ b/core/types/transactions/transaction_test.go
@@ -2,6 +2,7 @@ package transactions_test
 
 import (
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"math/big"
 	"testing"
@@ -54,6 +55,35 @@ func Test_TransactionMarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	require.Equal(t, tx, tx2)
+}
+
+func Test_TransactionBodyMarshalJSON(t *testing.T) {
+	txB := transactions.TransactionBody{ // not a pointer, ensure MarshalJSON method works for value
+		Payload:     []byte("payload"),
+		PayloadType: transactions.PayloadTypeDeploySchema,
+		Fee:         big.NewInt(100),
+		Nonce:       1,
+		ChainID:     "chainIDXXX",
+	}
+
+	b, err := json.Marshal(txB)
+	require.NoError(t, err)
+
+	txB2 := transactions.TransactionBody{}
+	err = json.Unmarshal(b, &txB2)
+	require.NoError(t, err)
+
+	require.Equal(t, txB, txB2)
+
+	// Marshal pointer
+	b, err = json.Marshal(&txB)
+	require.NoError(t, err)
+
+	txB3 := transactions.TransactionBody{}
+	err = json.Unmarshal(b, &txB3)
+	require.NoError(t, err)
+
+	require.Equal(t, txB, txB3)
 }
 
 type actionExecutionV0 struct {

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -51,14 +51,6 @@ type ValidatorRemoveProposal struct {
 	Remover []byte `json:"remover"` // pubkey of the validator proposing the removal
 }
 
-// NodeInfo contains public information about a node.
-// It can be used by clients to join as a peer.
-type NodeInfo struct {
-	NodeID           string   `json:"node_id"`
-	PublicKey        HexBytes `json:"pubkey"`
-	P2PListenAddress string   `json:"p2p_listen_address"`
-}
-
 func (v *Validator) String() string {
 	return fmt.Sprintf("{pubkey = %x, power = %d}", v.PubKey, v.Power)
 }


### PR DESCRIPTION
The Fee field of `core/types/transactions.TransactionBody` is a `*big.Int`.  By default this marshals to/from an integer (json number).  This should be a string to avoid issues with JavaScript representing all numbers as 64-bit floating point values, which can't store a large int64 (same reason why `json.Number` exists in Go).

This also changes a few field types:
- `TxQueryRequest.TxHash` is now `HexBytes`
- `TxQueryResponse.TxHash` is now `HexBytes`
- `BroadcastResponse.TxHash` is now `HexBytes`
- `VerifySignatureRequest.Msg` is now a `[]byte` (not `HexBytes`)

Finally, remove `core/types.NodeInfo`, which was unused (there's something similar that is used in core/types/admin).