### PR TITLE
[v0.7.5] kwild: fix cometbft client not setting "syncing"

### DIFF
--- a/cmd/kwild/server/utils.go
+++ b/cmd/kwild/server/utils.go
@@ -101,6 +101,7 @@ func (wc *wrappedCometBFTClient) Status(ctx context.Context) (*types.Status, err
 			BestBlockHash:   strings.ToLower(si.LatestBlockHash.String()),
 			BestBlockHeight: si.LatestBlockHeight,
 			BestBlockTime:   si.LatestBlockTime.UTC(),
+			Syncing:         si.CatchingUp,
 		},
 		Validator: &types.ValidatorInfo{
 			PubKey: vi.PubKey.Bytes(),


### PR DESCRIPTION
Backports https://github.com/kwilteam/kwil-db/pull/729 for v0.7.5