### PR TITLE
State sync fixes

### DIFF
--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -100,14 +100,15 @@ hostname = ""
 ###                Snapshot store Config Options                    ###
 #######################################################################
 [app.snapshots]
+
 # Toggle to enable snapshot store
-# This would snapshot the application state at every snapshot_heights blocks
+# This would snapshot the application state at every recurring_height blocks
 # and keep max_snapshots number of snapshots in the snapshot_dir
 # Application state includes the databases deployed, accounts and the Validators db
 enabled = false
 
 # The height at which the snapshot is taken
-snapshot_heights = 100000
+recurring_height = 100000
 
 # Maximum number of snapshots to be kept in the snapshot_dir.
 # If max limit is reached, the oldest would be deleted and replaced by the latest snapshot

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -96,14 +96,15 @@ hostname = ""
 ###                Snapshot store Config Options                    ###
 #######################################################################
 [app.snapshots]
+
 # Toggle to enable snapshot store
-# This would snapshot the application state at every snapshot_heights blocks
+# This would snapshot the application state at every recurring_height blocks
 # and keep max_snapshots number of snapshots in the snapshot_dir
 # Application state includes the databases deployed, accounts and the Validators db
 enabled = false
 
 # The height at which the snapshot is taken
-snapshot_heights = 100000
+recurring_height = 100000
 
 # Maximum number of snapshots to be kept in the snapshot_dir.
 # If max limit is reached, the oldest would be deleted and replaced by the latest snapshot

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -629,7 +629,7 @@ func buildStatesyncer(d *coreDependencies) *statesync.StateSyncer {
 		d.cfg.ChainCfg.StateSync.TrustHeight = res.Header.Height
 		d.cfg.ChainCfg.StateSync.TrustHash = res.Header.Hash().String()
 
-		d.log.Infof("trust height %v, hash %v", d.cfg.ChainCfg.StateSync.TrustHeight, d.cfg.ChainCfg.StateSync.TrustHash)
+		d.log.Infof("Provider %q: trust height %v, hash %v", p, d.cfg.ChainCfg.StateSync.TrustHeight, d.cfg.ChainCfg.StateSync.TrustHash)
 
 		configDone = true
 

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -604,6 +604,7 @@ func (a *AbciApp) ApplySnapshotChunk(ctx context.Context, req *abciTypes.Request
 		if errors.Is(err, statesync.ErrRefetchSnapshotChunk) {
 			refetchChunks = append(refetchChunks, req.Index)
 		}
+		a.log.Errorf("Failed to apply snapshot chunk: %v", err)
 		return &abciTypes.ResponseApplySnapshotChunk{
 			Result:        statesync.ToABCIApplySnapshotChunkResponse(err),
 			RefetchChunks: refetchChunks,

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -175,6 +175,8 @@ func NewCometBftNode(ctx context.Context, app abciTypes.Application, conf *comet
 		return nil, fmt.Errorf("failed to write the effective cometbft config files: %w", err)
 	}
 
+	logger.Debugf("%#v", *conf.StateSync)
+
 	err := conf.ValidateBasic()
 	if err != nil {
 		return nil, fmt.Errorf("invalid node config: %w", err)

--- a/internal/statesync/codes.go
+++ b/internal/statesync/codes.go
@@ -19,38 +19,57 @@ var (
 	ErrAbortSnapshotChunk   = fmt.Errorf("abort snapshot chunk")
 	ErrRetrySnapshotChunk   = fmt.Errorf("retry snapshot chunk")   // retries without refetching the chunk
 	ErrRefetchSnapshotChunk = fmt.Errorf("refetch snapshot chunk") // retries after refetching the chunk
-	ErrRetrySnapshot        = fmt.Errorf("retry snapshot")
 	ErrRejectSnapshotChunk  = fmt.Errorf("reject snapshot chunk")
+	// ErrRetrySnapshot        = fmt.Errorf("retry snapshot") // request full retry of snapshot ==> ResponseApplySnapshotChunk_RETRY_SNAPSHOT
 )
 
 func ToABCIOfferSnapshotResponse(err error) abciTypes.ResponseOfferSnapshot_Result {
-
-	if errors.Is(err, nil) {
+	if err == nil {
 		return abciTypes.ResponseOfferSnapshot_ACCEPT
-	} else if errors.Is(err, ErrAbortSnapshot) {
-		return abciTypes.ResponseOfferSnapshot_ABORT
-	} else if errors.Is(err, ErrRejectSnapshot) {
-		return abciTypes.ResponseOfferSnapshot_REJECT
-	} else if errors.Is(err, ErrUnsupportedSnapshotFormat) {
-		return abciTypes.ResponseOfferSnapshot_REJECT_FORMAT
-	} else {
-		return abciTypes.ResponseOfferSnapshot_UNKNOWN
 	}
+
+	if errors.Is(err, ErrAbortSnapshot) {
+		return abciTypes.ResponseOfferSnapshot_ABORT
+	}
+
+	if errors.Is(err, ErrRejectSnapshot) {
+		return abciTypes.ResponseOfferSnapshot_REJECT
+	}
+
+	if errors.Is(err, ErrUnsupportedSnapshotFormat) {
+		return abciTypes.ResponseOfferSnapshot_REJECT_FORMAT
+	}
+
+	return abciTypes.ResponseOfferSnapshot_UNKNOWN
 }
 
 func ToABCIApplySnapshotChunkResponse(err error) abciTypes.ResponseApplySnapshotChunk_Result {
 
-	if errors.Is(err, nil) {
+	if err == nil {
 		return abciTypes.ResponseApplySnapshotChunk_ACCEPT
-	} else if errors.Is(err, ErrAbortSnapshotChunk) {
-		return abciTypes.ResponseApplySnapshotChunk_ABORT
-	} else if errors.Is(err, ErrRetrySnapshotChunk) {
-		return abciTypes.ResponseApplySnapshotChunk_RETRY
-	} else if errors.Is(err, ErrRefetchSnapshotChunk) {
-		return abciTypes.ResponseApplySnapshotChunk_RETRY
-	} else if errors.Is(err, ErrRejectSnapshotChunk) {
-		return abciTypes.ResponseApplySnapshotChunk_REJECT_SNAPSHOT
-	} else {
-		return abciTypes.ResponseApplySnapshotChunk_UNKNOWN
 	}
+
+	if errors.Is(err, ErrAbortSnapshotChunk) {
+		return abciTypes.ResponseApplySnapshotChunk_ABORT
+	}
+
+	if errors.Is(err, ErrRetrySnapshotChunk) {
+		return abciTypes.ResponseApplySnapshotChunk_RETRY
+	}
+
+	if errors.Is(err, ErrRefetchSnapshotChunk) {
+		return abciTypes.ResponseApplySnapshotChunk_RETRY
+	}
+
+	if errors.Is(err, ErrRejectSnapshotChunk) {
+		return abciTypes.ResponseApplySnapshotChunk_REJECT_SNAPSHOT
+	}
+
+	// if errors.Is(err, ErrRetrySnapshot) {
+	// 	return abciTypes.ResponseApplySnapshotChunk_RETRY_SNAPSHOT
+	// }
+
+	// If the error is unrecognized, fall back to rejecting the snapshot.
+	// Returning UNKNOWN is fatal to cometbft.
+	return abciTypes.ResponseApplySnapshotChunk_REJECT_SNAPSHOT
 }

--- a/internal/statesync/snapshotter.go
+++ b/internal/statesync/snapshotter.go
@@ -19,7 +19,7 @@ import (
 )
 
 const (
-	chunkSize int64 = 16 * 1024 * 1024 // 16MB
+	chunkSize int64 = 16e6 - 4096 // 16 MB
 
 	DefaultSnapshotFormat = 0
 

--- a/internal/statesync/store.go
+++ b/internal/statesync/store.go
@@ -225,7 +225,10 @@ func (s *SnapshotStore) loadSnapshots() error {
 	// Scan the snapshot directory and load all the snapshots
 	files, err := os.ReadDir(s.cfg.SnapshotDir)
 	if err != nil {
-		return nil
+		if os.IsNotExist(err) {
+			return os.MkdirAll(s.cfg.SnapshotDir, 0755)
+		}
+		return err
 	}
 
 	for _, file := range files {


### PR DESCRIPTION
This gets state sync working and fixes some tangential issues.

- add logging around state sync code, particularly with trusted rpc provider and snapshot retrieval and apply
- Fix the default and example config files using `snapshot_heights` instead of `recurring_height`
- Reduce the chunk size limit to < 16,000,000 bytes (previously was set at 16 MiB, not MB, plus lacked overhead space)
- With statesync restore error handling, return `ResponseApplySnapshotChunk_REJECT_SNAPSHOT` to cometbft as a fallback when the error is not typed.  `UNKNOWN` caused cometbft to fail rather than continue with another snapshot candidate.

With this and https://github.com/kwilteam/kwil-db/pull/812 we were able to get longhorn running and state sync on the sync node working.