### PR TITLE
add missing return detection

### DIFF
--- a/internal/engine/generate/plpgsql.go
+++ b/internal/engine/generate/plpgsql.go
@@ -817,7 +817,8 @@ func (p *procedureGenerator) VisitLoopTermSQL(p0 *parse.LoopTermSQL) any {
 }
 
 func (p *procedureGenerator) VisitLoopTermVariable(p0 *parse.LoopTermVariable) any {
-	return fmt.Sprintf("ARRAY %s", p0.Variable.Accept(p).(string))
+	// we use coalesce here so that we do not error when looping on null arrays
+	return fmt.Sprintf("ARRAY COALESCE(%s, '{}')", p0.Variable.Accept(p).(string))
 }
 
 func (p *procedureGenerator) VisitProcedureStmtIf(p0 *parse.ProcedureStmtIf) any {

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -167,6 +167,16 @@ func Test_Procedures(t *testing.T) {
 			inputs:  []any{[]int64{1, 2, 3}},
 			outputs: [][]any{{int64(2)}, {int64(4)}, {int64(6)}},
 		},
+		{
+			name: "table return with no hits doesn't return postgres no-return error",
+			procedure: `procedure return_next($vals int[]) public view returns table(val int) {
+				for $i in $vals {
+					error('unreachable');
+				}
+			}`,
+			inputs:  []any{[]int64{}},
+			outputs: [][]any{},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -177,6 +177,18 @@ func Test_Procedures(t *testing.T) {
 			inputs:  []any{[]int64{}},
 			outputs: [][]any{},
 		},
+		{
+			name: "loop over null array",
+			procedure: `procedure loop_over_null() public view returns (count int) {
+				$vals int[];
+				$count := 0;
+				for $i in $vals {
+					$count := $count + 1;
+				}
+				return $count;
+			}`,
+			outputs: [][]any{{int64(0)}},
+		},
 	}
 
 	for _, test := range tests {

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -157,6 +157,16 @@ func Test_Procedures(t *testing.T) {
 			}`,
 			outputs: [][]any{{int64(11)}},
 		},
+		{
+			name: "return next from a non-table",
+			procedure: `procedure return_next($vals int[]) public view returns table(val int) {
+				for $i in $vals {
+					return next $i*2;
+				}
+			}`,
+			inputs:  []any{[]int64{1, 2, 3}},
+			outputs: [][]any{{int64(2)}, {int64(4)}, {int64(6)}},
+		},
 	}
 
 	for _, test := range tests {

--- a/parse/analyze.go
+++ b/parse/analyze.go
@@ -2187,6 +2187,11 @@ func (p *procedureAnalyzer) VisitProcedureStmtCall(p0 *ProcedureStmtCall) any {
 
 		callReturns = returns2
 	}
+	// if calling the `error` function, then this branch will return
+	exits := false
+	if p0.Call.FunctionName() == "error" {
+		exits = true
+	}
 
 	// if calling a non-view procedure, the above will set the sqlResult to be mutative
 	// if this procedure is a view, we should throw an error.
@@ -2228,7 +2233,9 @@ func (p *procedureAnalyzer) VisitProcedureStmtCall(p0 *ProcedureStmtCall) any {
 		}
 	}
 
-	return zeroProcedureReturn()
+	return &procedureStmtResult{
+		willReturn: exits,
+	}
 }
 
 // VisitProcedureStmtForLoop visits a for loop statement.

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -195,7 +195,9 @@ func analyzeProcedureAST(proc *types.Procedure, schema *types.Schema, ast []Proc
 		}
 	}
 
-	if proc.Returns != nil && !returns {
+	// if the procedure is expecting a return that is not a table, and it does not guarantee
+	// returning a value, we should add an error.
+	if proc.Returns != nil && !returns && !proc.Returns.IsTable {
 		errLis.AddErr(res.AST[len(res.AST)-1], ErrReturn, "procedure does not return a value")
 	}
 

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -187,8 +187,16 @@ func analyzeProcedureAST(proc *types.Procedure, schema *types.Schema, ast []Proc
 	}
 
 	// visit the AST
+	returns := false
 	for _, stmt := range res.AST {
-		stmt.Accept(visitor)
+		res := stmt.Accept(visitor).(*procedureStmtResult)
+		if res.willReturn {
+			returns = true
+		}
+	}
+
+	if proc.Returns != nil && !returns {
+		errLis.AddErr(res.AST[len(res.AST)-1], ErrReturn, "procedure does not return a value")
 	}
 
 	for k, v := range visitor.procResult.allVariables {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1423,6 +1423,28 @@ func Test_Procedure(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "error func exits",
+			proc: `error('error message');`,
+			returns: &types.ProcedureReturn{
+				Fields: []*types.NamedType{{
+					Name: "id",
+					Type: types.IntType,
+				}},
+			},
+			want: &parse.ProcedureParseResult{
+				AST: []parse.ProcedureStmt{
+					&parse.ProcedureStmtCall{
+						Call: &parse.ExpressionFunctionCall{
+							Name: "error",
+							Args: []parse.Expression{
+								exprLit("error message"),
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1323,7 +1323,7 @@ func Test_Procedure(t *testing.T) {
 					Type: types.IntType,
 				}},
 			},
-			proc: `return select id from users;`,
+			proc: `return select id from users;`, // this is intentional- plpgsql treats this as a table return
 			err:  parse.ErrReturn,
 		},
 		{

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1957,6 +1957,34 @@ func Test_SQL(t *testing.T) {
 			sql:  `SELECT count(u.id), u.username FROM users as u;`,
 			err:  parse.ErrAggregate,
 		},
+		{
+			name: "aggregate with no group by returns one column",
+			sql:  `SELECT count(*) FROM users;`,
+			want: &parse.SQLStatement{
+				SQL: &parse.SelectStatement{
+					SelectCores: []*parse.SelectCore{
+						{
+							Columns: []parse.ResultColumn{
+								&parse.ResultColumnExpression{
+									Expression: &parse.ExpressionFunctionCall{
+										Name: "count",
+										Star: true,
+									},
+								},
+							},
+							From: &parse.RelationTable{
+								Table: "users",
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "aggregate with no group by and ordering fails",
+			sql:  `SELECT count(*) FROM users order by count(*) DESC;`,
+			err:  parse.ErrAggregate,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR adds several tests, including:

- tests (and bug fixes) that ensure that all procedures that need a return have one. Without this check, users can hit unexpected plpgsql errors.
- tests for default ordering for aggregate and compound selects.
- tests for non-determinism checks with aggregates and group bys