### PR TITLE
pg,kwild: smoother handling of repl conn hangups, determinism guarantees 

### DIFF
--- a/cmd/kwild/main.go
+++ b/cmd/kwild/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	"github.com/kwilteam/kwil-db/cmd/kwild/root"
@@ -9,8 +8,7 @@ import (
 
 func main() {
 	if err := root.RootCmd().Execute(); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		os.Exit(1) // cobra nicely prints the error already
 	}
 	os.Exit(0)
 }

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -38,11 +38,13 @@ func RootCmd() *cobra.Command {
 		DisableAutoGenTag: true,
 		Args:              cobra.NoArgs, // just flags
 		Version:           version.KwilVersion,
-		RunE: func(cmd *cobra.Command, args []string) error {
+		SilenceUsage:      true, // not all errors imply cli misuse
+		RunE: func(cmd *cobra.Command, _ []string) error {
 			fmt.Printf("kwild version %v (Go version %s)\n", version.KwilVersion, runtime.Version())
 
 			kwildCfg, configFileExists, err := config.GetCfg(flagCfg, autoGen)
 			if err != nil {
+				cmd.Usage()
 				return err
 			}
 
@@ -62,6 +64,7 @@ func RootCmd() *cobra.Command {
 
 			stopProfiler, err := startProfilers(kwildCfg)
 			if err != nil {
+				cmd.Usage()
 				return err
 			}
 			defer stopProfiler()
@@ -78,7 +81,7 @@ func RootCmd() *cobra.Command {
 			svr, err := server.New(ctx, kwildCfg, genesisConfig, nodeKey, autoGen)
 			if err != nil {
 				if errors.Is(err, context.Canceled) {
-					return nil // clean shutdown
+					return nil // early but clean shutdown
 				}
 				return err
 			}

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -247,6 +247,7 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 		log:                *d.log.Named("server"),
 		closers:            closers,
 		cfg:                d.cfg,
+		dbCtx:              db,
 	}
 }
 

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -218,7 +218,6 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 // docs, "ResponseFinalizeBlock.app_hash is included as the Header.AppHash in
 // the next block."
 func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinalizeBlock) (*abciTypes.ResponseFinalizeBlock, error) {
-	fmt.Printf("\n\n")
 	logger := a.log.With(zap.String("stage", "ABCI FinalizeBlock"), zap.Int64("height", req.Height))
 
 	res := &abciTypes.ResponseFinalizeBlock{}

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -42,8 +42,10 @@ var demotedInfoMsgs = map[string]string{
 // cometbft/p2p.(*Switch) are the most egregious, but most of cometbft uses
 // error logging quite liberally, probably because they have no Warn.
 var demotedErrMsgs = map[string]string{
-	"Stopping peer for error":   "p2p",
-	"error while stopping peer": "p2p",
+	"Stopping peer for error":                        "p2p",
+	"error while stopping peer":                      "p2p",
+	"Error stopping pool":                            "blocksync", // this almost always happens on shutdown
+	"Stopped accept routine, as transport is closed": "p2p",
 }
 
 // LogWrapper that implements cometbft's Logger interface.

--- a/internal/sql/pg/conn.go
+++ b/internal/sql/pg/conn.go
@@ -84,8 +84,9 @@ type Pool struct {
 type PoolConfig struct {
 	ConnConfig
 
-	// MaxConns is the maximum number of allowable connections, including the
-	// one write connection. Thus there will be MaxConns-1 readers.
+	// MaxConns is the maximum number of allowable connections in the read pool.
+	// This does not include the reserved connections for the consensus thread,
+	// one of which is a writer.
 	MaxConns uint32
 }
 
@@ -177,6 +178,9 @@ func registerTypes(ctx context.Context, conn *pgx.Conn) error {
 	if err != nil {
 		return err
 	}
+
+	// PostgreSQL "domains" will use codec of the underlying type, but the
+	// dynamic OID of the custom domain needs to be registered with pgx.
 
 	pt, err := conn.LoadType(ctx, "uint256")
 	if err != nil {

--- a/internal/sql/pg/system.go
+++ b/internal/sql/pg/system.go
@@ -67,7 +67,20 @@ func pgVersion(ctx context.Context, conn *pgx.Conn) (ver string, verNum uint32, 
 
 type settingValidFn func(val string) error
 
-func wantMinIntFn(wantMin int64) settingValidFn {
+func wantIntFn(want int64) settingValidFn { //nolint:unused
+	return func(val string) error {
+		num, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return err
+		}
+		if num != want {
+			return fmt.Errorf("require %d, but setting is %d", want, num)
+		}
+		return nil
+	}
+}
+
+func wantMinIntFn(wantMin int64) settingValidFn { //nolint:unused
 	return func(val string) error {
 		num, err := strconv.ParseInt(val, 10, 64)
 		if err != nil {
@@ -80,7 +93,20 @@ func wantMinIntFn(wantMin int64) settingValidFn {
 	}
 }
 
-func wantStringFn(want string) settingValidFn {
+func wantMaxIntFn(wantMax int64) settingValidFn { //nolint:unused
+	return func(val string) error {
+		num, err := strconv.ParseInt(val, 10, 64)
+		if err != nil {
+			return err
+		}
+		if num > wantMax {
+			return fmt.Errorf("require at most %d, but setting is %d", wantMax, num)
+		}
+		return nil
+	}
+}
+
+func wantStringFn(want string) settingValidFn { //nolint:unused
 	want = strings.TrimSpace(want)
 	if want == "" {
 		panic("empty want string is invalid")
@@ -93,15 +119,52 @@ func wantStringFn(want string) settingValidFn {
 	}
 }
 
-func wantOnFn(on bool) settingValidFn {
+func wantOnFn(on bool) settingValidFn { //nolint:unused
 	if on {
 		return wantStringFn("on")
 	}
 	return wantStringFn("off")
 }
 
+// orValidFn creates a settings validation function that passes if *any* of the
+// conditions pass. This is useful for instance if there are two acceptable
+// string values, or if an integer value of either exactly 0 or >50 are
+// acceptable as no single min/max condition captures that criteria.
+func orValidFn(fns ...settingValidFn) settingValidFn { //nolint:unused
+	return func(val string) error {
+		var err error
+		for i, fn := range fns {
+			erri := fn(val)
+			if erri == nil {
+				return nil
+			}
+			err = errors.Join(err, fmt.Errorf("condition % 2d: %w", i, erri))
+		}
+		return errors.Join(errors.New("no condition is satisfied"), err)
+	}
+}
+
+// andValidFn creates a settings validation function that passes only if *all*
+// of the conditions pass. This can be used to define a range, or enumerate a
+// list of unacceptable values.
+func andValidFn(fns ...settingValidFn) settingValidFn { //nolint:unused
+	return func(val string) error {
+		var err error
+		for _, fn := range fns {
+			erri := fn(val)
+			if erri != nil {
+				return errors.Join(err, erri)
+			}
+		}
+		return nil
+	}
+}
+
 var settingValidations = map[string]settingValidFn{
-	"wal_level": wantStringFn("logical"),
+	"synchronous_commit": wantOnFn(true),
+	"fsync":              wantOnFn(true),
+	"max_connections":    wantMinIntFn(50),
+	"wal_level":          wantStringFn("logical"),
 
 	// There is one instance of the DB type that requires the a replication
 	// slot to precommit: the one used by TxApp for processing blockchain
@@ -110,10 +173,29 @@ var settingValidations = map[string]settingValidFn{
 	"max_wal_senders":           wantMinIntFn(10),
 	"max_replication_slots":     wantMinIntFn(10),
 	"max_prepared_transactions": wantMinIntFn(2),
+	"wal_sender_timeout":        orValidFn(wantIntFn(0), wantMinIntFn(3_600_000)), // ms units, 0 for no limit or 1 hr min
 
-	"synchronous_commit": wantOnFn(true),
-	"fsync":              wantOnFn(true),
-	"max_connections":    wantMinIntFn(50),
+	// We shouldn't have idle abandoned transactions, but we need to investigate
+	// the effect of allowing this kind of clean up.
+	"idle_in_transaction_timeout": wantIntFn(0), // disable disable idle transaction timeout for now
+
+	// Behavior related settings that must be set properly for determinism
+	// https://www.postgresql.org/docs/16/runtime-config-compatible.html
+	// The following are the documented defaults, which we enforce.
+	"array_nulls":                 wantOnFn(true),                // recognize NULL in array parser, false is for pre-8.2 compat
+	"standard_conforming_strings": wantOnFn(true),                // backslashes (\) in string literals are treated literally -- only escape syntax (E'...') is still usable if needed
+	"transform_null_equals":       wantOnFn(false),               // do not treat "expr=NULL" as "expr IS NULL"
+	"backslash_quote":             wantStringFn("safe_encoding"), // reject escaped single quotes like \', require standard ''
+	"lo_compat_privileges":        wantOnFn(false),               // access-controlled large object storage
+
+	// server_encoding is a read-only setting that allows postgres to report the
+	// character encoding of the connected database. The default for new
+	// databases is set by `initdb` when creating the cluster:
+	//   The database cluster will be initialized with locale "en_US.utf8".
+	//   The default database encoding has accordingly been set to "UTF8".
+	// Or it can be set for a new data base like
+	//   CREATE DATABASE ... WITH ENCODING 'UTF8'
+	"server_encoding": wantStringFn("UTF8"),
 }
 
 func verifySettings(ctx context.Context, conn *pgx.Conn) error {


### PR DESCRIPTION
This addresses some UX issues around the DB connections.  When a connection dies unexpectedly (e.g. postgresql shutdown or connection broken), `kwild` would previously not find out until something on the consensus thread tried to use the connection.  It now breaks cleanly and immediately.  This makes it much more clear what failed and when.

Related to the cryptic errors seen with DB connection issues is a key timeout setting, `wal_sender_timeout`, that should be disabled.  Our `kwildb/postgres:16.2-1` image disable it, but the 16.1 image did not, and a system install does not by default.  `kwild` now checks to ensure that it is disabled.

Several other `postgres` settings that could affect determinism are also verified.  These are already the default settings for the most part.  We are now just verifying that they are set as expected to ensure determinism of execution.

Also, `kwild` was double printing errors, and needlessly showing CLI usage info for application errors that were unrelated to CLI flag/config/etc.  This is resolved.

Finally, some very silly error messages from cometbft that we typically see on shutdown are now demoted to warnings so we don't have a distracting stack dump printed.

