### PR TITLE
kwil-cli: fix `utils parse` output

### DIFF
--- a/cmd/kwil-cli/cmds/utils/parse.go
+++ b/cmd/kwil-cli/cmds/utils/parse.go
@@ -6,6 +6,7 @@ import (
 	"os"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/parse"
 	"github.com/spf13/cobra"
 )
@@ -31,7 +32,11 @@ func newParseCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			return display.PrintCmd(cmd, &schemaDisplay{Result: res})
+			if res.Err() != nil {
+				return display.PrintErr(cmd, res.Err())
+			}
+
+			return display.PrintCmd(cmd, &schemaDisplay{Result: res.Schema})
 		},
 	}
 
@@ -39,9 +44,8 @@ func newParseCmd() *cobra.Command {
 }
 
 // schemaDisplay is a struct that will be used to display the schema.
-// It includes an error because the parser can return a schema even if there is an error.
 type schemaDisplay struct {
-	Result *parse.SchemaParseResult
+	Result *types.Schema
 }
 
 func (s *schemaDisplay) MarshalJSON() ([]byte, error) {
@@ -49,12 +53,5 @@ func (s *schemaDisplay) MarshalJSON() ([]byte, error) {
 }
 
 func (s *schemaDisplay) MarshalText() (text []byte, err error) {
-	// we set the schema info to nil because it is not needed for users
-	// who are just looking at the schema.type ParseResult struct {
-	s.Result.SchemaInfo = nil
-	if err := s.Result.Err(); err != nil {
-		return []byte(err.Error()), nil
-	} else {
-		return json.MarshalIndent(s.Result.Schema, "", "  ")
-	}
+	return json.MarshalIndent(s.Result, "", "  ")
 }

--- a/cmd/kwil-cli/cmds/utils/parse.go
+++ b/cmd/kwil-cli/cmds/utils/parse.go
@@ -55,6 +55,6 @@ func (s *schemaDisplay) MarshalText() (text []byte, err error) {
 	if err := s.Result.Err(); err != nil {
 		return []byte(err.Error()), nil
 	} else {
-		return json.MarshalIndent(s.Result, "", "  ")
+		return json.MarshalIndent(s.Result.Schema, "", "  ")
 	}
 }


### PR DESCRIPTION
This fix `kwil-cli utils parse` output, so the output can be used for `kwil-cli database deploy`.  

We have a test kf file:
`$ echo "database test;" > /tmp/test.kf`

Before:
```
$ .build/kwil-cli utils parse /tmp/test.kf                                                                                           
{
  "schema": {
    "name": "test",
    "owner": "",
    "extensions": null,
    "tables": null,
    "actions": null,
    "procedures": null,
    "foreign_calls": null
  }
}

$ .build/kwil-cli utils parse /tmp/test.kf > /tmp/test.json

$ .build/kwil-cli database deploy -p /tmp/test.json -t json
TxHash: 9a1f0200c2c7574f2e5f45c2546554ebb7a346d7b311ae0c3e1f4258f7953a3

$ .build/kwil-cli utils query-tx 9a1f0200c2c7574f2e5f45c2546554ebb7a346d7b311ae0c3e1f4258f7953a37
Transaction ID: 9a1f0200c2c7574f2e5f45c2546554ebb7a346d7b311ae0c3e1f4258f7953a37
Status: failed
Height: 78
Log: name cannot be empty
```

After:
```
$ .build/kwil-cli utils parse /tmp/test.kf 
{
  "name": "test",
  "owner": "",
  "extensions": null,
  "tables": null,
  "actions": null,
  "procedures": null,
  "foreign_calls": null
}

$ .build/kwil-cli utils parse /tmp/test.kf > /tmp/test.json

$ .build/kwil-cli database deploy -p /tmp/test.json -t json 
TxHash: 35ecace2fe1c49fb703ad339dcde3ab7279a62528e8d0367ad235c40be7344fd

$ .build/kwil-cli utils query-tx 35ecace2fe1c49fb703ad339dcde3ab7279a62528e8d0367ad235c40be7344fd
Transaction ID: 35ecace2fe1c49fb703ad339dcde3ab7279a62528e8d0367ad235c40be7344fd
Status: success
Height: 292
Log: success
```