### PR TITLE
added crypto functions, encode/decode

### DIFF
--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -4,11 +4,14 @@ package integration_test
 
 import (
 	"context"
+	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 	"strings"
 	"testing"
 
 	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/parse"
 	"github.com/stretchr/testify/require"
 )
@@ -188,6 +191,17 @@ func Test_Procedures(t *testing.T) {
 				return $count;
 			}`,
 			outputs: [][]any{{int64(0)}},
+		},
+		{
+			name: "encode, decode, and digest functions",
+			procedure: `procedure encode_decode_digest($hex text) public view returns (encoded text, decoded blob, digest blob) {
+				$decoded := decode($hex, 'hex');
+				$encoded := encode($decoded, 'base64');
+				$digest := digest($decoded, 'sha256');
+				return $encoded, $decoded, $digest;
+			}`,
+			inputs:  []any{hex.EncodeToString([]byte("hello"))},
+			outputs: [][]any{{base64.StdEncoding.EncodeToString([]byte("hello")), []byte("hello"), crypto.Sha256([]byte("hello"))}},
 		},
 	}
 

--- a/internal/sql/pg/db.go
+++ b/internal/sql/pg/db.go
@@ -162,6 +162,10 @@ func NewDB(ctx context.Context, cfg *DBConfig) (*DB, error) {
 		return nil, fmt.Errorf("failed to create UUID extension: %w", err)
 	}
 
+	if err = ensurePgCryptoExtension(ctx, conn); err != nil {
+		return nil, fmt.Errorf("failed to create pgcrypto extension: %w", err)
+	}
+
 	okSchema := cfg.SchemaFilter
 	if okSchema == nil {
 		okSchema = defaultSchemaFilter

--- a/internal/sql/pg/sql.go
+++ b/internal/sql/pg/sql.go
@@ -110,6 +110,11 @@ func ensureUUIDExtension(ctx context.Context, conn *pgx.Conn) error {
 	return err
 }
 
+func ensurePgCryptoExtension(ctx context.Context, conn *pgx.Conn) error {
+	_, err := conn.Exec(ctx, `CREATE EXTENSION IF NOT EXISTS pgcrypto;`)
+	return err
+}
+
 func ensureUint256Domain(ctx context.Context, conn *pgx.Conn) error {
 	_, err := conn.Exec(ctx, sqlCreateUint256Domain)
 	return err

--- a/parse/functions.go
+++ b/parse/functions.go
@@ -175,6 +175,90 @@ var (
 				return fmt.Sprintf("uuid_generate_v5(%s)", strings.Join(inputs, ", ")), nil
 			},
 		},
+		"encode": {
+			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
+				// first must be blob, second must be text
+				if len(args) != 2 {
+					return nil, wrapErrArgumentNumber(2, len(args))
+				}
+
+				if !args[0].EqualsStrict(types.BlobType) {
+					return nil, wrapErrArgumentType(types.BlobType, args[0])
+				}
+
+				if !args[1].EqualsStrict(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[1])
+				}
+
+				return types.TextType, nil
+			},
+			PGFormat: func(inputs []string, distinct bool, star bool) (string, error) {
+				if star {
+					return "", errStar("encode")
+				}
+				if distinct {
+					return "", errDistinct("encode")
+				}
+
+				return fmt.Sprintf("encode(%s)", strings.Join(inputs, ", ")), nil
+			},
+		},
+		"decode": {
+			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
+				// first must be text, second must be text
+				if len(args) != 2 {
+					return nil, wrapErrArgumentNumber(2, len(args))
+				}
+
+				if !args[0].EqualsStrict(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[0])
+				}
+
+				if !args[1].EqualsStrict(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[1])
+				}
+
+				return types.BlobType, nil
+			},
+			PGFormat: func(inputs []string, distinct bool, star bool) (string, error) {
+				if star {
+					return "", errStar("decode")
+				}
+				if distinct {
+					return "", errDistinct("decode")
+				}
+
+				return fmt.Sprintf("decode(%s)", strings.Join(inputs, ", ")), nil
+			},
+		},
+		"digest": {
+			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
+				// first must be either text or blob, second must be text
+				if len(args) != 2 {
+					return nil, wrapErrArgumentNumber(2, len(args))
+				}
+
+				if !args[0].EqualsStrict(types.TextType) && !args[0].EqualsStrict(types.BlobType) {
+					return nil, fmt.Errorf("expected first argument to be text or blob, got %s", args[0].String())
+				}
+
+				if !args[1].EqualsStrict(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[1])
+				}
+
+				return types.BlobType, nil
+			},
+			PGFormat: func(inputs []string, distinct bool, star bool) (string, error) {
+				if star {
+					return "", errStar("digest")
+				}
+				if distinct {
+					return "", errDistinct("digest")
+				}
+
+				return fmt.Sprintf("digest(%s)", strings.Join(inputs, ", ")), nil
+			},
+		},
 		// array functions
 		"array_append": {
 			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {


### PR DESCRIPTION
This PR adds three functions from Postgres:

- encode/decode: https://www.postgresql.org/docs/current/functions-binarystring.html
- digest: https://www.postgresql.org/docs/current/pgcrypto.html#PGCRYPTO-GENERAL-HASHING-FUNCS-DIGEST

This was requested by the Truflation team, so they can generate DBIDs within a procedure: https://github.com/truflation/tsn/issues/280#issuecomment-2133458185

I also felt that these were pretty reasonable functions to want to have access to.