### PR TITLE
fix parse bugs

### DIFF
--- a/cmd/kwil-cli/cmds/utils/parse.go
+++ b/cmd/kwil-cli/cmds/utils/parse.go
@@ -128,8 +128,7 @@ func (d *debugDisplay) MarshalJSON() ([]byte, error) {
 }
 
 func (d *debugDisplay) MarshalText() (text []byte, err error) {
-	type res debugDisplay // prevent recursion
-	return json.MarshalIndent((*res)(d), "", "  ")
+	return json.MarshalIndent(d, "", "  ")
 }
 
 // generateAll attempts to generate all ddl statements, sql, and plpgsql functions.

--- a/internal/engine/integration/sql_test.go
+++ b/internal/engine/integration/sql_test.go
@@ -183,6 +183,13 @@ func Test_SQL(t *testing.T) {
 				{"zeus"},
 			},
 		},
+		{
+			name: "select constant",
+			sql:  "select 1",
+			want: [][]any{
+				{int64(1)},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/sql/pg/query.go
+++ b/internal/sql/pg/query.go
@@ -337,6 +337,26 @@ func decodeFromPGType(vals ...any) ([]any, error) {
 		switch v := v.(type) {
 		default:
 			return v, nil
+
+		// we need to handle all ints as int64 since Kwil treats all
+		// ints as int64, but an integer literal in postgres can get
+		// returned as an int32
+		case int:
+			return int64(v), nil
+		case int8:
+			return int64(v), nil
+		case int16:
+			return int64(v), nil
+		case int32:
+			return int64(v), nil
+		case int64:
+			return v, nil
+		case uint:
+			return int64(v), nil
+		case uint16:
+			return int64(v), nil
+		case uint32:
+			return int64(v), nil
 		case pgtype.UUID:
 			u := types.UUID(v.Bytes)
 			return &u, nil

--- a/parse/actions.go
+++ b/parse/actions.go
@@ -29,9 +29,11 @@ func (a *actionAnalyzer) VisitActionStmtSQL(p0 *ActionStmtSQL) any {
 }
 
 func (a *actionAnalyzer) VisitActionStmtExtensionCall(p0 *ActionStmtExtensionCall) any {
+	a.sqlCtx.isInlineAction = true
 	for _, arg := range p0.Args {
 		arg.Accept(&a.sqlAnalyzer)
 	}
+	a.sqlCtx.isInlineAction = false
 
 	_, ok := a.schema.FindExtensionImport(p0.Extension)
 	if !ok {
@@ -47,9 +49,11 @@ func (a *actionAnalyzer) VisitActionStmtExtensionCall(p0 *ActionStmtExtensionCal
 }
 
 func (a *actionAnalyzer) VisitActionStmtActionCall(p0 *ActionStmtActionCall) any {
+	a.sqlCtx.isInlineAction = true
 	for _, arg := range p0.Args {
 		arg.Accept(&a.sqlAnalyzer)
 	}
+	a.sqlCtx.isInlineAction = false
 
 	act, ok := a.schema.FindAction(p0.Action)
 	if !ok {

--- a/parse/antlr.go
+++ b/parse/antlr.go
@@ -454,6 +454,11 @@ func (s *schemaVisitor) VisitTable_declaration(ctx *gen.Table_declarationContext
 		t.ForeignKeys[i] = fk.Accept(s).(*types.ForeignKey)
 	}
 
+	_, err := t.GetPrimaryKey()
+	if err != nil {
+		s.errs.RuleErr(ctx, ErrNoPrimaryKey, err.Error())
+	}
+
 	return t
 }
 

--- a/parse/errors.go
+++ b/parse/errors.go
@@ -24,9 +24,9 @@ type ParseError struct {
 // MarshalJSON marshals the error to JSON.
 func (p *ParseError) MarshalJSON() ([]byte, error) {
 	type Alias struct {
-		ParserName string    `json:"parser_name,omitempty"`
-		Message    string    `json:"message,omitempty"`
-		Position   *Position `json:"position,omitempty"`
+		ParserName string    `json:"parser_name"`
+		Message    string    `json:"message"`
+		Position   *Position `json:"position"`
 	}
 
 	a := &Alias{
@@ -36,10 +36,10 @@ func (p *ParseError) MarshalJSON() ([]byte, error) {
 	}
 
 	return json.Marshal(struct {
-		Error *error `json:"error,omitempty"`
+		Error string `json:"error"`
 		*Alias
 	}{
-		Error: &p.Err,
+		Error: p.Err.Error(),
 		Alias: a,
 	})
 }
@@ -219,4 +219,5 @@ var (
 	ErrInvalidExcludedTable      = errors.New("invalid excluded table usage")
 	ErrAmbiguousConflictTable    = errors.New("ambiguous conflict table")
 	ErrCollation                 = errors.New("collation error")
+	ErrNoPrimaryKey              = errors.New("missing primary key")
 )

--- a/parse/functions.go
+++ b/parse/functions.go
@@ -33,7 +33,9 @@ var (
 					return nil, wrapErrArgumentType(types.TextType, args[0])
 				}
 
-				return nil, nil
+				// technically error returns nothing, but for backwards compatibility with SELECT CASE we return null.
+				// It doesn't really matter, since error will cancel execution anyways.
+				return types.NullType, nil
 			},
 			PGFormat: defaultFormat("error"),
 		},

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -360,6 +360,10 @@ func analyzeActionAST(action *types.Action, schema *types.Schema, ast []ActionSt
 		res.AST = ast
 	}
 
+	if errLis.Err() != nil {
+		return res, nil
+	}
+
 	vars := makeSessionVars()
 	for _, v := range action.Parameters {
 		vars[v] = types.UnknownType
@@ -376,10 +380,6 @@ func analyzeActionAST(action *types.Action, schema *types.Schema, ast []ActionSt
 			sqlCtx: newSQLContext(),
 		},
 		schema: schema,
-	}
-
-	if errLis.Err() != nil {
-		return res, nil
 	}
 
 	for _, stmt := range res.AST {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -778,7 +778,7 @@ func Test_Kuneiform(t *testing.T) {
 			checkAfterErr: true,
 		},
 		{
-			// similar to the aboive test, the same edge case existed for foreign procedures
+			// similar to the above test, the same edge case existed for foreign procedures
 			name: "incomplete foreign procedure",
 			kf: `database a;
 			foreign proce`,
@@ -790,6 +790,37 @@ func Test_Kuneiform(t *testing.T) {
 			},
 			err:           parse.ErrSyntax,
 			checkAfterErr: true,
+		},
+		{
+			// this test tests for properly handling errors for missing primary keys
+			name: "missing primary key",
+			kf: `
+			database mydb;
+
+			table users {
+				id int not null
+			}
+			`,
+			want: &types.Schema{
+				Name: "mydb",
+				Tables: []*types.Table{
+					{
+						Name: "users",
+						Columns: []*types.Column{
+							{
+								Name: "id",
+								Type: types.IntType,
+								Attributes: []*types.Attribute{
+									{
+										Type: types.NOT_NULL,
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+			err: parse.ErrNoPrimaryKey,
 		},
 	}
 

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -2689,6 +2689,15 @@ func Test_Actions(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "action in-line statement calls select",
+			action: &types.Action{
+				Name:       "check_balance",
+				Parameters: []string{"$arg"},
+				Body:       "$res = my_ext.my_method($arg[0]);",
+			},
+			err: parse.ErrAssignment,
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -822,6 +822,26 @@ func Test_Kuneiform(t *testing.T) {
 			},
 			err: parse.ErrNoPrimaryKey,
 		},
+		{
+			name: "empty body",
+			kf: `
+			database mydb;
+
+			procedure get_users() public view {}
+			`,
+			want: &types.Schema{
+				Name: "mydb",
+				Procedures: []*types.Procedure{
+					{
+						Name:   "get_users",
+						Public: true,
+						Modifiers: []types.Modifier{
+							types.ModifierView,
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse/types.go
+++ b/parse/types.go
@@ -11,10 +11,10 @@ type Position struct {
 	// Set is true if the position of the Position has been set.
 	// This is useful for testing parsers.
 	IsSet     bool `json:"-"`
-	StartLine int  `json:"start_line,omitempty"`
-	StartCol  int  `json:"start_col,omitempty"`
-	EndLine   int  `json:"end_line,omitempty"`
-	EndCol    int  `json:"end_col,omitempty"`
+	StartLine int  `json:"start_line"`
+	StartCol  int  `json:"start_col"`
+	EndLine   int  `json:"end_line"`
+	EndCol    int  `json:"end_col"`
 }
 
 // Set sets the position of the Position based on the given parser rule context.


### PR DESCRIPTION
This fixes 3 parse errors that @KwilLuke found. Probably good for this to get backported, however it's not critical, as this simply fixes issues with errors output to the CLI and IDE.

The bugs are:
1. Parse error positions were being omitted if they occurred at the 0 line/column position. This was due to an `omitempty` tag that is no longer used anyways
2. Parse error types were not being included in the marshalled result.
3. Tables lacking primary keys were correctly identified as having errors, but the errors were not thrown in the parser, creating different error handling than other errors.

EDIT:

Also includes fixes for:
- `error` function not working in `SELECT CASE`
- The engine returning int literals as int32 instead of int64 (which all ints in kwil are assumed to be int64)