### PR TITLE
Remove duplicate unique constraints on name field in resolution_type …

### DIFF
--- a/core/types/uuid.go
+++ b/core/types/uuid.go
@@ -131,3 +131,11 @@ func (u *UUIDArray) Scan(src any) error {
 	}
 	return errors.New("not a byte slice slice")
 }
+
+func (u UUIDArray) Bytes() [][]byte {
+	v := make([][]byte, len(u))
+	for i, ui := range u {
+		v[i] = ui.Bytes()
+	}
+	return v
+}

--- a/go.work.example
+++ b/go.work.example
@@ -3,6 +3,7 @@ go 1.21
 use (
 	.
 	./core
+	./parse
 	./test
 )
 

--- a/internal/voting/sql.go
+++ b/internal/voting/sql.go
@@ -5,34 +5,34 @@ package voting
 */
 
 /*
-	Final schema after all the upgrades:
-	resolutions:
-		- id: uuid
-		- body: bytea
-		- type: bytea
-		- vote_body_proposer: bytea
-		- expiration: int8
+Final schema after all the upgrades:
+resolutions:
+  - id: uuid
+  - body: bytea
+  - type: bytea
+  - vote_body_proposer: bytea
+  - expiration: int8
 
-	resolution_types:
-		- id: uuid
+resolution_types:
+  - id: uuid
+  - name: text
 
-	voters:
-		- id: uuid
-		- name: bytea
-		- power: int8
+voters:
+  - id: uuid
+  - name: bytea
+  - power: int8
 
-	votes:
-		- resolution_id: uuid
-		- voter_id: uuid
+votes:
+  - resolution_id: uuid
+  - voter_id: uuid
 
-	processed:
-		- id: uuid
+processed:
+  - id: uuid
 */
