### PR TITLE
added tests for decimal

### DIFF
--- a/core/types/schema.go
+++ b/core/types/schema.go
@@ -1237,6 +1237,10 @@ func (c *DataType) Equals(other *DataType) bool {
 }
 
 func (c *DataType) IsNumeric() bool {
+	if c.IsArray {
+		return false
+	}
+
 	return c.Name == intStr || c.Name == DecimalStr || c.Name == uint256Str || c.Name == unknownStr
 }
 

--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -584,12 +584,19 @@ func (p *preparedProcedure) shapeReturn(result *sql.ResultSet) error {
 			// if it is an array, we need to convert each value in the array
 			if col.Type.IsArray {
 				for _, row := range result.Rows {
+					if row[i] == nil {
+						continue
+					}
+
 					arr, ok := row[i].([]any)
 					if !ok {
 						return fmt.Errorf("shapeReturn: expected decimal array, got %T", row[i])
 					}
 
 					for _, v := range arr {
+						if v == nil {
+							continue
+						}
 						dec, ok := v.(*decimal.Decimal)
 						if !ok {
 							return fmt.Errorf("shapeReturn: expected decimal, got %T", dec)
@@ -602,6 +609,10 @@ func (p *preparedProcedure) shapeReturn(result *sql.ResultSet) error {
 				}
 			} else {
 				for _, row := range result.Rows {
+					if row[i] == nil {
+						continue
+					}
+
 					dec, ok := row[i].(*decimal.Decimal)
 					if !ok {
 						return fmt.Errorf("shapeReturn: expected decimal, got %T", row[i])

--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -577,6 +577,43 @@ func (p *preparedProcedure) shapeReturn(result *sql.ResultSet) error {
 
 	for i, col := range p.returns.Fields {
 		result.Columns[i] = col.Name
+
+		// if the column is a decimal or a decimal array, we need to convert the values to
+		// the specified scale and precision
+		if col.Type.Name == types.DecimalStr {
+			// if it is an array, we need to convert each value in the array
+			if col.Type.IsArray {
+				for _, row := range result.Rows {
+					arr, ok := row[i].([]any)
+					if !ok {
+						return fmt.Errorf("shapeReturn: expected decimal array, got %T", row[i])
+					}
+
+					for _, v := range arr {
+						dec, ok := v.(*decimal.Decimal)
+						if !ok {
+							return fmt.Errorf("shapeReturn: expected decimal, got %T", dec)
+						}
+						err := dec.SetPrecisionAndScale(col.Type.Metadata[0], col.Type.Metadata[1])
+						if err != nil {
+							return err
+						}
+					}
+				}
+			} else {
+				for _, row := range result.Rows {
+					dec, ok := row[i].(*decimal.Decimal)
+					if !ok {
+						return fmt.Errorf("shapeReturn: expected decimal, got %T", row[i])
+					}
+
+					err := dec.SetPrecisionAndScale(col.Type.Metadata[0], col.Type.Metadata[1])
+					if err != nil {
+						return err
+					}
+				}
+			}
+		}
 	}
 
 	return nil

--- a/internal/engine/execution/queries.go
+++ b/internal/engine/execution/queries.go
@@ -318,7 +318,6 @@ func deleteSchema(ctx context.Context, tx sql.TxMaker, dbid string) error {
 }
 
 // setContextualVars sets the contextual variables for the given postgres session.
-// TODO: use this function for actions too.
 func setContextualVars(ctx context.Context, db sql.DB, data *common.ExecutionData) error {
 	// for contextual parameters, we use postgres's current_setting()
 	// feature for setting session variables. For example, @caller

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -1,4 +1,4 @@
-// go:build pglive
+//go:build pglive
 
 package integration_test
 

--- a/parse/functions.go
+++ b/parse/functions.go
@@ -573,6 +573,12 @@ var (
 					return nil, fmt.Errorf("expected argument to be numeric, got %s", args[0].String())
 				}
 
+				// we check if it is an unknown type before the switch,
+				// as unknown will be true for all EqualsStrict checks
+				if args[0] == types.UnknownType {
+					return types.UnknownType, nil
+				}
+
 				var retType *types.DataType
 				switch {
 				case args[0].EqualsStrict(types.IntType):
@@ -582,8 +588,6 @@ var (
 					retType.Metadata[0] = 1000 // max precision
 				case args[0].EqualsStrict(types.Uint256Type):
 					retType = decimal1000.Copy()
-				case args[0].EqualsStrict(types.UnknownType):
-					retType = types.UnknownType.Copy()
 				default:
 					panic(fmt.Sprintf("unexpected numeric type: %s", retType.String()))
 				}

--- a/parse/functions.go
+++ b/parse/functions.go
@@ -563,15 +563,32 @@ var (
 		},
 		"sum": {
 			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
+				// per https://www.postgresql.org/docs/current/datatype-numeric.html#DATATYPE-NUMERIC-TABLE
+				// the result of sum will be made a decimal(1000, 0)
 				if len(args) != 1 {
 					return nil, wrapErrArgumentNumber(1, len(args))
 				}
 
-				if !args[0].EqualsStrict(types.IntType) {
-					return nil, wrapErrArgumentType(types.IntType, args[0])
+				if !args[0].IsNumeric() {
+					return nil, fmt.Errorf("expected argument to be numeric, got %s", args[0].String())
 				}
 
-				return types.IntType, nil
+				var retType *types.DataType
+				switch {
+				case args[0].EqualsStrict(types.IntType):
+					retType = decimal1000.Copy()
+				case args[0].Name == types.DecimalStr:
+					retType = args[0].Copy()
+					retType.Metadata[0] = 1000 // max precision
+				case args[0].EqualsStrict(types.Uint256Type):
+					retType = decimal1000.Copy()
+				case args[0].EqualsStrict(types.UnknownType):
+					retType = types.UnknownType.Copy()
+				default:
+					panic(fmt.Sprintf("unexpected numeric type: %s", retType.String()))
+				}
+
+				return retType, nil
 			},
 			IsAggregate: true,
 			PGFormat: func(inputs []string, distinct bool, star bool) (string, error) {
@@ -650,6 +667,17 @@ func defaultFormat(name string) FormatFunc {
 		}
 
 		return fmt.Sprintf("%s(%s)", name, strings.Join(inputs, ", ")), nil
+	}
+}
+
+// decimal1000 is a decimal type with a precision of 1000.
+var decimal1000 *types.DataType
+
+func init() {
+	var err error
+	decimal1000, err = types.NewDecimalType(1000, 0)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create decimal type: 1000, 0: %v", err))
 	}
 }
 

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1638,6 +1638,16 @@ func Test_Procedure(t *testing.T) {
 				},
 			},
 		},
+		{
+			// this is a regression test for a previous bug
+			name: "adding arrays",
+			proc: `
+			$arr1 := [1,2,3];
+			$arr2 := [4,5,6];
+			$arr3 := $arr1 + $arr2;
+			`,
+			err: parse.ErrType,
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1566,6 +1566,78 @@ func Test_Procedure(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "sum types - failure",
+			proc: `
+			$sum := 0;
+			for $row in select sum(id) as id from users {
+				$sum := $sum + $row.id;
+			}
+			`,
+			// this should error, since sum returns numeric
+			err: parse.ErrType,
+		},
+		{
+			name: "sum types - success",
+			proc: `
+			$sum decimal(1000,0);
+			for $row in select sum(id) as id from users {
+				$sum := $sum + $row.id;
+			}
+			`,
+			want: &parse.ProcedureParseResult{
+				Variables: map[string]*types.DataType{
+					"$sum": mustNewDecimal(1000, 0),
+				},
+				CompoundVariables: map[string]struct{}{
+					"$row": {},
+				},
+				AST: []parse.ProcedureStmt{
+					&parse.ProcedureStmtDeclaration{
+						Variable: exprVar("$sum"),
+						Type:     mustNewDecimal(1000, 0),
+					},
+					&parse.ProcedureStmtForLoop{
+						Receiver: exprVar("$row"),
+						LoopTerm: &parse.LoopTermSQL{
+							Statement: &parse.SQLStatement{
+								SQL: &parse.SelectStatement{
+									SelectCores: []*parse.SelectCore{
+										{
+											Columns: []parse.ResultColumn{
+												&parse.ResultColumnExpression{
+													Expression: &parse.ExpressionFunctionCall{
+														Name: "sum",
+														Args: []parse.Expression{
+															exprColumn("", "id"),
+														},
+													},
+													Alias: "id",
+												},
+											},
+											From: &parse.RelationTable{
+												Table: "users",
+											},
+										},
+									},
+									// If there is an aggregate clause with no group by, then no ordering is applied.
+								},
+							},
+						},
+						Body: []parse.ProcedureStmt{
+							&parse.ProcedureStmtAssign{
+								Variable: exprVar("$sum"),
+								Value: &parse.ExpressionArithmetic{
+									Left:     exprVar("$sum"),
+									Operator: parse.ArithmeticOperatorAdd,
+									Right:    &parse.ExpressionFieldAccess{Record: exprVar("$row"), Field: "id"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -1642,6 +1714,14 @@ func exprVar(n string) *parse.ExpressionVariable {
 		Name:   n[1:],
 		Prefix: pref,
 	}
+}
+
+func mustNewDecimal(precision, scale uint16) *types.DataType {
+	dt, err := types.NewDecimalType(precision, scale)
+	if err != nil {
+		panic(err)
+	}
+	return dt
 }
 
 // exprLit makes an ExpressionLiteral.


### PR DESCRIPTION
This adds more tests for decimal and properly handles return types from `sum`, fixing a bug noted by Truflation https://github.com/truflation/tsn/pull/295.

It also fixes a variety of other small bugs, such as failure to catch runtime errors for calculations done on numeric array types, and not enforcing precision and scale on final results returned to the client.