### PR TITLE
added genesis-state and extension flags

### DIFF
--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -47,6 +47,8 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *KwildConfig) {
 	flagSet.Uint64Var(&cfg.AppCfg.Snapshots.MaxSnapshots, "app.snapshots.max-snapshots", cfg.AppCfg.Snapshots.MaxSnapshots, "Maximum snapshots to store on disk. Default is 3. If max snapshots is reached, the oldest snapshot is deleted.")
 	flagSet.StringVar(&cfg.AppCfg.Snapshots.SnapshotDir, "app.snapshots.snapshot-dir", cfg.AppCfg.Snapshots.SnapshotDir, "Snapshot directory path")
 
+	flagSet.StringVar(&cfg.AppCfg.GenesisState, "app.genesis-state", cfg.AppCfg.GenesisState, "Path to the genesis state file")
+
 	// Basic Chain Config flags
 	flagSet.StringVar(&cfg.ChainCfg.Moniker, "chain.moniker", cfg.ChainCfg.Moniker, "Node moniker")
 

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -48,7 +48,7 @@ func RootCmd() *cobra.Command {
 			fmt.Printf("kwild version %v (Go version %s)\n", version.KwilVersion, runtime.Version())
 
 			// args can be passed to kwild in the form of extension flags.
-			// These are delimited using a double dash, e.g. `kwild -- --extension1.flag1=value1 --extension2.flag2=value2`
+			// These are delimited using a double dash, e.g. `kwild -- --extension.extension1.flag1=value1 --extension.extension2.flag2=value2`
 			// This is in-line with guideline 10 of the POSIX guidelines: https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02
 			extensionConfig, err := parseExtensionFlags(args)
 			if err != nil {
@@ -131,13 +131,13 @@ func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 		}
 		// split the flag into the extension name and the flag name
 		// we intentionally do not use SplitN because we want to verify
-		// there are exactly 2 parts.
+		// there are exactly 3 parts.
 		parts := strings.Split(args[i], ".")
-		if len(parts) != 2 {
+		if len(parts) != 3 {
 			return nil, fmt.Errorf("invalid extension flag %q", args[i])
 		}
 
-		extName := strings.TrimPrefix(parts[0], "--")
+		extName := strings.TrimPrefix(parts[1], "--")
 
 		// get the extension map for the extension name.
 		// if it doesn't exist, create it.
@@ -150,9 +150,9 @@ func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 		// we now need to get the flag value. Flags can be passed
 		// as either "--extension.extname.flagname value" or
 		// "--extension.extname.flagname=value"
-		if strings.Contains(parts[1], "=") {
+		if strings.Contains(parts[2], "=") {
 			// flag value is in the same argument
-			val := strings.SplitN(parts[1], "=", 2)
+			val := strings.SplitN(parts[2], "=", 2)
 			ext[val[0]] = val[1]
 		} else {
 			// flag value is in the next argument
@@ -164,7 +164,7 @@ func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 				return nil, fmt.Errorf("missing value for extension flag %q", args[i])
 			}
 
-			ext[parts[1]] = args[i+1]
+			ext[parts[2]] = args[i+1]
 			i++
 		}
 	}

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -137,7 +137,7 @@ func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 			return nil, fmt.Errorf("invalid extension flag %q", args[i])
 		}
 
-		extName := strings.TrimPrefix(parts[1], "--")
+		extName := strings.TrimPrefix(parts[1], "--extension.")
 
 		// get the extension map for the extension name.
 		// if it doesn't exist, create it.

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -60,7 +60,8 @@ func RootCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:               "kwild",
 		Short:             "kwild node and rpc server",
-		Long:              "kwild: the Kwil blockchain node and RPC server",
+		Long:              long,
+		Example:           example,
 		DisableAutoGenTag: true,
 		Version:           version.KwilVersion,
 		SilenceUsage:      true, // not all errors imply cli misuse

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -146,7 +146,7 @@ func RootCmd() *cobra.Command {
 func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 	exts := make(map[string]map[string]string)
 	for i := 0; i < len(args); i++ {
-		if !strings.HasPrefix(args[i], "--extensions.") {
+		if !strings.HasPrefix(args[i], "--extension.") {
 			return nil, fmt.Errorf("expected extension flag, got %q", args[i])
 		}
 		// split the flag into the extension name and the flag name

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -32,6 +32,26 @@ import (
 	"github.com/spf13/viper"
 )
 
+var long = `kwild is the Kwil blockchain node and RPC server.
+
+kwild is a full-node implementation of the Kwil protocol. It provides the
+ability to fully participate in the Kwil network, and can run as either a
+validator or a non-validating node.
+
+Extensions can be configured by passing flags delimited by a double dash, e.g.
+"kwild --autogen -- --extension.extension1.flag1 value1 --extension.extension2.flag2 value2"
+This follows the POSIX guidelines for additional operands.
+`
+
+var example = `# Start kwild and auto-generate a private key, genesis file, and config file
+kwild --autogen
+
+# Start kwild from a root directory with a config file
+kwild --root-dir /path/to/root
+
+# Start kwild with extensions
+kwild -- --extension.extension1.flag1=value1 --extension.extension2.flag2=value2`
+
 func RootCmd() *cobra.Command {
 	// we use an empty config because this config gets merged later, and should only contain flag values
 	flagCfg := config.EmptyConfig()
@@ -126,7 +146,7 @@ func RootCmd() *cobra.Command {
 func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 	exts := make(map[string]map[string]string)
 	for i := 0; i < len(args); i++ {
-		if !strings.HasPrefix(args[i], "--") {
+		if !strings.HasPrefix(args[i], "--extensions.") {
 			return nil, fmt.Errorf("expected extension flag, got %q", args[i])
 		}
 		// split the flag into the extension name and the flag name
@@ -137,7 +157,7 @@ func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 			return nil, fmt.Errorf("invalid extension flag %q", args[i])
 		}
 
-		extName := strings.TrimPrefix(parts[1], "--extension.")
+		extName := parts[1]
 
 		// get the extension map for the extension name.
 		// if it doesn't exist, create it.

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -126,31 +126,33 @@ func RootCmd() *cobra.Command {
 func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 	exts := make(map[string]map[string]string)
 	for i := 0; i < len(args); i++ {
-		if !strings.HasPrefix(args[i], "--extension.") {
+		if !strings.HasPrefix(args[i], "--") {
 			return nil, fmt.Errorf("expected extension flag, got %q", args[i])
 		}
 		// split the flag into the extension name and the flag name
 		// we intentionally do not use SplitN because we want to verify
-		// there are exactly 3 parts.
+		// there are exactly 2 parts.
 		parts := strings.Split(args[i], ".")
-		if len(parts) != 3 {
+		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid extension flag %q", args[i])
 		}
 
+		extName := strings.TrimPrefix(parts[0], "--")
+
 		// get the extension map for the extension name.
 		// if it doesn't exist, create it.
-		ext, ok := exts[parts[1]]
+		ext, ok := exts[extName]
 		if !ok {
 			ext = make(map[string]string)
-			exts[parts[1]] = ext
+			exts[extName] = ext
 		}
 
 		// we now need to get the flag value. Flags can be passed
 		// as either "--extension.extname.flagname value" or
 		// "--extension.extname.flagname=value"
-		if strings.Contains(parts[2], "=") {
+		if strings.Contains(parts[1], "=") {
 			// flag value is in the same argument
-			val := strings.SplitN(parts[2], "=", 2)
+			val := strings.SplitN(parts[1], "=", 2)
 			ext[val[0]] = val[1]
 		} else {
 			// flag value is in the next argument
@@ -162,7 +164,7 @@ func parseExtensionFlags(args []string) (map[string]map[string]string, error) {
 				return nil, fmt.Errorf("missing value for extension flag %q", args[i])
 			}
 
-			ext[parts[2]] = args[i+1]
+			ext[parts[1]] = args[i+1]
 			i++
 		}
 	}

--- a/cmd/kwild/root/root_test.go
+++ b/cmd/kwild/root/root_test.go
@@ -22,7 +22,7 @@ func Test_ExtensionFlags(t *testing.T) {
 		},
 		{
 			name:    "single flag",
-			flagset: []string{"--extname.flagname", "value"},
+			flagset: []string{"--extension.extname.flagname", "value"},
 			want: map[string]map[string]string{
 				"extname": {
 					"flagname": "value",
@@ -31,7 +31,7 @@ func Test_ExtensionFlags(t *testing.T) {
 		},
 		{
 			name:    "multiple flags",
-			flagset: []string{"--extname.flagname", "value", "--extname2.flagname2=value2"},
+			flagset: []string{"--extension.extname.flagname", "value", "--extension.extname2.flagname2=value2"},
 			want: map[string]map[string]string{
 				"extname": {
 					"flagname": "value",
@@ -44,14 +44,14 @@ func Test_ExtensionFlags(t *testing.T) {
 		{
 			name: "missing value",
 			flagset: []string{
-				"--extname.flagname",
+				"--extension.extname.flagname",
 			},
 			wantErr: true,
 		},
 		{
 			name: "pass flag as a value errors",
 			flagset: []string{
-				"--extname.flagname", "--extname2.flagname2=value2",
+				"--extension.extname.flagname", "--extension.extname2.flagname2=value2",
 			},
 			wantErr: true,
 		},

--- a/cmd/kwild/root/root_test.go
+++ b/cmd/kwild/root/root_test.go
@@ -22,7 +22,7 @@ func Test_ExtensionFlags(t *testing.T) {
 		},
 		{
 			name:    "single flag",
-			flagset: []string{"--extension.extname.flagname", "value"},
+			flagset: []string{"--extname.flagname", "value"},
 			want: map[string]map[string]string{
 				"extname": {
 					"flagname": "value",
@@ -31,7 +31,7 @@ func Test_ExtensionFlags(t *testing.T) {
 		},
 		{
 			name:    "multiple flags",
-			flagset: []string{"--extension.extname.flagname", "value", "--extension.extname2.flagname2=value2"},
+			flagset: []string{"--extname.flagname", "value", "--extname2.flagname2=value2"},
 			want: map[string]map[string]string{
 				"extname": {
 					"flagname": "value",
@@ -44,14 +44,14 @@ func Test_ExtensionFlags(t *testing.T) {
 		{
 			name: "missing value",
 			flagset: []string{
-				"--extension.extname.flagname",
+				"--extname.flagname",
 			},
 			wantErr: true,
 		},
 		{
 			name: "pass flag as a value errors",
 			flagset: []string{
-				"--extension.extname.flagname", "--extension.extname2.flagname2=value2",
+				"--extname.flagname", "--extname2.flagname2=value2",
 			},
 			wantErr: true,
 		},

--- a/cmd/kwild/root/root_test.go
+++ b/cmd/kwild/root/root_test.go
@@ -1,0 +1,72 @@
+package root
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExtensionFlags(t *testing.T) {
+	type testcase struct {
+		name    string
+		flagset []string
+		want    map[string]map[string]string
+		wantErr bool
+	}
+
+	tests := []testcase{
+		{
+			name:    "empty flagset",
+			flagset: []string{},
+			want:    map[string]map[string]string{},
+		},
+		{
+			name:    "single flag",
+			flagset: []string{"--extension.extname.flagname", "value"},
+			want: map[string]map[string]string{
+				"extname": {
+					"flagname": "value",
+				},
+			},
+		},
+		{
+			name:    "multiple flags",
+			flagset: []string{"--extension.extname.flagname", "value", "--extension.extname2.flagname2=value2"},
+			want: map[string]map[string]string{
+				"extname": {
+					"flagname": "value",
+				},
+				"extname2": {
+					"flagname2": "value2",
+				},
+			},
+		},
+		{
+			name: "missing value",
+			flagset: []string{
+				"--extension.extname.flagname",
+			},
+			wantErr: true,
+		},
+		{
+			name: "pass flag as a value errors",
+			flagset: []string{
+				"--extension.extname.flagname", "--extension.extname2.flagname2=value2",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExtensionFlags(tt.flagset)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			require.EqualValues(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
PR fixes two issues I found regarding kwild flags.

1. `genesis-state` was not configurable via flags
2. extensions were not configurable via flags.

Adding genesis state was very straight forward. Extensions were tricky, because users should be able to specify any arbitrary extension name and key. To achieve this, I used the `--` delimiter from the [POSIX guidelines](<https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap12.html#tag_12_02>) (Guideline 10) to allow users to specify additional flag arguments for `kwild`. It verifies that these are correct flags for extensions:

```
kwild --autogen -- --my_ext.key=value --my_ext.key2 value2
```