### PR TITLE
added parse debug

### DIFF
--- a/cmd/kwil-cli/cmds/utils/parse.go
+++ b/cmd/kwil-cli/cmds/utils/parse.go
@@ -4,13 +4,16 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"reflect"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/internal/engine/ddl"
 	"github.com/kwilteam/kwil-db/parse"
 	"github.com/spf13/cobra"
 )
 
 func newParseCmd() *cobra.Command {
+	debug := false
 	cmd := &cobra.Command{
 		Use:   "parse <file_path>",
 		Short: "Parse a Kuneiform schema",
@@ -31,9 +34,54 @@ func newParseCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
+			if !debug {
+				res.Actions = nil
+				res.Procedures = nil
+			} else {
+				debugSchema := "debug_schema"
+				var tbls [][]string
+				for _, t := range res.Schema.Tables {
+					tbl, err := ddl.GenerateDDL(debugSchema, t)
+					if err != nil {
+						return display.PrintErr(cmd, err)
+					}
+
+					tbls = append(tbls, tbl)
+				}
+
+				var procs []string
+				for _, p := range res.Procedures {
+					proc, err := ddl.GenerateProcedure(p, debugSchema)
+					if err != nil {
+						return display.PrintErr(cmd, err)
+					}
+
+					procs = append(procs, proc)
+				}
+
+				var fprocs []string
+				for _, p := range res.Schema.ForeignProcedures {
+					proc, err := ddl.GenerateForeignProcedure(p)
+					if err != nil {
+						return display.PrintErr(cmd, err)
+					}
+
+					fprocs = append(fprocs, proc)
+				}
+
+				return display.PrintCmd(cmd, &dumpResult{
+					ParseResult:                *res,
+					GeneratedTables:            tbls,
+					GeneratedProcedures:        procs,
+					GeneratedForeignProcedures: fprocs,
+				})
+			}
+
 			return display.PrintCmd(cmd, &schemaDisplay{Result: res})
 		},
 	}
+
+	cmd.Flags().BoolVarP(&debug, "debug", "d", false, "debug mode (show generated code and ASTs)")
 
 	return cmd
 }
@@ -57,4 +105,35 @@ func (s *schemaDisplay) MarshalText() (text []byte, err error) {
 	} else {
 		return json.MarshalIndent(s.Result, "", "  ")
 	}
+}
+
+type dumpResult struct {
+	parse.ParseResult          `json:"base_result"`
+	GeneratedTables            [][]string `json:"generated_tables"`
+	GeneratedProcedures        []string   `json:"generated_procedures"`
+	GeneratedForeignProcedures []string   `json:"generated_foreign_procedures"`
+}
+
+func (d *dumpResult) MarshalJSON() ([]byte, error) {
+	return marshalSafe(d, json.Marshal)
+}
+
+func (d *dumpResult) MarshalText() (text []byte, err error) {
+	return marshalSafe(d, func(v any) ([]byte, error) {
+		return json.MarshalIndent(v, "", "  ")
+	})
+}
+
+// marshalSafe will ignore custom MarshalJSON methods and marshal the struct as is.
+// This is necessary to avoid infinite recursion when a struct has a custom MarshalJSON method.
+func marshalSafe(v any, fn func(v any) ([]byte, error)) (bs []byte, err error) {
+	k := reflect.TypeOf(v).Kind() // ptr or not?
+
+	if k != reflect.Ptr {
+		return fn(v)
+	}
+
+	// dereference pointer
+	v2 := reflect.ValueOf(v).Elem().Interface()
+	return marshalSafe(v2, fn)
 }

--- a/core/types/schema.go
+++ b/core/types/schema.go
@@ -898,7 +898,7 @@ type Procedure struct {
 	Body string `json:"body"`
 
 	// Returns is the return type of the procedure.
-	Returns *ProcedureReturn `json:"return_types"`
+	Returns *ProcedureReturn `json:"returns"`
 	// Annotations are the annotations of the procedure.
 	Annotations []string `json:"annotations"`
 }
