### PR TITLE
added debug for cli parse

### DIFF
--- a/cmd/kwil-cli/cmds/utils/parse.go
+++ b/cmd/kwil-cli/cmds/utils/parse.go
@@ -12,6 +12,9 @@ import (
 )
 
 func newParseCmd() *cobra.Command {
+	var debug bool
+	var out string
+
 	cmd := &cobra.Command{
 		Use:   "parse <file_path>",
 		Short: "Parse a Kuneiform schema",
@@ -32,13 +35,51 @@ func newParseCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			if res.Err() != nil {
-				return display.PrintErr(cmd, res.Err())
+			// if not in debug mode, throw any errors and swallow the schema,
+			// since the schema is invalid.
+			if !debug {
+				if res.Err() != nil {
+					return display.PrintErr(cmd, res.Err())
+				}
+
+				if out == "" {
+					return display.PrintCmd(cmd, &schemaDisplay{Result: res.Schema})
+				}
+
+				bts, err := json.MarshalIndent(res.Schema, "", "  ")
+				if err != nil {
+					return display.PrintErr(cmd, err)
+				}
+
+				err = os.WriteFile(out, bts, 0644)
+				if err != nil {
+					return display.PrintErr(cmd, err)
+				}
+
+				return display.PrintCmd(cmd, display.RespString(fmt.Sprintf("Schema written to %s", out)))
 			}
 
-			return display.PrintCmd(cmd, &schemaDisplay{Result: res.Schema})
+			// if in debug mode, output the schema and the debug information.
+			if out == "" {
+				return display.PrintCmd(cmd, &debugDisplay{Result: res})
+			}
+
+			bts, err := json.MarshalIndent(res, "", "  ")
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			err = os.WriteFile(out, bts, 0644)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			return display.PrintCmd(cmd, display.RespString(fmt.Sprintf("Debug information written to %s", out)))
 		},
 	}
+
+	cmd.Flags().BoolVarP(&debug, "debug", "d", false, "Display debug information")
+	cmd.Flags().StringVarP(&out, "out", "o", "", "Output file. If debug is true, errors will also be written to this file")
 
 	return cmd
 }
@@ -54,4 +95,18 @@ func (s *schemaDisplay) MarshalJSON() ([]byte, error) {
 
 func (s *schemaDisplay) MarshalText() (text []byte, err error) {
 	return json.MarshalIndent(s.Result, "", "  ")
+}
+
+// debugDisplay is a struct that will be used to display the schema.
+// It is used to display the debug information.
+type debugDisplay struct {
+	Result *parse.SchemaParseResult
+}
+
+func (d *debugDisplay) MarshalJSON() ([]byte, error) {
+	return json.Marshal(d.Result)
+}
+
+func (d *debugDisplay) MarshalText() (text []byte, err error) {
+	return json.MarshalIndent(d.Result, "", "  ")
 }

--- a/parse/errors.go
+++ b/parse/errors.go
@@ -98,7 +98,7 @@ func (p ParseError) Unwrap() error {
 func (p *ParseError) Error() string {
 	// Add 1 to the column numbers to make them 1-indexed, since antlr-go is 0-indexed
 	// for columns.
-	return fmt.Sprintf("(%s) %s: %s\nstart %d:%d end %d:%d", p.ParserName, p.Err.Error(), p.Message,
+	return fmt.Sprintf("(%s) %s: %s\n start %d:%d end %d:%d", p.ParserName, p.Err.Error(), p.Message,
 		p.Position.StartLine, p.Position.StartCol+1,
 		p.Position.EndLine, p.Position.EndCol+1)
 }

--- a/parse/types.go
+++ b/parse/types.go
@@ -11,10 +11,10 @@ type Position struct {
 	// Set is true if the position of the Position has been set.
 	// This is useful for testing parsers.
 	IsSet     bool `json:"-"`
-	StartLine int  `json:"start_line"`
-	StartCol  int  `json:"start_col"`
-	EndLine   int  `json:"end_line"`
-	EndCol    int  `json:"end_col"`
+	StartLine int  `json:"-"`
+	StartCol  int  `json:"-"`
+	EndLine   int  `json:"-"`
+	EndCol    int  `json:"-"`
 }
 
 // Set sets the position of the Position based on the given parser rule context.


### PR DESCRIPTION
This adds debug functionality for `kwil-cli utils parse`. It replaces https://github.com/kwilteam/kwil-db/pull/739