### PR TITLE
fix: decimal bug from  exponent greater than precision

### DIFF
--- a/core/types/decimal/decimal.go
+++ b/core/types/decimal/decimal.go
@@ -20,12 +20,15 @@ var (
 	// We can change this to have different precision/speed properties,
 	// but for now have it set to favor precision.
 	context = apd.Context{
-		Precision:   1000,
+		Precision:   uint32(maxPrecision),
 		MaxExponent: 2000,
 		MinExponent: -2000,
 		Traps:       apd.DefaultTraps,
 		Rounding:    apd.RoundHalfUp,
 	}
+
+	// maxPrecision is the maximum supported precision.
+	maxPrecision = uint16(1000)
 )
 
 // Decimal is a decimal number. It has a set precision and scale that
@@ -197,7 +200,7 @@ func mathOp(x, y *Decimal, op func(z, x, y *apd.Decimal) (apd.Condition, error))
 	dec := &Decimal{
 		dec:       *z,
 		scale:     uint16(-z.Exponent),
-		precision: 1000,
+		precision: maxPrecision,
 	}
 
 	return dec, nil
@@ -305,7 +308,7 @@ func (d *Decimal) Neg() error {
 
 // Round rounds the decimal to the specified scale.
 func (d *Decimal) Round(scale uint16) error {
-	if scale > 1000 {
+	if scale > maxPrecision {
 		return fmt.Errorf("scale too large: %d", scale)
 	}
 
@@ -430,7 +433,7 @@ func CheckPrecisionAndScale(precision, scale uint16) error {
 		return fmt.Errorf("precision must be at least 1: %d", precision)
 	}
 
-	if precision > 1000 {
+	if precision > maxPrecision {
 		return fmt.Errorf("precision too large: %d", precision)
 	}
 

--- a/core/types/decimal/decimal.go
+++ b/core/types/decimal/decimal.go
@@ -80,6 +80,14 @@ func NewFromBigInt(i *big.Int, exp int32) (*Decimal, error) {
 		precision: uint16(len(strings.TrimLeft(i.String(), "-+"))),
 	}
 
+	// It is possible for scale to be greater than precision here, if for example
+	// we were given the number .0001, which would be big int 1 and exponent -4.
+	// To account for this, if the scale is greater than the precision, we set the
+	// precision to the scale.
+	if dec.scale > dec.precision {
+		dec.precision = dec.scale
+	}
+
 	if err := CheckPrecisionAndScale(dec.precision, dec.scale); err != nil {
 		return nil, err
 	}

--- a/core/types/decimal/decimal_test.go
+++ b/core/types/decimal/decimal_test.go
@@ -92,6 +92,20 @@ func Test_NewParsedDecimal(t *testing.T) {
 			scale:   6,
 			want:    "0.000123",
 		},
+		{
+			name:    "scale exceeds precision",
+			decimal: "123.456",
+			prec:    6,
+			scale:   7,
+			err:     true,
+		},
+		{
+			name:    "precision too large",
+			decimal: "123.456",
+			prec:    1001,
+			scale:   3,
+			err:     true,
+		},
 	}
 
 	// test cases for decimal creation

--- a/core/types/decimal/decimal_test.go
+++ b/core/types/decimal/decimal_test.go
@@ -85,6 +85,13 @@ func Test_NewParsedDecimal(t *testing.T) {
 			scale:   1,
 			want:    "123.4",
 		},
+		{
+			name:    "<1",
+			decimal: "0.000123",
+			prec:    6,
+			scale:   6,
+			want:    "0.000123",
+		},
 	}
 
 	// test cases for decimal creation
@@ -514,10 +521,12 @@ func Test_BigAndExp(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "exp too low",
-			big:     "123",
-			exp:     -4,
-			wantErr: true,
+			name:     "exp less than precision properly adjusts precision",
+			big:      "123",
+			exp:      -4,
+			out:      "0.0123",
+			outPrec:  4,
+			outScale: 4,
 		},
 	}
 


### PR DESCRIPTION
I spotted a bug that occurs when we create a new decimal type where the exponent is greater than the precision. This causes issues when reading values from Postgres of type `decimal` where the value is greater than -1 and less than 1.
