### PR TITLE
Optimize TxQuery

### DIFF
--- a/cmd/common/display/message.go
+++ b/cmd/common/display/message.go
@@ -93,7 +93,7 @@ func (r *RespTxQuery) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Hash     string                         `json:"hash"` // HEX
 		Height   int64                          `json:"height"`
-		Tx       transactions.Transaction       `json:"tx"`
+		Tx       *transactions.Transaction      `json:"tx"`
 		TxResult transactions.TransactionResult `json:"tx_result"`
 	}{
 		Hash:     hex.EncodeToString(r.Msg.Hash),

--- a/cmd/common/display/message_test.go
+++ b/cmd/common/display/message_test.go
@@ -103,7 +103,7 @@ func getExampleTxQueryResponse() *transactions.TcTxQueryResponse {
 	return &transactions.TcTxQueryResponse{
 		Hash:   []byte("1024"),
 		Height: 10,
-		Tx: transactions.Transaction{
+		Tx: &transactions.Transaction{
 			Body: &transactions.TransactionBody{
 				Payload:     payloadRLP,
 				PayloadType: rawPayload.Type(),

--- a/cmd/kwil-admin/cmds/utils/query-tx.go
+++ b/cmd/kwil-admin/cmds/utils/query-tx.go
@@ -53,7 +53,7 @@ func (r *RespTxQuery) MarshalJSON() ([]byte, error) {
 	return json.Marshal(struct {
 		Hash     string                         `json:"hash"` // HEX
 		Height   int64                          `json:"height"`
-		Tx       transactions.Transaction       `json:"tx"`
+		Tx       *transactions.Transaction      `json:"tx"`
 		TxResult transactions.TransactionResult `json:"tx_result"`
 	}{
 		Hash:     hex.EncodeToString(r.Msg.Hash),

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -197,7 +197,10 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	cometBftNode := buildCometNode(d, closers, abciApp)
 
 	cometBftClient := buildCometBftClient(cometBftNode)
-	wrappedCmtClient := &wrappedCometBFTClient{cometBftClient}
+	wrappedCmtClient := &wrappedCometBFTClient{
+		cl:    cometBftClient,
+		cache: abciApp,
+	}
 	txApp.SetReplayStatusChecker(cometBftNode.IsCatchup)
 
 	eventBroadcaster := buildEventBroadcaster(d, ev, wrappedCmtClient, txApp)

--- a/core/rpc/client/user/http/client.go
+++ b/core/rpc/client/user/http/client.go
@@ -284,7 +284,7 @@ func (c *Client) TxQuery(ctx context.Context, txHash []byte) (*transactions.TcTx
 	return &transactions.TcTxQueryResponse{
 		Hash:     decodedHash,
 		Height:   decodedHeight,
-		Tx:       *convertedTx,
+		Tx:       convertedTx,
 		TxResult: *convertedTxResult,
 	}, nil
 }

--- a/core/rpc/client/user/jsonrpc/methods.go
+++ b/core/rpc/client/user/jsonrpc/methods.go
@@ -212,10 +212,11 @@ func (cl *Client) TxQuery(ctx context.Context, txHash []byte) (*transactions.TcT
 	if err != nil {
 		return nil, err
 	}
+
 	return &transactions.TcTxQueryResponse{
 		Hash:     res.Hash,
 		Height:   res.Height,
-		Tx:       *res.Tx,
+		Tx:       res.Tx,
 		TxResult: *res.TxResult,
 	}, nil
 }

--- a/core/types/transactions/result.go
+++ b/core/types/transactions/result.go
@@ -82,6 +82,6 @@ func (c TxCode) String() string {
 type TcTxQueryResponse struct {
 	Hash     []byte            `json:"hash,omitempty"`
 	Height   int64             `json:"height,omitempty"`
-	Tx       Transaction       `json:"tx"`
+	Tx       *Transaction      `json:"tx"`
 	TxResult TransactionResult `json:"tx_result"`
 }

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -10,6 +10,7 @@ import (
 	"math/big"
 	"sort"
 	"strings"
+	"sync"
 
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/core/types"
@@ -48,6 +49,7 @@ func NewAbciApp(cfg *AbciConfig, snapshotter SnapshotModule, statesyncer StateSy
 		log: log,
 
 		validatorAddressToPubKey: make(map[string][]byte),
+		txCache:                  make(map[string]bool),
 	}
 
 	return app
@@ -96,6 +98,13 @@ type AbciApp struct {
 
 	// validatorAddressToPubKey is a map of validator addresses to their public keys
 	validatorAddressToPubKey map[string][]byte
+
+	// txCache stores hashes of all the transactions currently in the mempool.
+	// This is used to avoid recomputing the hash for all mempool transactions
+	// on every TxQuery request (to mitigate Potential DDOS attack vector).
+	// https://github.com/kwilteam/kwil-db/issues/714
+	txCache   map[string]bool
+	txCacheMu sync.RWMutex
 }
 
 func (a *AbciApp) ChainID() string {
@@ -150,12 +159,10 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 		return &abciTypes.ResponseCheckTx{Code: code.Uint32(), Log: err.Error()}, nil // return error now or is it still all about code?
 	}
 
-	txHash := cmtTypes.Tx(incoming.Tx).Hash()
 	logger.Debug("",
 		zap.String("sender", hex.EncodeToString(tx.Sender)),
 		zap.String("PayloadType", tx.Body.PayloadType.String()),
-		zap.Uint64("nonce", tx.Body.Nonce),
-		zap.String("hash", hex.EncodeToString(txHash)))
+		zap.Uint64("nonce", tx.Body.Nonce))
 
 	// For a new transaction (not re-check), before looking at execution cost or
 	// checking nonce validity, ensure the payload is recognized and signature is valid.
@@ -176,7 +183,7 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 			return &abciTypes.ResponseCheckTx{Code: code.Uint32(), Log: err.Error()}, nil
 		}
 	} else {
-		logger.Info("Recheck", zap.String("hash", hex.EncodeToString(txHash)), zap.Uint64("nonce", tx.Body.Nonce), zap.String("payloadType", tx.Body.PayloadType.String()), zap.String("sender", hex.EncodeToString(tx.Sender)))
+		logger.Info("Recheck", zap.String("sender", hex.EncodeToString(tx.Sender)), zap.Uint64("nonce", tx.Body.Nonce), zap.String("payloadType", tx.Body.PayloadType.String()))
 	}
 
 	err = a.txApp.ApplyMempool(ctx, tx)
@@ -197,6 +204,13 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 		return &abciTypes.ResponseCheckTx{Code: code.Uint32(), Log: err.Error()}, nil
 	}
 
+	// Cache the transaction hash
+	if newTx {
+		txHash := cmtTypes.Tx(incoming.Tx).Hash()
+		a.txCacheMu.Lock()
+		defer a.txCacheMu.Unlock()
+		a.txCache[string(txHash)] = true
+	}
 	return &abciTypes.ResponseCheckTx{Code: code.Uint32()}, nil
 }
 
@@ -275,6 +289,12 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 		abciRes.GasUsed = txRes.Spend
 
 		res.TxResults = append(res.TxResults, abciRes)
+
+		// Remove the transaction from the cache as it has been included in a block
+		hash := cmtTypes.Tx(tx).Hash()
+		a.txCacheMu.Lock()
+		delete(a.txCache, string(hash))
+		a.txCacheMu.Unlock()
 	}
 
 	res.ConsensusParamUpdates = &tendermintTypes.ConsensusParams{ // why are we "updating" these on every block? Should be nil for no update.
@@ -936,4 +956,11 @@ type EventBroadcaster func(ctx context.Context, proposer []byte) error
 
 func (a *AbciApp) SetEventBroadcaster(fn EventBroadcaster) {
 	a.broadcastFn = fn
+}
+
+func (a *AbciApp) TxInMempool(txHash []byte) bool {
+	a.txCacheMu.Lock()
+	defer a.txCacheMu.Unlock()
+	_, ok := a.txCache[string(txHash)]
+	return ok
 }

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -440,10 +440,14 @@ func (svc *Service) TxQuery(ctx context.Context, req *jsonrpc.TxQueryRequest) (*
 		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to query transaction", nil)
 	}
 
-	tx := &transactions.Transaction{}
-	if err := tx.UnmarshalBinary(cmtResult.Tx); err != nil {
-		logger.Error("failed to deserialize transaction", log.Error(err))
-		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to deserialize transaction", nil)
+	//cmtResult.Tx can be nil
+	var tx *transactions.Transaction
+	if cmtResult.Tx != nil {
+		tx = &transactions.Transaction{}
+		if err := tx.UnmarshalBinary(cmtResult.Tx); err != nil {
+			logger.Error("failed to deserialize transaction", log.Error(err))
+			return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to deserialize transaction", nil)
+		}
 	}
 
 	txResult := &transactions.TransactionResult{


### PR DESCRIPTION
Performance showed that polling TxQuery frequently can lead to resource saturation due to computation of Hash() for all the transaction in the mempool. This PR avoids this by ABCI computing the TxHash when it first sees the transaction through CheckTx and stores it in its internal structure. This hash would be purged once the tx is included in the block. This avoids repeated computation of the Hash() in the TxQueries. 

Also reduces the repeated hash computations in checkTx making them a tad bit faster. 

One major change in the TXQuery behavior is the result doesn't include the actual transaction if its in the mempool, as we currently don't have a way to retrieve it without computing and checking the Hashes of all the mempool transactions. I am gonna raise a issue with cometBft to expose these APIs on the mempool. TxQuery would just return `{txHash, height=-1 and tx=nil}` for mempool transactions.

The block times have reduced from 60sec to 12 sec with this fix as shown below.
![image](https://github.com/kwilteam/kwil-db/assets/45089429/961a0626-93ff-4a68-b6d0-b6ce94051d80)
