### PR TITLE
[WIP] ci: fix backport not run

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -4,12 +4,15 @@ on:
   pull_request_target:
     types:
       - closed
+      - labeled # so labels will be updated if PR is labeled after creation
 
 jobs:
   backport:
     name: Backport PR
     runs-on: ubuntu-latest
-    if: contains(github.event.pull_request.labels.*.name, 'backport-to-')
+    #NOTE: condition on labels will make this workflow not run, don't do it.
+    #if: github.event.pull_request.merged && contains(github.event.pull_request.labels.*.name, 'backport-to-')
+    if: github.event.pull_request.merged
     steps:
       - name: Backport Action
         uses: kwilteam/backport-github-action@b3eae3fb1be75da400e9d7094282dfcd9bc6ffa1 # kwil branch


### PR DESCRIPTION
This fix the issue that `backport` workflow doesn't run.

I've tested in https://github.com/Yaiba/test-relase-based-workflow pr 17-28. It'll backport when put label when create pr, after create pr, after pr is merged. 

Only one issue is that it'll run on every pr even if not labelled, I just cannot make it not run , we can just ignore it.