### PR TITLE
services/jsonrpc: do not throw away engine error details

### DIFF
--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -307,7 +307,7 @@ func checkEngineError(err error) (jsonrpc.ErrorCode, string) {
 		return jsonrpc.ErrorEngineInvalidSchema, execution.ErrInvalidSchema.Error()
 	}
 
-	return jsonrpc.ErrorEngineInternal, "internal engine error"
+	return jsonrpc.ErrorEngineInternal, err.Error()
 }
 
 func engineError(err error) *jsonrpc.Error {


### PR DESCRIPTION
Resolves https://github.com/kwilteam/kwil-db/issues/725

The following rpc service methods calling into engine are now returning the full error when it is unidentified:
- `Query` (this is the most sensible place to return the full engine error)
- `ListDatabases` (but this error is more likely to be genuinely internal, since an empty slice is the result if none found rather than an error)
- `Call` (like `Query` it is likely that the "internal" error will be important to help the user resolve the issue with their call or the dataset definition itself).

Note that `Schema` also uses the `engineError` helper, but `engine.GetSchema` only returns `ErrDatasetNotFound` or `nil`, and there is no internal error that would have been discarded.