### PR TITLE
Stop creating empty snapshots in the  error scenarioes.

### DIFF
--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -167,7 +167,7 @@ hostname = "{{ .AppCfg.Hostname }}"
 
 # Path to the snapshot file to restore the database from.
 # Used during the network migration process.
-snapshot_file = "{{ .AppCfg.SnapshotFile }}"
+genesis_state = "{{ .AppCfg.GenesisState }}"
 
 #######################################################################
 ###                     Extension Configuration                     ###

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -90,10 +90,10 @@ type AppConfig struct {
 
 	Snapshots SnapshotConfig `mapstructure:"snapshots"`
 
-	// SnapshotFile is the path to the snapshot file to load on startup
-	// during network initialization. If genesis app_hash is not provided,
-	// this snapshot file is not used.
-	SnapshotFile string `mapstructure:"snapshot_file"`
+	// GenesisState is the path to the snapshot file containing genesis state
+	// to be loaded on startup during network initialization. If genesis app_hash
+	// is not provided, this snapshot file is not used.
+	GenesisState string `mapstructure:"genesis_state"`
 }
 
 type SnapshotConfig struct {
@@ -570,7 +570,7 @@ func DefaultConfig() *KwildConfig {
 				MaxSnapshots:    3,
 				SnapshotDir:     SnapshotDirName,
 			},
-			SnapshotFile: "",
+			GenesisState: "",
 		},
 		Logging: &Logging{
 			Level:        "info",
@@ -706,13 +706,13 @@ func (cfg *KwildConfig) sanitizeCfgPaths() error {
 		fmt.Println("State sync received snapshots directory:", cfg.ChainCfg.StateSync.SnapshotDir)
 	}
 
-	if cfg.AppCfg.SnapshotFile != "" {
-		path, err := ExpandPath(cfg.AppCfg.SnapshotFile)
+	if cfg.AppCfg.GenesisState != "" {
+		path, err := ExpandPath(cfg.AppCfg.GenesisState)
 		if err != nil {
-			return fmt.Errorf("failed to expand snapshot file path \"%v\": %v", cfg.AppCfg.SnapshotFile, err)
+			return fmt.Errorf("failed to expand snapshot file path \"%v\": %v", cfg.AppCfg.GenesisState, err)
 		}
-		cfg.AppCfg.SnapshotFile = path
-		fmt.Println("Snapshot file to initialize database from:", cfg.AppCfg.SnapshotFile)
+		cfg.AppCfg.GenesisState = path
+		fmt.Println("Snapshot file to initialize database from:", cfg.AppCfg.GenesisState)
 	}
 	return nil
 }

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -185,7 +185,7 @@ type StateSyncConfig struct {
 	SnapshotDir string `mapstructure:"snapshot_dir"`
 
 	// Trusted snapshot servers to fetch/validate the snapshots from.
-	// Atleast 2 servers are required for the state sync to work.
+	// At least 1 server is required for the state sync to work.
 	RPCServers string `mapstructure:"rpc_servers"`
 
 	// Time to spend discovering snapshots before initiating starting
@@ -707,7 +707,11 @@ func (cfg *KwildConfig) sanitizeCfgPaths() error {
 	}
 
 	if cfg.AppCfg.SnapshotFile != "" {
-		cfg.AppCfg.SnapshotFile = rootify(cfg.AppCfg.SnapshotFile, rootDir)
+		path, err := ExpandPath(cfg.AppCfg.SnapshotFile)
+		if err != nil {
+			return fmt.Errorf("failed to expand snapshot file path \"%v\": %v", cfg.AppCfg.SnapshotFile, err)
+		}
+		cfg.AppCfg.SnapshotFile = path
 		fmt.Println("Snapshot file to initialize database from:", cfg.AppCfg.SnapshotFile)
 	}
 	return nil

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -450,19 +450,19 @@ func restoreDB(d *coreDependencies) {
 	// Ensure that the snapshot file exists and the snapshot hash matches the genesis apphash.
 
 	// Ensure that the snapshot file exists, if node is supposed to start with a snapshot state
-	if genCfg.DataAppHash != nil && appCfg.SnapshotFile == "" {
+	if genCfg.DataAppHash != nil && appCfg.GenesisState == "" {
 		failBuild(nil, "snapshot file not provided")
 	}
 
 	// Snapshot file exists
-	snapFile, err := os.Open(appCfg.SnapshotFile)
+	snapFile, err := os.Open(appCfg.GenesisState)
 	if err != nil {
 		failBuild(err, "failed to open snapshot file")
 	}
 
 	// Check if the snapshot file is compressed, if yes decompress it
 	var reader io.Reader
-	if strings.HasSuffix(appCfg.SnapshotFile, ".gz") {
+	if strings.HasSuffix(appCfg.GenesisState, ".gz") {
 		// Decompress the snapshot file
 		gzipReader, err := gzip.NewReader(snapFile)
 		if err != nil {

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -33,6 +33,7 @@ var demotedInfoMsgs = map[string]string{
 	"executed block":                   "",
 	"Starting localClient service":     "proxy",
 	"Timed out":                        "consensus", // only the one from consensus.(*timeoutTicker).timeoutRoutine, which seems to be normal
+	"Could not check tx":               "mempool",
 }
 
 // demotedErrMsgs contain error-level messages that should not be logged as


### PR DESCRIPTION
PR includes the below fixes:
- Fix issues related to path of snapshot-file
- `kwil-admin snapshot create` used to create a snapshot file(empty) even in the error scenarios. It's misleading, removed that behavior in this PR