-
 const (
 	votingSchemaName = `kwild_voting`
 
-	voteStoreVersion = 2
+	voteStoreVersion = 3
 
 	// tableResolutions is the sql table used to store resolutions that can be voted on.
 	// the vote_body_proposer is the BYTEA of the public key of the submitter, NOT the UUID
@@ -198,4 +198,12 @@ const (
 // upgrades V1 -> V2
 const (
 	dropExtraVoteID = `ALTER TABLE ` + votingSchemaName + `.resolutions DROP COLUMN extra_vote_id;`
+)
+
+// upgrades V2 -> V3
+const (
+	// remove unique constraint on name on both resolution_types and voters as id is derived from name and is unique.
+	removeResolutionTypesUniqueNameConstraint = `ALTER TABLE ` + votingSchemaName + `.resolution_types DROP CONSTRAINT resolution_types_name_key;`
+
+	removeVotersUniqueNameConstraint = `ALTER TABLE ` + votingSchemaName + `.voters DROP CONSTRAINT voters_name_key;`
 )

--- a/internal/voting/voting.go
+++ b/internal/voting/voting.go
@@ -28,7 +28,6 @@ func initializeVoteStore(ctx context.Context, db sql.TxMaker) error {
 		0: initVotingTables,
 		1: dropHeight,
 		2: dropExtraVoteIDColumn,
-		3: dropUniqueNameConstraints,
 	}
 
 	err := versioning.Upgrade(ctx, db, votingSchemaName, upgradeFns, voteStoreVersion)
@@ -50,7 +49,8 @@ func initializeVoteStore(ctx context.Context, db sql.TxMaker) error {
 	resolutions := resolutions.ListResolutions()
 	for _, name := range resolutions {
 		uuid := types.NewUUIDV5([]byte(name))
-		_, err := tx.Execute(ctx, createResolutionType, uuid, name)
+		fmt.Println("Creating resolution type", name, " with UUID: ", uuid, " value: ", *uuid, " uuid[:] ", uuid[:])
+		_, err := tx.Execute(ctx, createResolutionType, uuid[:], name)
 		if err != nil {
 			return err
 		}
@@ -84,15 +84,6 @@ func dropExtraVoteIDColumn(ctx context.Context, db sql.DB) error {
 	return err
 }
 
-func dropUniqueNameConstraints(ctx context.Context, db sql.DB) error {
-	if _, err := db.Execute(ctx, removeResolutionTypesUniqueNameConstraint); err != nil {
-		return err
-	}
-
-	_, err := db.Execute(ctx, removeVotersUniqueNameConstraint)
-	return err
-}
-
 // ApproveResolution approves a resolution from a voter.
 // If the resolution does not yet exist, it will be errored,
 // Validators should only vote on existing resolutions.
@@ -115,7 +106,7 @@ func ApproveResolution(ctx context.Context, db sql.TxMaker, resolutionID *types.
 	// if the vote from the voter already exists, nothing will happen
 	// if the resolution doesn't exist, the following would error
 	userID := types.NewUUIDV5(from)
-	_, err = tx.Execute(ctx, addVote, resolutionID, userID)
+	_, err = tx.Execute(ctx, addVote, resolutionID[:], userID[:])
 	if err != nil {
 		return err
 	}
@@ -136,7 +127,8 @@ func CreateResolution(ctx context.Context, db sql.TxMaker, event *types.VotableE
 
 	// NOTE: could check IsProcessed() here and skip the insert.
 
-	_, err = tx.Execute(ctx, insertResolution, event.ID(), event.Body, event.Type, expiration, voteBodyProposer)
+	id := event.ID()
+	_, err = tx.Execute(ctx, insertResolution, id[:], event.Body, event.Type, expiration, voteBodyProposer)
 	if err != nil {
 		return err
 	}
@@ -154,11 +146,16 @@ func fromRow(row []any) (*resolutions.Resolution, error) {
 
 	v := &resolutions.Resolution{}
 
-	uid, ok := row[0].(*types.UUID)
+	bts, ok := row[0].([]byte)
 	if !ok {
 		return nil, fmt.Errorf("invalid type for id (%T)", row[0])
 	}
-	v.ID = uid
+	if len(bts) != 16 {
+		return nil, fmt.Errorf("invalid length for id, required 16, got (%d)", len(bts))
+	}
+
+	uid := types.UUID(slices.Clone(bts))
+	v.ID = &uid
 
 	if row[1] == nil {
 		v.Body = nil
@@ -335,11 +332,17 @@ func GetResolutionIDsByTypeAndProposer(ctx context.Context, db sql.Executor, res
 	}
 
 	for i, row := range res.Rows {
-		id, ok := row[0].(*types.UUID)
+		id, ok := row[0].([]byte)
 		if !ok {
 			return nil, fmt.Errorf("internal bug: invalid type for id (%T)", row[0])
 		}
-		ids[i] = id
+		if len(id) != 16 {
+			// this should never happen, just for safety
+			return nil, fmt.Errorf("internal bug: invalid length for id. required 16 bytes, got %d", len(id))
+		}
+
+		uuid := types.UUID(slices.Clone(id))
+		ids[i] = &uuid
 	}
 
 	return ids, nil
@@ -351,7 +354,7 @@ func DeleteResolutions(ctx context.Context, db sql.Executor, ids ...*types.UUID)
 	if len(ids) == 0 {
 		return nil
 	}
-	_, err := db.Execute(ctx, deleteResolutions, ids)
+	_, err := db.Execute(ctx, deleteResolutions, types.UUIDArray(ids).Bytes())
 	return err
 }
 
@@ -360,13 +363,13 @@ func MarkProcessed(ctx context.Context, db sql.Executor, ids ...*types.UUID) err
 	if len(ids) == 0 {
 		return nil
 	}
-	_, err := db.Execute(ctx, markManyProcessed, ids)
+	_, err := db.Execute(ctx, markManyProcessed, types.UUIDArray(ids).Bytes())
 	return err
 }
 
 // IsProcessed checks if a vote has been marked as processed.
 func IsProcessed(ctx context.Context, tx sql.Executor, resolutionID *types.UUID) (bool, error) {
-	res, err := tx.Execute(ctx, alreadyProcessed, resolutionID)
+	res, err := tx.Execute(ctx, alreadyProcessed, resolutionID[:])
 	if err != nil {
 		return false, err
 	}
@@ -381,7 +384,7 @@ func FilterNotProcessed(ctx context.Context, db sql.Executor, ids []*types.UUID)
 		return nil, nil
 	}
 
-	res, err := db.Execute(ctx, returnProcessed, ids)
+	res, err := db.Execute(ctx, returnProcessed, types.UUIDArray(ids).Bytes())
 	if err != nil {
 		return nil, err
 	}
@@ -392,8 +395,8 @@ func FilterNotProcessed(ctx context.Context, db sql.Executor, ids []*types.UUID)
 			// this should never happen, just for safety
 			return nil, fmt.Errorf("invalid number of columns returned. this is an internal bug")
 		}
-		idBts := row[0].(*types.UUID)
-		processed[*idBts] = true
+		idBts := slices.Clone(row[0].([]byte))
+		processed[types.UUID(idBts)] = true
 	}
 
 	var notProcessed []*types.UUID
@@ -410,7 +413,7 @@ func FilterNotProcessed(ctx context.Context, db sql.Executor, ids []*types.UUID)
 func GetValidatorPower(ctx context.Context, db sql.Executor, identifier []byte) (power int64, err error) {
 	uuid := types.NewUUIDV5(identifier)
 
-	res, err := db.Execute(ctx, getVoterPower, uuid)
+	res, err := db.Execute(ctx, getVoterPower, uuid[:])
 	if err != nil {
 		return 0, err
 	}
@@ -485,11 +488,11 @@ func SetValidatorPower(ctx context.Context, db sql.Executor, recipient []byte, p
 	uuid := types.NewUUIDV5(recipient)
 
 	if power == 0 {
-		_, err := db.Execute(ctx, removeVoter, uuid)
+		_, err := db.Execute(ctx, removeVoter, uuid[:])
 		return err
 	}
 
-	_, err := db.Execute(ctx, upsertVoter, uuid, recipient, power)
+	_, err := db.Execute(ctx, upsertVoter, uuid[:], recipient, power)
 	return err
 }
 

--- a/internal/voting/voting.go
+++ b/internal/voting/voting.go
@@ -28,6 +28,7 @@ func initializeVoteStore(ctx context.Context, db sql.TxMaker) error {
 		0: initVotingTables,
 		1: dropHeight,
 		2: dropExtraVoteIDColumn,
+		3: dropUniqueNameConstraints,
 	}
 
 	err := versioning.Upgrade(ctx, db, votingSchemaName, upgradeFns, voteStoreVersion)
@@ -80,6 +81,15 @@ func dropHeight(ctx context.Context, db sql.DB) error {
 
 func dropExtraVoteIDColumn(ctx context.Context, db sql.DB) error {
 	_, err := db.Execute(ctx, dropExtraVoteID)
+	return err
+}
+
+func dropUniqueNameConstraints(ctx context.Context, db sql.DB) error {
+	if _, err := db.Execute(ctx, removeResolutionTypesUniqueNameConstraint); err != nil {
+		return err
+	}
+
+	_, err := db.Execute(ctx, removeVotersUniqueNameConstraint)
 	return err
 }
 


### PR DESCRIPTION
The below crash is because the Voters and the resolution_types tables have id as a primary key and unique constraint on the name field. Whenever inserts are done on these tables, we have the "On conflict (id) do nothing" clause, but as id is derivate from name, even though the conflict on the id is ignored, duplicate inserts still violates the unique constraint checks on the name fields in these 2 tables. 

2 ways to fix the issue:
- Either remove the unique constraint on the name field as the constraint is already applied on its derivate (id) -> this is what done in the PR
- Or specify a joint constraint using id and name and use this joint constraint check during inserts. 

I audited all other tables to ensure that we don't have any such discrepencies.

```sh
panic while building kwild: failed to build event store: ERROR: duplicate key value violates unique constraint "resolution_types_name_key" (SQLSTATE 23505)

stack:

goroutine 1 [running]:
github.com/kwilteam/kwil-db/cmd/kwild/server.New.func1()
        /home/ubuntu/kwil/git/kwil-db/cmd/kwild/server/server.go:76 +0x24d
panic({0x171d480?, 0xc000600c80?})
        /home/ubuntu/go122/src/runtime/panic.go:770 +0x132
github.com/kwilteam/kwil-db/cmd/kwild/server.failBuild(...)
        /home/ubuntu/kwil/git/kwil-db/cmd/kwild/server/build.go:908
github.com/kwilteam/kwil-db/cmd/kwild/server.buildEventStore(0xc0000a8300, 0xc0006000a0)
        /home/ubuntu/kwil/git/kwil-db/cmd/kwild/server/build.go:394 +0x1a5
github.com/kwilteam/kwil-db/cmd/kwild/server.buildServer(0xc0000a8300, 0xc0006000a0)
        /home/ubuntu/kwil/git/kwil-db/cmd/kwild/server/build.go:178 +0x85
github.com/kwilteam/kwil-db/cmd/kwild/server.New({0x1b915e8, 0xc000100460}, 0xc0001f6b70, 0xc000169c00, 0xc00011bd10, 0x0)
        /home/ubuntu/kwil/git/kwil-db/cmd/kwild/server/server.go:115 +0xa09
github.com/kwilteam/kwil-db/cmd/kwild/root.RootCmd.func1(0xc0002d1508, {0xc0001f9980?, 0x7?, 0x1839c98?})
        /home/ubuntu/kwil/git/kwil-db/cmd/kwild/root/root.go:78 +0x43f
github.com/spf13/cobra.(*Command).execute(0xc0002d1508, {0xc000112640, 0x2, 0x2})
        /data/gopath/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:983 +0xaca
github.com/spf13/cobra.(*Command).ExecuteC(0xc0002d1508)
        /data/gopath/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1115 +0x3ff
github.com/spf13/cobra.(*Command).Execute(0x0?)
        /data/gopath/pkg/mod/github.com/spf13/cobra@v1.8.0/command.go:1039 +0x13
main.main()
        /home/ubuntu/kwil/git/kwil-db/cmd/kwild/main.go:11 +0x18
```