### PR TITLE
[v0.7.6] kwild,rpc: db and rpc timeout settings

### DIFF
--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -100,6 +100,12 @@ http_listen_addr = "{{ .AppCfg.HTTPListenAddress }}"
 # Unix socket or TCP address for the KWILD App's Admin GRPC server to listen on
 admin_listen_addr = "{{ .AppCfg.AdminListenAddress }}"
 
+# Timeout on requests on the user RPC servers
+rpc_timeout = "{{ .AppCfg.RPCTimeout }}"
+
+# Timeout on database reads initiated by the user RPC service
+db_read_timeout = "{{ .AppCfg.ReadTxTimeout }}"
+
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = {{arrayFormatter .AppCfg.ExtensionEndpoints}}
 

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -71,6 +71,8 @@ type AppConfig struct {
 	DBPass string `mapstructure:"pg_db_pass"`
 	DBName string `mapstructure:"pg_db_name"`
 
+	RPCTimeout         Duration                     `mapstructure:"rpc_timeout"`
+	ReadTxTimeout      Duration                     `mapstructure:"db_read_timeout"`
 	ExtensionEndpoints []string                     `mapstructure:"extension_endpoints"`
 	TLSCertFile        string                       `mapstructure:"tls_cert_file"`
 	TLSKeyFile         string                       `mapstructure:"tls_key_file"`
@@ -486,6 +488,8 @@ func DefaultConfig() *KwildConfig {
 			DBPort:             "5432", // ignored with unix socket, but applies if IP used for DBHost
 			DBUser:             "kwild",
 			DBName:             "kwild",
+			RPCTimeout:         Duration(45 * time.Second),
+			ReadTxTimeout:      Duration(5 * time.Second),
 			// SnapshotConfig: SnapshotConfig{
 			// 	Enabled:         false,
 			// 	RecurringHeight: uint64(10000),

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -39,6 +39,12 @@ http_listen_addr = "0.0.0.0:8080"
 # UNIX socket for KWILD Admin server to listen on
 admin_unix_socket = "/tmp/kwil_admin.sock"
 
+# Timeout on requests on the user RPC servers
+rpc_timeout = "45s"
+
+# Timeout on database reads initiated by the user RPC service
+db_read_timeout = "5s"
+
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = []
 

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -31,6 +31,9 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *KwildConfig) {
 	flagSet.StringVar(&cfg.AppCfg.ProfileMode, "app.profile-mode", cfg.AppCfg.ProfileMode, "kwild profile mode (http, cpu, mem, mutex, or block)")
 	flagSet.StringVar(&cfg.AppCfg.ProfileFile, "app.profile-file", cfg.AppCfg.ProfileFile, "kwild profile output file path (e.g. cpu.pprof)")
 
+	flagSet.Var(&cfg.AppCfg.RPCTimeout, "app.rpc-timeout", "timeout for RPC requests (through reading the request, handling the request, and sending the response)")
+	flagSet.Var(&cfg.AppCfg.ReadTxTimeout, "app.db-read-timeout", "timeout for database reads initiated by RPC requests")
+
 	// Extension endpoints flags
 	flagSet.StringSliceVar(&cfg.AppCfg.ExtensionEndpoints, "app.extension-endpoints", cfg.AppCfg.ExtensionEndpoints, "kwild extension endpoints")
 

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -40,6 +40,12 @@ admin_listen_addr="localhost:50151"
 # TCP address for the KWILD App's HTTP server to listen on
 http_listen_addr = "localhost:8080"
 
+# Timeout on requests on the user RPC servers
+rpc_timeout = "45s"
+
+# Timeout on database reads initiated by the user RPC service
+db_read_timeout = "5s"
+
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = ["localhost:50052", "localhost:50053", "localhost:50054"]
 

--- a/internal/services/grpc/txsvc/v1/call.go
+++ b/internal/services/grpc/txsvc/v1/call.go
@@ -45,7 +45,10 @@ func (s *Service) Call(ctx context.Context, req *txpb.CallRequest) (*txpb.CallRe
 		}
 	}
 
-	executeResult, err := s.engine.Procedure(ctx, tx, &common.ExecutionData{
+	ctxExec, cancel := context.WithTimeout(ctx, s.readTxTimeout)
+	defer cancel()
+
+	executeResult, err := s.engine.Procedure(ctxExec, tx, &common.ExecutionData{
 		Dataset:   body.DBID,
 		Procedure: body.Action,
 		Args:      args,

--- a/internal/services/grpc/txsvc/v1/opts.go
+++ b/internal/services/grpc/txsvc/v1/opts.go
@@ -1,6 +1,8 @@
 package txsvc
 
 import (
+	"time"
+
 	"github.com/kwilteam/kwil-db/core/log"
 )
 
@@ -9,5 +11,13 @@ type TxSvcOpt func(*Service)
 func WithLogger(logger log.Logger) TxSvcOpt {
 	return func(s *Service) {
 		s.log = logger
+	}
+}
+
+// WithReadTxTimeout sets a timeout for read-only DB transactions, as used by
+// the Query and Call methods of Service.
+func WithReadTxTimeout(timeout time.Duration) TxSvcOpt {
+	return func(s *Service) {
+		s.readTxTimeout = timeout
 	}
 }

--- a/internal/services/grpc/txsvc/v1/query.go
+++ b/internal/services/grpc/txsvc/v1/query.go
@@ -18,7 +18,10 @@ func (s *Service) Query(ctx context.Context, req *txpb.QueryRequest) (*txpb.Quer
 	}
 	defer tx.Rollback(ctx)
 
-	result, err := s.engine.Execute(ctx, tx, req.Dbid, req.Query, nil)
+	ctxExec, cancel := context.WithTimeout(ctx, s.readTxTimeout)
+	defer cancel()
+
+	result, err := s.engine.Execute(ctxExec, tx, req.Dbid, req.Query, nil)
 	if err != nil {
 		// We don't know for sure that it's an invalid argument, but an invalid
 		// user-provided query isn't an internal server error.

--- a/internal/services/grpc/txsvc/v1/service.go
+++ b/internal/services/grpc/txsvc/v1/service.go
@@ -3,6 +3,7 @@ package txsvc
 import (
 	"context"
 	"math/big"
+	"time"
 
 	cmtCoreTypes "github.com/cometbft/cometbft/rpc/core/types"
 	"github.com/kwilteam/kwil-db/common"
@@ -14,12 +15,15 @@ import (
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 )
 
+const defaultReadTxTimeout = 5 * time.Second
+
 type Service struct {
 	txpb.UnimplementedTxServiceServer
 
 	log log.Logger
 
-	engine EngineReader
+	readTxTimeout time.Duration
+	engine        EngineReader
 
 	db sql.ReadTxMaker // this should only ever make a read-only tx
 
@@ -30,11 +34,12 @@ type Service struct {
 func NewService(db sql.ReadTxMaker, engine EngineReader,
 	chainClient BlockchainTransactor, nodeApp NodeApplication, opts ...TxSvcOpt) *Service {
 	s := &Service{
-		log:         log.NewNoOp(),
-		engine:      engine,
-		nodeApp:     nodeApp,
-		chainClient: chainClient,
-		db:          db,
+		log:           log.NewNoOp(),
+		readTxTimeout: defaultReadTxTimeout,
+		engine:        engine,
+		nodeApp:       nodeApp,
+		chainClient:   chainClient,
+		db:            db,
 	}
 
 	for _, opt := range opts {

--- a/internal/services/grpc_server/options.go
+++ b/internal/services/grpc_server/options.go
@@ -1,11 +1,21 @@
 package server
 
-import "google.golang.org/grpc"
+import (
+	"time"
+
+	"google.golang.org/grpc"
+)
 
 type Option func(*Server)
 
 func WithSrvOpt(srvOpt grpc.ServerOption) Option {
 	return func(s *Server) {
 		s.srvOpts = append(s.srvOpts, srvOpt)
+	}
+}
+
+func WithTimeout(timeout time.Duration) Option {
+	return func(s *Server) {
+		s.timeout = timeout
 	}
 }

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0.7.5"
+const kwilVersion = "0.7.6"
 
 // KwildVersion may be set at compile time by:
 //


### PR DESCRIPTION
This backports https://github.com/kwilteam/kwil-db/pull/736, just without the JSON-RPC pieces.