### PR TITLE
chore: use kwil-db/core v0.2.0-beta.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,8 +18,8 @@ require (
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9
 	github.com/jackc/pgx/v5 v5.5.5
 	github.com/jpillora/backoff v1.0.0
-	github.com/kwilteam/kwil-db/core v0.2.0-beta
-	github.com/kwilteam/kwil-db/parse v0.2.0-beta
+	github.com/kwilteam/kwil-db/core v0.2.0-beta.1
+	github.com/kwilteam/kwil-db/parse v0.2.0-beta.1
 	github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7
 	github.com/manifoldco/promptui v0.9.0
 	github.com/mitchellh/mapstructure v1.5.0

--- a/parse/go.mod
+++ b/parse/go.mod
@@ -7,7 +7,7 @@ replace github.com/kwilteam/kwil-db/core => ../core
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0
 	github.com/google/go-cmp v0.6.0
-	github.com/kwilteam/kwil-db/core v0.2.0-beta
+	github.com/kwilteam/kwil-db/core v0.2.0-beta.1
 	github.com/pganalyze/pg_query_go/v5 v5.1.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/test/go.mod
+++ b/test/go.mod
@@ -17,8 +17,8 @@ require (
 	github.com/drhodes/golorem v0.0.0-20220328165741-da82e5b29246
 	github.com/ethereum/go-ethereum v1.14.3
 	github.com/kwilteam/kwil-db v0.7.2
-	github.com/kwilteam/kwil-db/core v0.2.0-beta
-	github.com/kwilteam/kwil-db/parse v0.2.0-beta
+	github.com/kwilteam/kwil-db/core v0.2.0-beta.1
+	github.com/kwilteam/kwil-db/parse v0.2.0-beta.1
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.29.1
 	github.com/testcontainers/testcontainers-go/modules/compose v0.29.2-0.20240321072901-c83b93cb1eff


### PR DESCRIPTION
This updates all package to use `kwil-db/core v0.2.0-beta.1` and ` kwil-db/parse v0.2.0-beta.1`.

` kwil-db/parse v0.2.0-beta.1` hasn't been tagged yet, but it should pass the test since we have 'replace'.