@@ -963,6 +963,10 @@ type ProcedureReturn struct {
 func (p *ProcedureReturn) Clean() error {
 	for _, t := range p.Fields {
 		return t.Clean()
+	}
+
+	if len(p.Fields) == 0 {
+		return fmt.Errorf("procedure return must have at least one field, or be nil")
 	}
 
 	return nil

--- a/parse/actions/actions.go
+++ b/parse/actions/actions.go
@@ -149,17 +149,17 @@ func convertStatement(stmt actparser.ActionStmt, schema *types.Schema, pgSchemaN
 // AnalyzedAction contains the results of analyzing an action.
 type AnalyzedAction struct {
 	// Name is the name of the action.
-	Name string
+	Name string `json:"name"`
 	// Public is true if the action is public.
-	Public bool
+	Public bool `json:"public"`
 	// IsView is true if the action is a view.
-	IsView bool
+	IsView bool `json:"is_view"`
 	// OwnerOnly is true if the action is owner-only.
-	OwnerOnly bool
+	OwnerOnly bool `json:"owner_only"`
 	// Parameters is a list of parameters for the action.
-	Parameters []string
+	Parameters []string `json:"parameters"`
 	// Statements are the statements in the action.
-	Statements []AnalyzedStatement
+	Statements []AnalyzedStatement `json:"statements"`
 }
 
 // AnalyzedStatement is an interface for analyzed statements.

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -43,7 +43,7 @@ func ParseKuneiform(kf string) (*ParseResult, error) {
 		return nil, err
 	}
 
-	_, actionErrs, err := actions.AnalyzeActions(schema, &actions.AnalyzeOpts{
+	acs, actionErrs, err := actions.AnalyzeActions(schema, &actions.AnalyzeOpts{
 		PGSchemaName: schema.DBID(),
 		SchemaInfo:   info,
 	})
@@ -52,7 +52,7 @@ func ParseKuneiform(kf string) (*ParseResult, error) {
 	}
 	res.Errs.Add(actionErrs...)
 
-	_, procErrs, err := procedures.AnalyzeProcedures(schema, schema.DBID(), &procedures.AnalyzeOptions{
+	procs, procErrs, err := procedures.AnalyzeProcedures(schema, schema.DBID(), &procedures.AnalyzeOptions{
 		SchemaInfo: info,
 	})
 	if err != nil {
@@ -60,14 +60,19 @@ func ParseKuneiform(kf string) (*ParseResult, error) {
 	}
 	res.Errs.Add(procErrs...)
 
+	res.Actions = acs
+	res.Procedures = procs
+
 	return res, nil
 }
 
 // ParseResult is the result of parsing a Kuneiform schema.
 type ParseResult struct {
-	Schema     *types.Schema          `json:"schema"`
-	Errs       parseTypes.ParseErrors `json:"errors,omitempty"`
-	SchemaInfo *parseTypes.SchemaInfo `json:"schema_info,omitempty"`
+	Schema     *types.Schema                   `json:"schema"`
+	Errs       parseTypes.ParseErrors          `json:"errors,omitempty"`
+	SchemaInfo *parseTypes.SchemaInfo          `json:"schema_info,omitempty"`
+	Actions    []*actions.AnalyzedAction       `json:"actions,omitempty"`
+	Procedures []*procedures.AnalyzedProcedure `json:"procedures,omitempty"`
 }
 
 // Err returns the first error in the parse result.

--- a/parse/procedures/procedures.go
+++ b/parse/procedures/procedures.go
@@ -132,22 +132,22 @@ func AnalyzeProcedures(schema *types.Schema, pgSchemaName string, options *Analy
 // AnalyzedProcedure is the result of analyzing a procedure.
 type AnalyzedProcedure struct {
 	// Name is the name of the procedure.
-	Name string
+	Name string `json:"name"`
 	// Parameters are the parameters, in order, that the procedure is expecting.
 	// If no parameters are expected, this will be nil.
-	Parameters []*types.NamedType
+	Parameters []*types.NamedType `json:"parameters"`
 	// Returns is the expected return type(s) of the procedure.
 	// If no return is expected, this will be nil.
-	Returns types.ProcedureReturn
+	Returns types.ProcedureReturn `json:"returns"`
 	// DeclaredVariables are the variables that need to be declared.
-	DeclaredVariables []*types.NamedType
+	DeclaredVariables []*types.NamedType `json:"declared_variables"`
 	// LoopTargets is a list of all variables that are loop targets.
 	// They should be declared as RECORD in plpgsql.
-	LoopTargets []string
+	LoopTargets []string `json:"loop_targets"`
 	// Body is the plpgsql code for the procedure.
-	Body string
+	Body string `json:"body"`
 	// IsView is true if the procedure is a view.
-	IsView bool
+	IsView bool `json:"is_view"`
 	// OwnerOnly is true if the procedure is owner-only.
-	OwnerOnly bool
+	OwnerOnly bool `json:"owner_only"`
 }

--- a/parse/wasm/wasm.go
+++ b/parse/wasm/wasm.go
@@ -25,6 +25,10 @@ func parseAndMarshal(input string) (jsonStr string, err error) {
 		e.Node.EndLine++
 	}
 
+	// remove unwanted outputs
+	schema.Actions = nil
+	schema.Procedures = nil
+
 	jsonBytes, err := json.Marshal(schema)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
@KwilLuke was running into a bug that was fixed by https://github.com/kwilteam/kwil-db/pull/737.

In the process of trying to figure it out, I added to our parse cli command to help with debugging. I also added to the schema cleaning, which should prevent this error from reaching postgres in the first place (since the error is still possible to hit with bad rlp encoding.)
