### PR TITLE
feature: support basic cors for jsonrpc server

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -213,7 +213,8 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	jsonRPCTxSvc := usersvc.NewService(db, e, wrappedCmtClient, txApp,
 		*d.log.Named("user-json-svc"), usersvc.WithReadTxTimeout(time.Duration(d.cfg.AppCfg.ReadTxTimeout)))
 	jsonRPCServer, err := rpcserver.NewServer(d.cfg.AppCfg.JSONRPCListenAddress,
-		*d.log.Named("user-jsonrpc-server"), rpcserver.WithTimeout(time.Duration(d.cfg.AppCfg.RPCTimeout)))
+		*d.log.Named("user-jsonrpc-server"), rpcserver.WithTimeout(time.Duration(d.cfg.AppCfg.RPCTimeout)),
+		rpcserver.WithCORS())
 	if err != nil {
 		failBuild(err, "unable to create json-rpc server")
 	}

--- a/internal/services/jsonrpc/server.go
+++ b/internal/services/jsonrpc/server.go
@@ -43,7 +43,7 @@ type serverConfig struct {
 	pass       string
 	tlsConfig  *tls.Config
 	timeout    time.Duration
-	enabelCORS bool
+	enableCORS bool
 }
 
 type Opt func(*serverConfig)
@@ -75,7 +75,7 @@ func WithTimeout(timeout time.Duration) Opt {
 
 func WithCORS() Opt {
 	return func(c *serverConfig) {
-		c.enabelCORS = true
+		c.enableCORS = true
 	}
 }
 
@@ -174,7 +174,7 @@ func NewServer(addr string, log log.Logger, opts ...Opt) (*Server, error) {
 	// contexts: https://github.com/golang/go/issues/59602
 	// So, we add a timeout to the Request's context.
 	h = jsonRPCTimeoutHandler(h, cfg.timeout)
-	if cfg.enabelCORS {
+	if cfg.enableCORS {
 		h = corsHandler(h)
 	}
 	h = recoverer(h, log)
@@ -207,7 +207,7 @@ func corsHandler(h http.Handler) http.Handler {
 		w.Header().Set("Access-Control-Allow-Credentials", "true")
 
 		// Preflight request
-		if r.Method == "OPTIONS" {
+		if r.Method == http.MethodOptions {
 			return
 		}
 


### PR DESCRIPTION
This resolves #749

This adds a simple basic CORS returns cors headers for all requests