### PR TITLE
Height var

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -76,6 +76,9 @@ type TransactionData struct {
 
 	// TxID is the transaction ID of the incoming transaction.
 	TxID string
+
+	// Height is the block height of the incoming transaction.
+	Height int64
 }
 
 // ExecutionOptions is contextual data that is passed to a procedure

--- a/core/utils/json/json.go
+++ b/core/utils/json/json.go
@@ -31,6 +31,9 @@ func UnmarshalMapWithoutFloat(b []byte) ([]map[string]any, error) {
 // convertJsonNumbers recursively converts json.Number to int64.
 // It traverses through the map and array and converts all json.Number to int64.
 func convertJsonNumbers(val any) any {
+	if val == nil {
+		return nil
+	}
 	switch val := val.(type) {
 	case map[string]any:
 		for k, v := range val {

--- a/core/utils/json/json.go
+++ b/core/utils/json/json.go
@@ -1,0 +1,50 @@
+// package json includes JSON utilities commonly used in Kwil.
+package json
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// UnmarshalMapWithoutFloat unmarshals a JSON byte slice into a slice of maps.
+// It will try to convert all return values into ints, but will keep them as strings if it fails.
+// It ensures they aren't returned as floats, which is important for maintaining consistency
+// with Kwil's decimal types. All returned types will be string or int64.
+func UnmarshalMapWithoutFloat(b []byte) ([]map[string]any, error) {
+	d := json.NewDecoder(strings.NewReader(string(b)))
+	d.UseNumber()
+
+	// unmashal result
+	var result []map[string]any
+	err := d.Decode(&result)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert numbers to int64
+	for _, record := range result {
+		for k, v := range record {
+			if num, ok := v.(json.Number); ok {
+				i, err := num.Int64()
+				if err != nil {
+					record[k] = num.String()
+				} else {
+					record[k] = i
+				}
+			} else if num, ok := v.([]any); ok {
+				for j, n := range num {
+					if n, ok := n.(json.Number); ok {
+						i, err := n.Int64()
+						if err != nil {
+							num[j] = n.String()
+						} else {
+							num[j] = i
+						}
+					}
+				}
+			}
+		}
+	}
+
+	return result, nil
+}

--- a/core/utils/json/json.go
+++ b/core/utils/json/json.go
@@ -3,6 +3,7 @@ package json
 
 import (
 	"encoding/json"
+	"reflect"
 	"strings"
 )
 
@@ -22,29 +23,50 @@ func UnmarshalMapWithoutFloat(b []byte) ([]map[string]any, error) {
 	}
 
 	// convert numbers to int64
-	for _, record := range result {
-		for k, v := range record {
-			if num, ok := v.(json.Number); ok {
-				i, err := num.Int64()
-				if err != nil {
-					record[k] = num.String()
-				} else {
-					record[k] = i
-				}
-			} else if num, ok := v.([]any); ok {
-				for j, n := range num {
-					if n, ok := n.(json.Number); ok {
-						i, err := n.Int64()
-						if err != nil {
-							num[j] = n.String()
-						} else {
-							num[j] = i
-						}
-					}
-				}
-			}
-		}
-	}
+	result = convertJsonNumbers(result).([]map[string]any)
 
 	return result, nil
+}
+
+// convertJsonNumbers recursively converts json.Number to int64.
+// It traverses through the map and array and converts all json.Number to int64.
+func convertJsonNumbers(val any) any {
+	switch val := val.(type) {
+	case map[string]any:
+		for k, v := range val {
+			val[k] = convertJsonNumbers(v)
+		}
+		return val
+	case []map[string]any:
+		for i, v := range val {
+			for j, n := range v {
+				v[j] = convertJsonNumbers(n)
+			}
+			val[i] = v
+		}
+		return val
+	case []any:
+		for i, v := range val {
+			val[i] = convertJsonNumbers(v)
+		}
+		return val
+	case json.Number:
+		i, err := val.Int64()
+		if err != nil {
+			return val.String()
+		}
+		return i
+	default:
+		// in case we are unmarshalling something crazy like a double nested slice,
+		// we reflect on the value and recursively call convertJsonNumbers if it's a slice.
+		typeOf := reflect.TypeOf(val)
+		if typeOf.Kind() == reflect.Slice {
+			s := reflect.ValueOf(val)
+			for i := 0; i < s.Len(); i++ {
+				s.Index(i).Set(reflect.ValueOf(convertJsonNumbers(s.Index(i).Interface())))
+			}
+			return s.Interface()
+		}
+		return val
+	}
 }

--- a/core/utils/json/json_test.go
+++ b/core/utils/json/json_test.go
@@ -1,0 +1,64 @@
+package json
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_convertJsonNumbers(t *testing.T) {
+
+	tests := []struct {
+		name string
+		val  any
+		want any
+	}{
+		{
+			name: "number",
+			val:  json.Number("123"),
+			want: int64(123),
+		},
+		{
+			name: "object",
+			val: map[string]any{
+				"key": json.Number("123"),
+				"val": []map[string]any{
+					{
+						"key": json.Number("123"),
+					},
+					{
+						"key": json.Number("456"),
+						"val": []map[string]any{
+							{
+								"key": json.Number("789"),
+							},
+						},
+					},
+				},
+			},
+			want: map[string]any{
+				"key": int64(123),
+				"val": []map[string]any{
+					{
+						"key": int64(123),
+					},
+					{
+						"key": int64(456),
+						"val": []map[string]any{
+							{
+								"key": int64(789),
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			a := convertJsonNumbers(tt.val)
+			require.EqualValues(t, tt.want, a)
+		})
+	}
+}

--- a/extensions/precompiles/actions.go
+++ b/extensions/precompiles/actions.go
@@ -68,6 +68,8 @@ type ProcedureContext struct {
 	Procedure string
 	// Result is the result of the most recent SQL query.
 	Result *sql.ResultSet
+	// Height is the block height of the current execution.
+	Height int64
 
 	// StackDepth tracks the current depth of the procedure call stack. It is
 	// incremented each time a procedure calls another procedure.
@@ -104,6 +106,7 @@ func (p *ProcedureContext) Values() map[string]any {
 	values["@caller"] = p.Caller
 	values["@txid"] = p.TxID
 	values["@signer"] = p.Signer
+	values["@height"] = p.Height
 
 	return values
 }
@@ -122,6 +125,7 @@ func (p *ProcedureContext) NewScope() *ProcedureContext {
 		Procedure:  p.Procedure,
 		StackDepth: p.StackDepth,
 		UsedGas:    p.UsedGas,
+		Height:     p.Height,
 	}
 }
 

--- a/internal/engine/execution/global.go
+++ b/internal/engine/execution/global.go
@@ -256,6 +256,7 @@ func (g *GlobalContext) Procedure(ctx context.Context, tx sql.DB, options *commo
 		DBID:      options.Dataset,
 		Procedure: options.Procedure,
 		TxID:      options.TxID,
+		Height:    options.Height,
 		// starting with stack depth 0, increment in each action call
 	}
 

--- a/internal/engine/execution/queries.go
+++ b/internal/engine/execution/queries.go
@@ -2,7 +2,7 @@ package execution
 
 import (
 	"context"
-	"encoding/hex"
+	"encoding/base64"
 	"encoding/json"
 	"fmt"
 
@@ -334,7 +334,12 @@ func setContextualVars(ctx context.Context, db sql.DB, data *common.ExecutionDat
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.SignerVar, hex.EncodeToString(data.Signer)))
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.SignerVar, base64.StdEncoding.EncodeToString(data.Signer)))
+	if err != nil {
+		return err
+	}
+
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.HeightVar, data.Height))
 	if err != nil {
 		return err
 	}

--- a/internal/engine/generate/plpgsql.go
+++ b/internal/engine/generate/plpgsql.go
@@ -118,7 +118,9 @@ func (s *sqlGenerator) VisitExpressionForeignCall(p0 *parse.ExpressionForeignCal
 }
 
 func (s *sqlGenerator) VisitExpressionVariable(p0 *parse.ExpressionVariable) any {
-	if s.numberParameters {
+	// if a user param $, then we need to number it.
+	// Vars using @ get set and accessed using postgres's current_setting function
+	if s.numberParameters && p0.Prefix == parse.VariablePrefixDollar {
 		str := p0.String()
 
 		// if it already exists, we write it as that index.
@@ -978,7 +980,7 @@ func formatContextualVariableName(name string) string {
 
 	switch dataType {
 	case types.BlobType:
-		return fmt.Sprintf("%s::bytea", str)
+		return fmt.Sprintf("decode(%s, 'base64')", str)
 	case types.IntType:
 		return fmt.Sprintf("%s::int8", str)
 	case types.BoolType:

--- a/internal/services/grpc/txsvc/v1/call.go
+++ b/internal/services/grpc/txsvc/v1/call.go
@@ -52,6 +52,7 @@ func (s *Service) Call(ctx context.Context, req *txpb.CallRequest) (*txpb.CallRe
 		TransactionData: common.TransactionData{
 			Signer: signer,
 			Caller: caller,
+			Height: -1, // not available
 		},
 	})
 	if err != nil {

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -438,6 +438,7 @@ func (svc *Service) Call(ctx context.Context, req *jsonrpc.CallRequest) (*jsonrp
 		TransactionData: common.TransactionData{
 			Signer: signer,
 			Caller: caller,
+			Height: -1, // not available
 		},
 	})
 	if err != nil {

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -296,6 +296,7 @@ func (e *executeActionRoute) Execute(ctx TxContext, router *TxApp, tx *transacti
 				Signer: tx.Sender,
 				Caller: identifier,
 				TxID:   hex.EncodeToString(ctx.TxID),
+				Height: ctx.BlockHeight,
 			},
 		})
 		if err != nil {

--- a/parse/contextual.go
+++ b/parse/contextual.go
@@ -11,12 +11,15 @@ var (
 	TxidVar = "txid"
 	// signer is the session variable for the signer.
 	SignerVar = "signer"
+	// height is the session variable for the block height.
+	HeightVar = "height"
 	// SessionVars are the session variables that are available in the engine.
 	// It maps the variable name to its type.
 	SessionVars = map[string]*types.DataType{
 		CallerVar: types.TextType,
 		TxidVar:   types.TextType,
 		SignerVar: types.BlobType,
+		HeightVar: types.IntType,
 	}
 )
 

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -244,6 +244,9 @@ func TestTypes(t *testing.T) {
 			// we only test nils if using json rpc driver, becase the cli driver cannot support nil
 			// args to actions/procedures
 			specifications.ExecuteTypesSpecification(ctx, t, creatorDriver, driverType == "jsonrpc")
+
+			// test contextual vars
+			specifications.ExecuteContextualVarsSpecification(ctx, t, creatorDriver)
 		})
 	}
 }

--- a/test/acceptance/test-data/contextual_vars.kf
+++ b/test/acceptance/test-data/contextual_vars.kf
@@ -1,0 +1,43 @@
+database vars;
+
+table vars {
+    id uuid primary key,
+    caller text,
+    signer blob,
+    txid text,
+    height int
+}
+
+// act_store_vars checks that contextual variables work as expected
+// in actions
+action act_store_vars() public {
+    insert into vars (id, caller, signer, txid, height)
+    values (
+        uuid_generate_v5('985b93a4-2045-44d6-bde4-442a4e498bc6'::uuid, @txid),
+        @caller,
+        @signer,
+        @txid,
+        @height
+    );
+}
+
+// proc_store_vars checks that contextual variables work as expected
+// in procedures
+procedure proc_store_vars() public {
+    insert into vars (id, caller, signer, txid, height)
+    values (
+        uuid_generate_v5('985b93a4-2045-44d6-bde4-442a4e498bc6'::uuid, @txid),
+        @caller,
+        @signer,
+        @txid,
+        @height
+    );
+}
+
+procedure get_stored() public view returns table(caller text, signer blob, txid text, height int) {
+    return select caller, signer, txid, height from vars;
+}
+
+procedure delete_all() public {
+    delete from vars;
+}

--- a/test/driver/client_driver.go
+++ b/test/driver/client_driver.go
@@ -215,3 +215,11 @@ func (d *KwildClientDriver) Allowance(ctx context.Context, sender *ecdsa.Private
 	senderAddr := ec.PubkeyToAddress(sender.PublicKey)
 	return d.deployer.Allowance(ctx, senderAddr)
 }
+
+func (d *KwildClientDriver) Signer() []byte {
+	return d.signer.Identity()
+}
+
+func (d *KwildClientDriver) Identifier() (string, error) {
+	return auth.EthSecp256k1Authenticator{}.Identifier(d.Signer())
+}

--- a/test/specifications/contextual_vars.go
+++ b/test/specifications/contextual_vars.go
@@ -1,0 +1,70 @@
+package specifications
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/hex"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func ExecuteContextualVarsSpecification(ctx context.Context, t *testing.T, execute ProcedureDSL) {
+	db := SchemaLoader.Load(t, ContextualVarsDB)
+
+	res, err := execute.DeployDatabase(ctx, db)
+	require.NoError(t, err)
+	ExpectTxSuccess(t, execute, ctx, res)
+
+	// test procedures
+	t.Log("Testing contextual vars procedures")
+	testCtxVars(ctx, t, execute, execute.DBID(db.Name), "proc")
+
+	// delete
+	res, err = execute.Execute(ctx, execute.DBID(db.Name), "delete_all", []any{})
+	require.NoError(t, err)
+	ExpectTxSuccess(t, execute, ctx, res)
+
+	// test actions
+	t.Log("Testing contextual vars actions")
+	testCtxVars(ctx, t, execute, execute.DBID(db.Name), "act")
+}
+
+func testCtxVars(ctx context.Context, t *testing.T, execute ProcedureDSL, dbid, prefix string) {
+	res, err := execute.Execute(ctx, dbid, prefix+"_store_vars", []any{})
+	require.NoError(t, err)
+	ExpectTxSuccess(t, execute, ctx, res)
+
+	results, err := execute.Call(ctx, dbid, "get_stored", []any{})
+	require.NoError(t, err)
+
+	count := 0
+	for results.Next() {
+		count++
+		rec := results.Record()
+		require.NotNil(t, rec)
+		require.Len(t, rec, 4)
+
+		// check caller
+		ident, err := execute.Identifier()
+		require.NoError(t, err)
+		assert.Equal(t, ident, rec["caller"])
+
+		expectedSigner := base64.StdEncoding.EncodeToString(execute.Signer())
+		// signer
+		assert.Equal(t, expectedSigner, rec["signer"])
+
+		// txid
+		expectedRes := hex.EncodeToString(res)
+		assert.Equal(t, expectedRes, rec["txid"])
+
+		// height.
+		// We don't know the exact height, but it should be greater than 0
+		height := rec["height"]
+		if height.(int64) <= 0 {
+			t.Errorf("height should be greater than 0")
+		}
+	}
+	require.Equal(t, 1, count)
+}

--- a/test/specifications/dsl.go
+++ b/test/specifications/dsl.go
@@ -95,6 +95,11 @@ type TxQueryDsl interface {
 // to usage in the TxSvc
 type InfoDsl interface {
 	ChainInfo(ctx context.Context) (*types.ChainInfo, error)
+	// Signer returns the wallet's signer. This is the bytes address for eth signers.
+	Signer() []byte
+	// Identifier returns the identifier derived from the authenticator.
+	// This is a hex address for eth signers.
+	Identifier() (string, error)
 }
 
 // ValidatorStatusDsl is the dsl for checking validator status, including

--- a/test/specifications/procedures.go
+++ b/test/specifications/procedures.go
@@ -12,6 +12,7 @@ import (
 type ProcedureDSL interface {
 	DatabaseDeployDsl
 	ExecuteActionsDsl
+	InfoDsl
 }
 
 // ExecuteProcedureSpecification tests that procedures for a specific schema

--- a/test/specifications/schemas.go
+++ b/test/specifications/schemas.go
@@ -34,4 +34,7 @@ var (
 	TypesDB = &testSchema{
 		FileName: "types",
 	}
+	ContextualVarsDB = &testSchema{
+		FileName: "contextual_vars",
+	}
 )


### PR DESCRIPTION
Adds @height and contextual variables tests.

This commit adds an @height variable at the request of the Truflation team. It also adds an integration test for testing contextual variables.

Finally, it fixes two bugs. The first one caused SQL generated for actions to not use the `current_setting` postgres function, which caused it to incorrectly read contextual variables. The second bug caused postgres to incorrectly decode the transaction signer, essentially yielding an incorrect signer for the @signer variable.
