### PR TITLE
added backwards compatibility for kwil-provider

### DIFF
--- a/cmd/kwil-cli/cmds/root.go
+++ b/cmd/kwil-cli/cmds/root.go
@@ -1,6 +1,8 @@
 package cmds
 
 import (
+	"fmt"
+
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/common/version"
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/cmds/account"
@@ -10,6 +12,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/cmds/utils"
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 )
 
 func NewRootCmd() *cobra.Command {
@@ -40,4 +43,18 @@ The Kwil CLI can be configured with a persistent configuration file.  This file 
 	`,
 	SilenceUsage:      true,
 	DisableAutoGenTag: true,
+	PersistentPreRunE: func(cmd *cobra.Command, args []string) error {
+		// for backwards compatibility, we need to check if the deprecated flag is set.
+		// If the new flag is set and the deprecated flag is not, we can proceed.
+		// If both are set, we should return an error.
+		if cmd.Flags().Changed("kwil-provider") {
+			if cmd.Flags().Changed(config.GlobalProviderFlag) {
+				return fmt.Errorf("cannot use both --provider and --kwil-provider flags")
+			} else {
+				viper.BindPFlag(config.GlobalProviderFlag, cmd.Flags().Lookup("kwil-provider"))
+			}
+		}
+
+		return nil
+	},
 }

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -55,4 +55,10 @@ func BindGlobalFlags(fs *pflag.FlagSet) {
 	viper.BindPFlag(viperPrivateKeyName, fs.Lookup(globalPrivateKeyFlag))
 	viper.BindPFlag(viperProviderName, fs.Lookup(globalProviderFlag))
 	viper.BindPFlag(viperChainID, fs.Lookup(globalChainIDFlag))
+
+	// for backwards compatibility, we add kwil-provider but mark it as deprecated
+	fs.String("kwil-provider", cliCfg.Provider, "the Kwil provider RPC endpoint")
+	fs.MarkDeprecated("kwil-provider", "use '--provider' instead")
+	// we also need to alias using the viper key name
+	viper.BindPFlag(viperProviderName, fs.Lookup("kwil-provider"))
 }

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var CliCfg = DefaultKwilCliPersistedConfig()
+var cliCfg = DefaultKwilCliPersistedConfig()
 
 const (
 	defaultConfigDirName      = ".kwil-cli"
@@ -46,9 +46,9 @@ func init() {
 
 func BindGlobalFlags(fs *pflag.FlagSet) {
 	// Bind flags to environment variables
-	fs.String(globalPrivateKeyFlag, CliCfg.PrivateKey, "the private key of the wallet that will be used for signing")
-	fs.String(GlobalProviderFlag, CliCfg.Provider, "the Kwil provider RPC endpoint")
-	fs.String(globalChainIDFlag, CliCfg.ChainID, "the expected/intended Kwil Chain ID")
+	fs.String(globalPrivateKeyFlag, cliCfg.PrivateKey, "the private key of the wallet that will be used for signing")
+	fs.String(GlobalProviderFlag, cliCfg.Provider, "the Kwil provider RPC endpoint")
+	fs.String(globalChainIDFlag, cliCfg.ChainID, "the expected/intended Kwil Chain ID")
 	fs.StringVar(&configFile, globalConfigFileFlag, defaultConfigFile, "the path to the Kwil CLI persistent global settings file")
 
 	// Bind flags to viper, named by the flag name
@@ -57,6 +57,6 @@ func BindGlobalFlags(fs *pflag.FlagSet) {
 	viper.BindPFlag(viperChainID, fs.Lookup(globalChainIDFlag))
 
 	// Add deprecated flag
-	fs.String("kwil-provider", CliCfg.Provider, "the Kwil provider RPC endpoint")
+	fs.String("kwil-provider", cliCfg.Provider, "the Kwil provider RPC endpoint")
 	fs.MarkDeprecated("kwil-provider", "use '--provider' instead")
 }

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -8,7 +8,7 @@ import (
 	"github.com/spf13/viper"
 )
 
-var cliCfg = DefaultKwilCliPersistedConfig()
+var CliCfg = DefaultKwilCliPersistedConfig()
 
 const (
 	defaultConfigDirName      = ".kwil-cli"
@@ -17,7 +17,7 @@ const (
 
 	// NOTE: these flags below are also used as viper key names
 	globalPrivateKeyFlag = "private-key"
-	globalProviderFlag   = "provider"
+	GlobalProviderFlag   = "provider"
 	globalChainIDFlag    = "chain-id"
 	globalConfigFileFlag = "config"
 
@@ -46,19 +46,17 @@ func init() {
 
 func BindGlobalFlags(fs *pflag.FlagSet) {
 	// Bind flags to environment variables
-	fs.String(globalPrivateKeyFlag, cliCfg.PrivateKey, "the private key of the wallet that will be used for signing")
-	fs.String(globalProviderFlag, cliCfg.Provider, "the Kwil provider RPC endpoint")
-	fs.String(globalChainIDFlag, cliCfg.ChainID, "the expected/intended Kwil Chain ID")
+	fs.String(globalPrivateKeyFlag, CliCfg.PrivateKey, "the private key of the wallet that will be used for signing")
+	fs.String(GlobalProviderFlag, CliCfg.Provider, "the Kwil provider RPC endpoint")
+	fs.String(globalChainIDFlag, CliCfg.ChainID, "the expected/intended Kwil Chain ID")
 	fs.StringVar(&configFile, globalConfigFileFlag, defaultConfigFile, "the path to the Kwil CLI persistent global settings file")
 
 	// Bind flags to viper, named by the flag name
 	viper.BindPFlag(viperPrivateKeyName, fs.Lookup(globalPrivateKeyFlag))
-	viper.BindPFlag(viperProviderName, fs.Lookup(globalProviderFlag))
+	viper.BindPFlag(viperProviderName, fs.Lookup(GlobalProviderFlag))
 	viper.BindPFlag(viperChainID, fs.Lookup(globalChainIDFlag))
 
-	// for backwards compatibility, we add kwil-provider but mark it as deprecated
-	fs.String("kwil-provider", cliCfg.Provider, "the Kwil provider RPC endpoint")
+	// Add deprecated flag
+	fs.String("kwil-provider", CliCfg.Provider, "the Kwil provider RPC endpoint")
 	fs.MarkDeprecated("kwil-provider", "use '--provider' instead")
-	// we also need to alias using the viper key name
-	viper.BindPFlag(viperProviderName, fs.Lookup("kwil-provider"))
 }


### PR DESCRIPTION
This adds backwards compatibility for the `--kwil-provider` flag, which was changed to `--provider` in this release. Users will get a warning when they use this flag, however it will still work.

I think it is important to have a deprecation period for this, since both Fractal and Truflation have critical infra built around our CLI.