### PR TITLE
abci,txapp: on DB read pool use on consensus conn

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -49,10 +49,7 @@ tasks:
         goimports -format-only -w ./cmd ./internal ./test ./core/client \
           ./core/crypto ./core/log ./core/rpc/client \
           ./core/rpc/transport ./core/types ./core/utils \
-          ./parse/parse.go ./parse/metadata ./parse/kuneiform/*.go \
-          ./parse/procedures/*.go ./parse/procedures/parser ./parse/procedures/visitors \
-          ./parse/sql/*.go ./parse/sql/postgres ./parse/sql/sqlanalyzer ./parse/sql/tree \
-          ./parse/actions/*.go ./parse/actions/parser \
+          ./parse/*.go ./parse/wasm ./parse/postgres
 
   tidy:
     desc: go mod tidy each module

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -216,7 +216,7 @@ func Test_prepareMempoolTxns(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := abciApp.prepareBlockTransactions(tt.txs, &logger, 1e6, []byte("proposer"))
+			got := abciApp.prepareBlockTransactions(context.Background(), tt.txs, &logger, 1e6, []byte("proposer"))
 			if len(got) != len(tt.want) {
 				t.Errorf("got %d txns, expected %d", len(got), len(tt.want))
 			}
@@ -246,7 +246,7 @@ func Test_ProcessProposal_UnfundedAccount(t *testing.T) {
 	txA1 := newTxBts(t, 1, signerA)
 
 	// Unfunded account
-	txs := abciApp.prepareBlockTransactions([][]byte{txA1}, &logger, 1e6, []byte("proposer"))
+	txs := abciApp.prepareBlockTransactions(context.Background(), [][]byte{txA1}, &logger, 1e6, []byte("proposer"))
 	assert.Len(t, txs, 0)
 
 }
@@ -391,6 +391,10 @@ func (m *mockTxApp) AccountInfo(ctx context.Context, acctID []byte, getUncommitt
 	return big.NewInt(0), 0, nil
 }
 
+func (m *mockTxApp) ConsensusAccountInfo(ctx context.Context, acctID []byte) (balance *big.Int, nonce int64, err error) {
+	return big.NewInt(0), 0, nil
+}
+
 func (m *mockTxApp) ApplyMempool(ctx context.Context, tx *transactions.Transaction) error {
 	return nil
 }
@@ -421,6 +425,10 @@ func (m *mockTxApp) ChainInfo(ctx context.Context) (height int64, appHash []byte
 }
 
 func (m *mockTxApp) GetValidators(ctx context.Context) ([]*types.Validator, error) {
+	return nil, nil
+}
+
+func (m *mockTxApp) ConsensusValidators(ctx context.Context) ([]*types.Validator, error) {
 	return nil, nil
 }
 

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -37,18 +37,38 @@ type StateSyncModule interface {
 // It has methods for beginning and ending blocks, applying transactions,
 // and managing a mempool
 type TxApp interface {
+	// GenesisInit is used outside of the consensus thread, creating it's own
+	// transient outer DB transaction.
 	GenesisInit(ctx context.Context, validators []*types.Validator, accounts []*types.Account, initialHeight int64, appHash []byte) error
+
+	// Read-only methods. Do NOT use these from consensus connection methods.
 	ChainInfo(ctx context.Context) (int64, []byte, error)
+	GetValidators(ctx context.Context) ([]*types.Validator, error)
+	AccountInfo(ctx context.Context, acctID []byte, unconfirmed bool) (balance *big.Int, nonce int64, err error)
 	ApplyMempool(ctx context.Context, tx *transactions.Transaction) error
-	// Begin signals that a new block has begun.
+
+	// ProposerTxs is used when a validator prepares a block proposal This is
+	// prior to the Begin->Commit cycle, and as such does not use the DB
+	// transaction or a writer connection. TODO: The contention with other
+	// readers, such as RPC requests, may be something to resolve.
+	ProposerTxs(ctx context.Context, txNonce uint64, maxTxSize int64, proposerAddr []byte) ([][]byte, error)
+
+	// Begin signals that a new block has begun. The following methods are
+	// expected to use either an encompassing DB transaction started with Begin
+	// and ended with Commit.
 	Begin(ctx context.Context) error
+	Execute(ctx txapp.TxContext, tx *transactions.Transaction) *txapp.TxResponse
+	UpdateValidator(ctx context.Context, validator []byte, power int64) error
 	Finalize(ctx context.Context, blockHeight int64) (appHash []byte, validatorUpgrades []*types.Validator, err error)
 	Commit(ctx context.Context) error
-	Execute(ctx txapp.TxContext, tx *transactions.Transaction) *txapp.TxResponse
-	ProposerTxs(ctx context.Context, txNonce uint64, maxTxSize int64, proposerAddr []byte) ([][]byte, error)
-	UpdateValidator(ctx context.Context, validator []byte, power int64) error
-	GetValidators(ctx context.Context) ([]*types.Validator, error)
-	AccountInfo(ctx context.Context, acctID []byte, getUncommitted bool) (balance *big.Int, nonce int64, err error)
+
+	// ConsensusAccountInfo and ConsensusValidators are used in two different
+	// contexts, but always from the ABCI consensus connection. During block
+	// execution (between Begin and Commit) the active write transaction is used
+	// to read uncommitted data. From PrepareProposal and ProcessProposal, an
+	// ephemeral read-only transaction is created.
+	ConsensusAccountInfo(ctx context.Context, acctID []byte) (balance *big.Int, nonce int64, err error)
+	ConsensusValidators(ctx context.Context) ([]*types.Validator, error)
 
 	// Reload reloads the state of engine and txapp.
 	Reload(ctx context.Context) error

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -49,8 +49,7 @@ type TxApp interface {
 
 	// ProposerTxs is used when a validator prepares a block proposal This is
 	// prior to the Begin->Commit cycle, and as such does not use the DB
-	// transaction or a writer connection. TODO: The contention with other
-	// readers, such as RPC requests, may be something to resolve.
+	// transaction or a writer connection.
 	ProposerTxs(ctx context.Context, txNonce uint64, maxTxSize int64, proposerAddr []byte) ([][]byte, error)
 
 	// Begin signals that a new block has begun. The following methods are

--- a/internal/sql/pg/system_online_test.go
+++ b/internal/sql/pg/system_online_test.go
@@ -16,9 +16,15 @@ func TestVersion(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	conn := pool.writer
+	defer pool.Close()
 
-	ver, verNum, err := pgVersion(ctx, conn)
+	conn, err := pool.writer.Acquire(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer conn.Release()
+
+	ver, verNum, err := pgVersion(ctx, conn.Conn())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/txapp/interfaces.go
+++ b/internal/txapp/interfaces.go
@@ -23,6 +23,12 @@ type DB interface {
 	sql.OuterTxMaker
 	sql.ReadTxMaker
 	sql.SnapshotTxMaker
+	// BeginReservedReadTx creates a read-only transaction on a reserved
+	// connection that does not contend with readers in the pool that services
+	// RPC requests. NOTE: I think the read tx could use the writer conn given
+	// the concurrency guarantees of the consensus connection, but I'm working
+	// with a more general assumption in the pg package.
+	BeginReservedReadTx(context.Context) (sql.Tx, error)
 }
 
 type Snapshotter interface {

--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -292,8 +292,33 @@ func (r *TxApp) announceValidators() {
 	}
 }
 
+// ConsensusValidators gets the current validator set from the database. It will
+// use the active write transaction if it exists (meaning it is called from
+// FinalizeBlock, etc. between Commit and Begin), otherwise it uses a reserved
+// reader connection to avoid contention with user requests.
+func (r *TxApp) ConsensusValidators(ctx context.Context) ([]*types.Validator, error) {
+	// NOTE: this method is meant ONLY for use from methods on ABCI's consensus
+	// connection, which ensures no use (no data race on r.currentTx).
+	var tx sql.Executor
+	if r.currentTx == nil { // coming from PrepareProposal / ProcessProposal, which does not happen presently
+		rtx, err := r.Database.BeginReservedReadTx(ctx)
+		if err != nil {
+			return nil, err
+		}
+		defer rtx.Rollback(ctx)
+		tx = rtx
+	} else { // coming from FinalizeBlock
+		tx = r.currentTx
+	}
+
+	// We're not making a nested tx since an error in the consensus thread will
+	// halt the node (and rollback) anyway.
+
+	return getAllVoters(ctx, tx)
+}
+
 // GetValidators returns a shallow copy of the current validator set.
-// It will not return uncommitted changes.
+// It will not return ONLY committed changes.
 func (r *TxApp) GetValidators(ctx context.Context) ([]*types.Validator, error) {
 	r.valMtx.Lock()
 	defer r.valMtx.Unlock()
@@ -314,19 +339,22 @@ func (r *TxApp) GetValidators(ctx context.Context) ([]*types.Validator, error) {
 	return getAllVoters(ctx, readTx)
 }
 
-// GetValidatorsPower returns the total power of the current validator set.
-func (r *TxApp) GetValidatorSetPower(ctx context.Context) (int64, error) {
-	validators, err := r.GetValidators(ctx)
-	if err != nil {
-		return 0, err
-	}
-
+func validatorSetPower(validators []*types.Validator) int64 {
 	var totalPower int64
 	for _, v := range validators {
 		totalPower += v.Power
 	}
+	return totalPower
+}
 
-	return totalPower, nil
+// validatorsPower returns the total power of the current validator set
+// according to the DB.
+func (r *TxApp) validatorSetPower(ctx context.Context, tx sql.Executor) (int64, error) {
+	validators, err := getAllVoters(ctx, tx)
+	if err != nil {
+		return 0, err
+	}
+	return validatorSetPower(validators), nil
 }
 
 // Execute executes a transaction.  It will route the transaction to the
@@ -442,13 +470,13 @@ func (r *TxApp) Finalize(ctx context.Context, blockHeight int64) (appHash []byte
 
 // processVotes confirms resolutions that have been approved by the network,
 // expires resolutions that have expired, and properly credits proposers and voters.
-func (r *TxApp) processVotes(ctx context.Context, blockheight int64) error {
+func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 	credits := make(creditMap)
 
-	var finalizedIds []*types.UUID
-	// markedProcessedIds is a separate list for marking processed, since we do not want to process validator resolutions
+	var finalizedIDs []*types.UUID
+	// markedProcessedIDs is a separate list for marking processed, since we do not want to process validator resolutions
 	// validator vote IDs are not unique, so we cannot mark them as processed, in case a validator leaves and joins again
-	var markProcessedIds []*types.UUID
+	var markProcessedIDs []*types.UUID
 	// resolveFuncs tracks the resolve function for each resolution, in the order they are queried.
 	// we track this and execute all of these functions after we have found all confirmed resolutions
 	// because a resolve function can change a validator's power. This would then change the required power
@@ -458,7 +486,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockheight int64) error {
 		ResolveFunc func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error
 	}
 
-	totalPower, err := r.GetValidatorSetPower(ctx)
+	totalPower, err := r.validatorSetPower(ctx, r.currentTx)
 	if err != nil {
 		return err
 	}
@@ -476,11 +504,11 @@ func (r *TxApp) processVotes(ctx context.Context, blockheight int64) error {
 
 		for _, resolution := range finalized {
 			credits.applyResolution(resolution)
-			finalizedIds = append(finalizedIds, resolution.ID)
+			finalizedIDs = append(finalizedIDs, resolution.ID)
 
 			// we do not want to mark processed for validator join and remove events, as they can occur again
 			if resolution.Type != voting.ValidatorJoinEventType && resolution.Type != voting.ValidatorRemoveEventType {
-				markProcessedIds = append(markProcessedIds, resolution.ID)
+				markProcessedIDs = append(markProcessedIDs, resolution.ID)
 			}
 
 			resolveFuncs = append(resolveFuncs, &struct {
@@ -525,17 +553,17 @@ func (r *TxApp) processVotes(ctx context.Context, blockheight int64) error {
 	}
 
 	// now we will expire resolutions
-	expired, err := getExpired(ctx, r.currentTx, blockheight)
+	expired, err := getExpired(ctx, r.currentTx, blockHeight)
 	if err != nil {
 		return err
 	}
 
-	expiredIds := make([]*types.UUID, 0, len(expired))
+	expiredIDs := make([]*types.UUID, 0, len(expired))
 	requiredPowerMap := make(map[string]int64) // map of resolution type to required power
 	for _, resolution := range expired {
-		expiredIds = append(expiredIds, resolution.ID)
+		expiredIDs = append(expiredIDs, resolution.ID)
 		if resolution.Type != voting.ValidatorJoinEventType && resolution.Type != voting.ValidatorRemoveEventType {
-			markProcessedIds = append(markProcessedIds, resolution.ID)
+			markProcessedIDs = append(markProcessedIDs, resolution.ID)
 		}
 
 		threshold, ok := requiredPowerMap[resolution.Type]
@@ -548,23 +576,23 @@ func (r *TxApp) processVotes(ctx context.Context, blockheight int64) error {
 			// we need to use each configured resolutions refund threshold
 			requiredPowerMap[resolution.Type] = requiredPower(ctx, r.currentTx, cfg.RefundThreshold, totalPower)
 		}
-		refunded := false
 		// if it has enough power, we will still refund
-		if resolution.ApprovedPower >= threshold {
-			refunded = true
+		refunded := resolution.ApprovedPower >= threshold
+		if refunded {
 			credits.applyResolution(resolution)
 		}
 
-		r.log.Debug("expiring resolution", log.String("type", resolution.Type), log.String("id", resolution.ID.String()), log.Bool("refunded", refunded))
+		r.log.Debug("expiring resolution", log.String("type", resolution.Type),
+			log.String("id", resolution.ID.String()), log.Bool("refunded", refunded))
 	}
 
-	allIds := append(finalizedIds, expiredIds...)
-	err = deleteResolutions(ctx, r.currentTx, allIds...)
+	allIDs := append(finalizedIDs, expiredIDs...)
+	err = deleteResolutions(ctx, r.currentTx, allIDs...)
 	if err != nil {
 		return err
 	}
 
-	err = markProcessed(ctx, r.currentTx, markProcessedIds...)
+	err = markProcessed(ctx, r.currentTx, markProcessedIDs...)
 	if err != nil {
 		return err
 	}
@@ -573,7 +601,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockheight int64) error {
 	// per block vote sizes, they never get to vote and essentially delete the event
 	// So this is handled instead when the nodes are approved.
 	// TODO: We need to figure out the consequences of resolutions getting expired due to the vote limits set per block. There can be scenarios where the events are observed by the nodes, but before they can vote, the event gets expired. rare but possible in the situations with higher event traffic.
-	err = deleteEvents(ctx, r.currentTx, markProcessedIds...)
+	err = deleteEvents(ctx, r.currentTx, markProcessedIDs...)
 	if err != nil {
 		return err
 	}
@@ -718,9 +746,31 @@ func (r *TxApp) ApplyMempool(ctx context.Context, tx *transactions.Transaction) 
 	return r.mempool.applyTransaction(ctx, tx, readTx, r.events)
 }
 
+func (r *TxApp) ConsensusAccountInfo(ctx context.Context, acctID []byte) (balance *big.Int, nonce int64, err error) {
+	// NOTE: this method is meant ONLY for use from methods on ABCI's consensus
+	// connection, which ensures no use (no data race on r.currentTx).
+	var tx sql.Executor
+	if r.currentTx == nil { // coming from PrepareProposal / ProcessProposal, which is always the case presently
+		rtx, err := r.Database.BeginReservedReadTx(ctx)
+		if err != nil {
+			return nil, 0, err
+		}
+		defer rtx.Rollback(ctx)
+		tx = rtx
+	} else { // coming from FinalizeBlock
+		tx = r.currentTx
+	}
+
+	acct, err := getAccount(ctx, tx, acctID)
+	if err != nil {
+		return nil, 0, err
+	}
+	return acct.Balance, acct.Nonce, nil
+}
+
 // AccountInfo gets account info from either the mempool or the account store.
 // It takes a flag to indicate whether it should check the mempool first.
-func (r *TxApp) AccountInfo(ctx context.Context, acctID []byte, getUncommitted bool) (balance *big.Int, nonce int64, err error) {
+func (r *TxApp) AccountInfo(ctx context.Context, acctID []byte, getUnconfirmed bool) (balance *big.Int, nonce int64, err error) {
 	readTx, err := r.Database.BeginReadTx(ctx)
 	if err != nil {
 		return nil, 0, err
@@ -728,7 +778,7 @@ func (r *TxApp) AccountInfo(ctx context.Context, acctID []byte, getUncommitted b
 	defer readTx.Rollback(ctx) // always rollback read tx
 
 	var a *types.Account
-	if getUncommitted {
+	if getUnconfirmed {
 		a, err = r.mempool.accountInfoSafe(ctx, readTx, acctID)
 	} else {
 		a, err = getAccount(ctx, readTx, acctID)
@@ -748,10 +798,17 @@ func (r *TxApp) AccountInfo(ctx context.Context, acctID []byte, getUncommitted b
 // This transaction only includes voteBodies for events whose bodies have not been received by the network.
 // Therefore, there won't be more than 1 VoteBody transaction per event.
 func (r *TxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxsSize int64, proposerAddr []byte) ([][]byte, error) {
-	bal, nonce, err := r.AccountInfo(ctx, proposerAddr, false)
+	readTx, err := r.Database.BeginReservedReadTx(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get proposer account: %w", err)
+		return nil, err
 	}
+	defer readTx.Rollback(ctx) // always rollback read tx
+
+	acct, err := getAccount(ctx, readTx, proposerAddr)
+	if err != nil {
+		return nil, err
+	}
+	bal, nonce := acct.Balance, acct.Nonce
 
 	if r.GasEnabled && nonce == 0 && bal.Sign() == 0 {
 		r.log.Debug("proposer account has no balance, not allowed to propose any new transactions")
@@ -761,12 +818,6 @@ func (r *TxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxsSize int6
 	if txNonce == 0 {
 		txNonce = uint64(nonce) + 1
 	}
-
-	readTx, err := r.Database.BeginReadTx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer readTx.Rollback(ctx) // always rollback read tx
 
 	maxTxsSize -= r.emptyVoteBodyTxSize + 1000 // empty payload size + 1000 safety buffer
 	events, err := getEvents(ctx, readTx)
@@ -855,7 +906,7 @@ func (r *TxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxsSize int6
 
 // eventRLPSize is the extra size added to an event from RLP
 // encoding. It is the same regardless of event data.
-var eventRLPSize int64 = func() int64 {
+var eventRLPSize = func() int64 {
 	event := &types.VotableEvent{
 		Body: []byte("body"),
 		Type: "type",

--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -309,16 +309,15 @@ func (r *TxApp) ConsensusValidators(ctx context.Context) ([]*types.Validator, er
 		tx = rtx
 	} else { // coming from FinalizeBlock
 		tx = r.currentTx
+		// We're not making a nested tx since an error in the consensus thread
+		// will halt the node (and rollback) anyway.
 	}
-
-	// We're not making a nested tx since an error in the consensus thread will
-	// halt the node (and rollback) anyway.
 
 	return getAllVoters(ctx, tx)
 }
 
 // GetValidators returns a shallow copy of the current validator set.
-// It will not return ONLY committed changes.
+// It will return ONLY committed changes.
 func (r *TxApp) GetValidators(ctx context.Context) ([]*types.Validator, error) {
 	r.valMtx.Lock()
 	defer r.valMtx.Unlock()


### PR DESCRIPTION
Resolves https://github.com/kwilteam/kwil-db/issues/755

The gist of the reserved connections is:

```go
// BeginReservedReadTx starts a read-only transaction using a reserved reader
// connection. This is to allow read-only consensus operations that operate
// outside of the write transaction's lifetime, such as proposal preparation and
// approval, to function without contention on the reader pool that services
// user requests.
```

So, some stuff can use `r.currentTx` (the consensus write connection) but in other place like `ProcessProposal` we are not in block execution but we don't want to fight for a read connection from RPC users.