### PR TITLE
change log level for failed resolutions

### DIFF
--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -634,7 +634,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 
 			// if the resolveFunc fails, we should still continue on, since it simply means
 			// some business logic failed in a deployed schema.
-			r.log.Error("error resolving resolution", log.String("type", resolveFunc.Resolution.Type), log.String("id", resolveFunc.Resolution.ID.String()), log.Error(err))
+			r.log.Warn("error resolving resolution", log.String("type", resolveFunc.Resolution.Type), log.String("id", resolveFunc.Resolution.ID.String()), log.Error(err))
 			continue
 		}
 


### PR DESCRIPTION
The recent change made to log errors from resolutions logs as an error. This prints a full stack trace, which is not desirable. We should use warn instead.

Not critical, but should probably be backported for v0.8.2