### PR TITLE
fix error in resolve funcs

### DIFF
--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -631,7 +631,11 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 			if err2 != nil {
 				return fmt.Errorf("error rolling back transaction: %s, error: %s", err.Error(), err2.Error())
 			}
-			return err
+
+			// if the resolveFunc fails, we should still continue on, since it simply means
+			// some business logic failed in a deployed schema.
+			r.log.Error("error resolving resolution", log.String("type", resolveFunc.Resolution.Type), log.String("id", resolveFunc.Resolution.ID.String()), log.Error(err))
+			continue
 		}
 
 		err = tx.Commit(ctx)


### PR DESCRIPTION
While working through the Powerpod integration, I spotted a bug in our resolution code. If a resolution fails, it will halt consensus. This should not be the case, since resolutions are made to target databases, which can have arbitrary user-defined logic.