### PR TITLE
kwild: fix cometbft client not setting "syncing"

### DIFF
--- a/cmd/kwild/server/utils.go
+++ b/cmd/kwild/server/utils.go
@@ -104,6 +104,7 @@ func (wc *wrappedCometBFTClient) Status(ctx context.Context) (*types.Status, err
 			BestBlockHash:   strings.ToLower(si.LatestBlockHash.String()),
 			BestBlockHeight: si.LatestBlockHeight,
 			BestBlockTime:   si.LatestBlockTime.UTC(),
+			Syncing:         si.CatchingUp,
 		},
 		Validator: &types.ValidatorInfo{
 			PubKey: vi.PubKey.Bytes(),


### PR DESCRIPTION
This fixes the "syncing" field of the node status response always being false.

This change sets it from the "CatchingUp" field of the response from cometbft's `Status` RPC (local client).