### PR TITLE
txapp: report insufficient balance for new accounts

### DIFF
--- a/internal/txapp/mempool.go
+++ b/internal/txapp/mempool.go
@@ -79,7 +79,7 @@ func (m *mempool) applyTransaction(ctx context.Context, tx *transactions.Transac
 	// reject the transactions from unfunded user accounts in gasEnabled mode
 	if m.gasEnabled && acct.Nonce == 0 && acct.Balance.Sign() == 0 {
 		delete(m.accounts, string(tx.Sender))
-		return fmt.Errorf("account %s does not exist", hex.EncodeToString(tx.Sender))
+		return transactions.ErrInsufficientBalance
 	}
 
 	// It is normally permissible to accept a transaction with the same nonce as


### PR DESCRIPTION
When a transaction is submitted to mempool while gas is enabled, a new account (which has no balance) now has the transaction rejected with an "insufficient balance" error instead of reporting that the account was not found.

Resolves https://github.com/kwilteam/kwil-db/issues/653