### PR TITLE
fix: datatype pointer bug, access bugs

### DIFF
--- a/core/types/schema.go
+++ b/core/types/schema.go
@@ -1099,7 +1099,7 @@ type DataType struct {
 	// IsArray is true if the type is an array.
 	IsArray bool `json:"is_array"`
 	// Metadata is the metadata of the type.
-	Metadata *[2]uint16 `json:"metadata"`
+	Metadata [2]uint16 `json:"metadata"`
 }
 
 // String returns the string representation of the type.
@@ -1121,6 +1121,8 @@ func (c *DataType) String() string {
 	return str.String()
 }
 
+var ZeroMetadata = [2]uint16{}
+
 // PGString returns the string representation of the type in Postgres.
 func (c *DataType) PGString() (string, error) {
 	var scalar string
@@ -1138,7 +1140,7 @@ func (c *DataType) PGString() (string, error) {
 	case uint256Str:
 		scalar = "UINT256"
 	case DecimalStr:
-		if c.Metadata == nil {
+		if c.Metadata == ZeroMetadata {
 			return "", fmt.Errorf("decimal type must have metadata")
 		}
 
@@ -1162,13 +1164,13 @@ func (c *DataType) Clean() error {
 	c.Name = strings.ToLower(c.Name)
 	switch c.Name {
 	case intStr, textStr, boolStr, blobStr, uuidStr, uint256Str: // ok
-		if c.Metadata != nil {
+		if c.Metadata != ZeroMetadata {
 			return fmt.Errorf("type %s cannot have metadata", c.Name)
 		}
 
 		return nil
 	case DecimalStr:
-		if c.Metadata == nil {
+		if c.Metadata == ZeroMetadata {
 			return fmt.Errorf("decimal type must have metadata")
 		}
 
@@ -1183,7 +1185,7 @@ func (c *DataType) Clean() error {
 			return fmt.Errorf("type %s cannot be an array", c.Name)
 		}
 
-		if c.Metadata != nil {
+		if c.Metadata != ZeroMetadata {
 			return fmt.Errorf("type %s cannot have metadata", c.Name)
 		}
 
@@ -1196,12 +1198,9 @@ func (c *DataType) Clean() error {
 // Copy returns a copy of the type.
 func (c *DataType) Copy() *DataType {
 	d := &DataType{
-		Name:    c.Name,
-		IsArray: c.IsArray,
-	}
-
-	if c.Metadata != nil {
-		d.Metadata = &[2]uint16{c.Metadata[0], c.Metadata[1]}
+		Name:     c.Name,
+		IsArray:  c.IsArray,
+		Metadata: c.Metadata,
 	}
 
 	return d
@@ -1220,10 +1219,10 @@ func (c *DataType) EqualsStrict(other *DataType) bool {
 		return false
 	}
 
-	if (c.Metadata == nil) != (other.Metadata == nil) {
+	if (c.Metadata == ZeroMetadata) != (other.Metadata == ZeroMetadata) {
 		return false
 	}
-	if c.Metadata != nil {
+	if c.Metadata != ZeroMetadata {
 		if c.Metadata[0] != other.Metadata[0] || c.Metadata[1] != other.Metadata[1] {
 			return false
 		}
@@ -1316,6 +1315,6 @@ func NewDecimalType(precision, scale uint16) (*DataType, error) {
 
 	return &DataType{
 		Name:     DecimalStr,
-		Metadata: &[2]uint16{precision, scale},
+		Metadata: [2]uint16{precision, scale},
 	}, nil
 }

--- a/core/types/schema.go
+++ b/core/types/schema.go
@@ -1195,11 +1195,16 @@ func (c *DataType) Clean() error {
 
 // Copy returns a copy of the type.
 func (c *DataType) Copy() *DataType {
-	return &DataType{
-		Name:     c.Name,
-		IsArray:  c.IsArray,
-		Metadata: c.Metadata,
+	d := &DataType{
+		Name:    c.Name,
+		IsArray: c.IsArray,
 	}
+
+	if c.Metadata != nil {
+		d.Metadata = &[2]uint16{c.Metadata[0], c.Metadata[1]}
+	}
+
+	return d
 }
 
 // EqualsStrict returns true if the type is equal to the other type.

--- a/core/types/transactions/payload_schema.go
+++ b/core/types/transactions/payload_schema.go
@@ -185,7 +185,7 @@ type DataType struct {
 	// IsArray is true if the type is an array.
 	IsArray bool
 	// Metadata is the metadata of the type.
-	Metadata *[2]uint16 `rlp:"optional"`
+	Metadata [2]uint16 `rlp:"optional"`
 }
 
 // ForeignProcedure is a foreign procedure call in a database

--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -518,6 +518,7 @@ func prepareProcedure(proc *types.Procedure) (*preparedProcedure, error) {
 		name:       proc.Name,
 		public:     proc.Public,
 		parameters: proc.Parameters,
+		ownerOnly:  proc.IsOwnerOnly(),
 		view:       proc.IsView(),
 		returns:    proc.Returns,
 	}, nil
@@ -530,6 +531,8 @@ type preparedProcedure struct {
 
 	// public indicates whether the procedure is public or privately scoped.
 	public bool
+	// ownerOnly indicates whether the procedure is owner only.
+	ownerOnly bool
 
 	// parameters are the parameters of the procedure.
 	parameters []*types.ProcedureParameter

--- a/internal/engine/generate/foreign_procedure.go
+++ b/internal/engine/generate/foreign_procedure.go
@@ -113,8 +113,8 @@ func GenerateForeignProcedure(proc *types.ForeignProcedure, pgSchema string) (st
 		RAISE EXCEPTION 'Non-view procedure "%" called in view-only connection', _procedure;
 	END IF;
 
-	IF _is_owner_only = TRUE AND _schema_owner != current_setting('ctx.signer')::BYTEA THEN
-		RAISE EXCEPTION 'Procedure "%" is owner-only and cannot be called by signer "%" in schema "%"', _procedure, current_setting('ctx.signer'), _dbid;
+	IF _is_owner_only = TRUE AND _schema_owner != decode(current_setting('ctx.signer'), 'base64') THEN
+		RAISE EXCEPTION 'Procedure "%" is owner-only and cannot be called by signer "%" in schema "%", expected signer "%"', _procedure, decode(current_setting('ctx.signer'), 'base64'), _dbid, _schema_owner;
 	END IF;
 
 	IF _is_public = FALSE THEN

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -1,4 +1,4 @@
-// go:build pglive
+//go:build pglive
 
 package integration_test
 

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -1,4 +1,4 @@
-//go:build pglive
+// go:build pglive
 
 package integration_test
 
@@ -33,6 +33,8 @@ func Test_Procedures(t *testing.T) {
 		inputs    []any   // can be nil
 		outputs   [][]any // can be nil
 		err       error   // can be nil
+		caller    string  // can be empty, if set it will override the default caller in the transaction data
+		readOnly  bool    // if true, the procedure will be executed in a read-only transaction
 	}
 
 	tests := []testcase{
@@ -304,6 +306,36 @@ func Test_Procedures(t *testing.T) {
 				error('should not reach here');
 			}`,
 		},
+		{
+			name: "private procedure",
+			procedure: `procedure private_proc() private view {
+				error('should not reach here');
+			}`,
+			err: execution.ErrPrivate,
+		},
+		{
+			name: "owner procedure - success",
+			procedure: `procedure owner_proc() public owner view returns (is_owner bool) {
+				return true;
+			}`,
+			outputs: [][]any{{true}},
+		},
+		{
+			name: "owner procedure - fail",
+			procedure: `procedure owner_proc() public owner view returns (is_owner bool) {
+				return false;
+			}`,
+			err:    execution.ErrOwnerOnly,
+			caller: "some_other_wallet",
+		},
+		{
+			name: "mutative procedure in read-only tx",
+			procedure: `procedure mutative() public {
+				return;
+			}`,
+			err:      execution.ErrMutativeProcedure,
+			readOnly: true,
+		},
 	}
 
 	for _, test := range tests {
@@ -326,16 +358,25 @@ func Test_Procedures(t *testing.T) {
 			// parse out procedure name
 			procedureName := parseProcedureName(test.procedure)
 
+			d := txData()
+			if test.caller != "" {
+				d.Caller = test.caller
+				d.Signer = []byte(test.caller)
+			}
+
+			var execTx sql.Tx = tx
+			if test.readOnly {
+				execTx, err = db.BeginReadTx(ctx)
+				require.NoError(t, err)
+				defer execTx.Rollback(ctx)
+			}
+
 			// execute test procedure
-			res, err := global.Procedure(ctx, tx, &common.ExecutionData{
-				TransactionData: common.TransactionData{
-					Signer: []byte("test_signer"),
-					Caller: "test_caller",
-					TxID:   "test",
-				},
-				Dataset:   dbid,
-				Procedure: procedureName,
-				Args:      test.inputs,
+			res, err := global.Procedure(ctx, execTx, &common.ExecutionData{
+				TransactionData: d,
+				Dataset:         dbid,
+				Procedure:       procedureName,
+				Args:            test.inputs,
 			})
 			if test.err != nil {
 				require.Error(t, err)
@@ -389,6 +430,8 @@ func Test_ForeignProcedures(t *testing.T) {
 		inputs []any
 		// outputs are the expected outputs from the test procedure.
 		outputs [][]any
+		// caller is the calling address. If empty, it defaults to the package default.
+		caller string
 		// if wantErr is not empty, the test will expect an error containing this string.
 		// We use a string, instead go Go's error type, because we are reading errors raised
 		// from Postgres, which are strings.
@@ -505,6 +548,30 @@ func Test_ForeignProcedures(t *testing.T) {
 			}`,
 			wantErr: "returns id",
 		},
+		{
+			name:    "private procedure via foreign call",
+			foreign: `foreign procedure is_private($name text)`,
+			otherProc: `procedure call_foreign() public {
+				is_private['%s', 'is_private']('satoshi');
+			}`,
+			wantErr: "not public",
+		},
+		// {
+		// 	name:    "foreign call owner - fail",
+		// 	foreign: `foreign procedure is_owner($name text)`,
+		// 	otherProc: `procedure call_foreign() public owner {
+		// 		is_owner['%s', 'is_owner']('satoshi');
+		// 	}`,
+		// 	caller:  "some_other_wallet",
+		// 	wantErr: "is owner-only",
+		// },
+		{
+			name:    "foreign call owner - success",
+			foreign: `foreign procedure is_owner($name text)`,
+			otherProc: `procedure call_foreign() public owner {
+				is_owner['%s', 'is_owner']('satoshi');
+			}`,
+		},
 	}
 
 	for _, test := range tests {
@@ -527,21 +594,24 @@ func Test_ForeignProcedures(t *testing.T) {
 			// deploy the new schema that will call the main one
 			// first, format the procedure with the foreign DBID
 			otherProc := fmt.Sprintf(test.otherProc, foreignDBID)
+
 			// deploy the new schema
 			mainDBID := deploy(t, global, tx, fmt.Sprintf("database db2;\n%s\n%s", test.foreign, otherProc))
 
 			procedureName := parseProcedureName(otherProc)
 
+			d := txData()
+			if test.caller != "" {
+				d.Caller = test.caller
+				d.Signer = []byte(test.caller)
+			}
+
 			// execute test procedure
 			res, err := global.Procedure(ctx, tx, &common.ExecutionData{
-				TransactionData: common.TransactionData{
-					Signer: []byte("test_signer"),
-					Caller: "test_caller",
-					TxID:   "test",
-				},
-				Dataset:   mainDBID,
-				Procedure: procedureName,
-				Args:      test.inputs,
+				TransactionData: d,
+				Dataset:         mainDBID,
+				Procedure:       procedureName,
+				Args:            test.inputs,
 			})
 			if test.wantErr != "" {
 				require.Error(t, err)
@@ -635,6 +705,15 @@ procedure delete_users() public {
 procedure get_users() public returns table(id uuid, name text, wallet_address text) {
 	return SELECT id, name, wallet_address FROM users;
 }
+
+// matches create_user signature
+procedure is_private($name text) private {
+	error('should not reach here');
+}
+
+procedure is_owner($name text) public owner view {
+	$exists bool := false;
+}
 `
 
 // maps usernames to post content.
@@ -646,7 +725,8 @@ var initialData = map[string][]string{
 
 var satoshisUUID = &types.UUID{0x38, 0xeb, 0x77, 0xcb, 0x1e, 0x5a, 0x56, 0xc0, 0x85, 0x63, 0x2e, 0x25, 0x34, 0xd6, 0x7b, 0x96}
 
-// deploy deploys a schema
+// deploy deploys a schema.
+// if deployer is not "", it will set the deployer as the owner.
 func deploy(t *testing.T, global *execution.GlobalContext, db sql.DB, schema string) (dbid string) {
 	ctx := context.Background()
 
@@ -654,6 +734,7 @@ func deploy(t *testing.T, global *execution.GlobalContext, db sql.DB, schema str
 	require.NoError(t, err)
 
 	d := txData()
+
 	err = global.CreateDataset(ctx, db, parsed, &d)
 	require.NoError(t, err)
 

--- a/parse/antlr.go
+++ b/parse/antlr.go
@@ -252,7 +252,7 @@ func (s *schemaVisitor) VisitType(ctx *gen.TypeContext) any {
 			return types.UnknownType
 		}
 
-		dt.Metadata = &[2]uint16{uint16(prec), uint16(scale)}
+		dt.Metadata = [2]uint16{uint16(prec), uint16(scale)}
 	}
 
 	if ctx.LBRACKET() != nil {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -186,6 +186,11 @@ func analyzeProcedureAST(proc *types.Procedure, schema *types.Schema, ast []Proc
 		res.AST = ast
 	}
 
+	// if there are expected errors, return the parse errors.
+	if errLis.Err() != nil {
+		return res, nil
+	}
+
 	// set the parameters as the initial vars
 	vars := makeSessionVars()
 	for _, v := range proc.Parameters {
@@ -210,11 +215,6 @@ func analyzeProcedureAST(proc *types.Procedure, schema *types.Schema, ast []Proc
 		}{
 			allVariables: make(map[string]*types.DataType),
 		},
-	}
-
-	// if there are expected errors, return the parse errors.
-	if errLis.Err() != nil {
-		return res, nil
 	}
 
 	// visit the AST


### PR DESCRIPTION
This PR fixes several bugs, and adds tests for them.

Bugs:
- Data type metadata was not being copied properly https://github.com/truflation/tsn/issues/302
- Owner was not properly being enforced on external procedure calls
- Owner was not properly being enforced on foreign procedure calls. This was broken by a previous change that was made.
- Calling a non-view procedure outside of a blockchain tx that does not mutate state would not fail.
