### PR TITLE
[WIP] docs: add release notes for v0.8

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,14 +24,13 @@ To check if your schemas are compatible with v0.8, use the `kwil-cli utils parse
 
 - Kuneiform is now handled in kwil-db's `parse` module. Previously, Kuneiform was handled in a separate repository. The `parse` module will be tagged as `parse/v0.2.0` for the v0.8 release of Kwil DB.
 
-#### Breaking Changes:
+#### Breaking Changes
 
 - SQL statements that are valid SQL but have invalid predicates will fail during parse, instead of at runtime.
 - Fixed edge cases where users could perform cartesian joins. Now, one side of a join must be a column of unique values.
 - Fixed a handful of cases that could lead to non-deterministic query results:
-    - Disallowing conflicting column names when returned from a query.
-    - Not returning unnamed columns in query results.
-    - Applying deterministic ordering for joins against subqueries.
+  - Disallowing conflicting column names when returned from a query.
+  - Applying deterministic ordering for joins against subqueries.
 
 ### Network Migrations
 
@@ -48,7 +47,7 @@ To check if your schemas are compatible with v0.8, use the `kwil-cli utils parse
 - The JSON-RPC listen address can be set with `jsonrpc_listen_addr` in the node's `config.toml` file. By default, the JSON-RPC server listens on port 8484.
 - Kwil CLI, GO SDK, and JS SDK have been updated to use the JSON-RPC server.
 
-#### Breaking Changes:
+#### Breaking Changes
 
 - The HTTP server (`http_listen_addr`) is DEPRECATED and will be removed in the susbequent release.
 - The gRPC server (`grpc_listen_addr`) is no longer exposed.
@@ -82,7 +81,8 @@ In the node's `config.toml` file, the following changes have been made:
 
 #### Breaking Changes
 
-- The admin service now listens on `"/tmp/kwild.socket"` by default. Previously, the admin service listened on `"unix:///tmp/kwil_admin.sock"`.
+- The `kwild` admin service now listens on `"/tmp/kwild.socket"` by default. Previously, the admin service listened on `"/tmp/kwil_admin.sock"`.
+- The `rpcserver` setting may be either an IP address (host:port format) or a UNIX socket path. URLs are not accepted, and any scheme such as `"http://"` or `"unix://"` should be omitted. The transport (TCP or UNIX) is inferred by the host format, and the protocol is always JSON-RPC over HTTP.
 
 ### Core Module (Go SDK)
 
@@ -94,7 +94,7 @@ The `core` module is tagged as `core/v0.2.0` for the Kwil DB v0.8 release.
 
 ##### Breaking Changes
 
-- The JSON tags on the `Signature` struct have changed:
+The JSON tags on the `Signature` struct have changed:
 
 ```go
 type Signature struct {
@@ -111,14 +111,15 @@ type Signature struct {
 ##### Breaking Changes
 
 - There are many new types and fields on the `Schema` struct to support procedures and strongly typed values. Changes include:
-    - `Owner` is now `HexBytes` instead of `byte[]`. `HexBytes` is an alias for `byte[]`; however, when marshaled to JSON, it is represented as a hex string.
-    - `Table.Column.Type` now uses the `DataType` struct instead of a `string` to support strongly typed values.
-    - Added the `Procedures` field to the `Schema` struct to support procedures.
-    - Added the `ForeignProcedures` field to the `Schema` struct to support calling procedures that are defined in other schemas.
+  - `Owner` is now `HexBytes` instead of `byte[]`. `HexBytes` is an alias for `byte[]`; however, when marshaled to JSON, it is represented as a hex string.
+  - `Table.Column.Type` now uses the `DataType` struct instead of a `string` to support strongly typed values.
+  - Added the `Procedures` field to the `Schema` struct to support procedures.
+  - Added the `ForeignProcedures` field to the `Schema` struct to support calling procedures that are defined in other schemas.
 
 #### `core/types/transactions`
 
-- **Note**: Most users do not need to be concerned with these changes as the `core/client` and `core/rpc/...` packages handle their use.
+**Note**: Most users do not need to be concerned with these changes as the `core/client` and `core/rpc/...` packages handle their use.
+
 - Added the helper function `UnmarshalPayload` to assist in unmarshaling payloads from `byte[]` give its `PayloadType`.
 - Added new `TxCode` values:
 

--- a/docs/modules.gv
+++ b/docs/modules.gv
@@ -9,18 +9,11 @@ digraph {
 
 	{rank=min core}
 	{rank=max test}
-	{rank=same core}
-
-	// sqlgrammargo [label="sql-grammar-go" fillcolor=lightgray]
-	// actgrammargo [label="action-grammar-go" fillcolor=lightgray]
-	kuneiform [label="kuneiform" fillcolor=lightgray]
+	{rank=same core parse}
 
 	core -> kwildb [dir=back color=black]
+	core -> parse [dir=back color=black]
 	core -> test [dir=back color=black]
 	kwildb -> test [dir=back color=black]
 	parse -> kwildb [dir=back color=black]
-
-	parse -> kuneiform [dir=back color=gray]
-	// sqlgrammargo -> parse [dir=back color=gray]
-	// actgrammargo -> parse [dir=back color=gray]
 }

--- a/docs/modules.svg
+++ b/docs/modules.svg
@@ -13,62 +13,56 @@
 <!-- kwildb -->
 <g id="node1" class="node">
 <title>kwildb</title>
-<path fill="dodgerblue" stroke="black" d="M122.25,-108C122.25,-108 78.25,-108 78.25,-108 72.25,-108 66.25,-102 66.25,-96 66.25,-96 66.25,-84 66.25,-84 66.25,-78 72.25,-72 78.25,-72 78.25,-72 122.25,-72 122.25,-72 128.25,-72 134.25,-78 134.25,-84 134.25,-84 134.25,-96 134.25,-96 134.25,-102 128.25,-108 122.25,-108"/>
-<text text-anchor="middle" x="100.25" y="-86.3" font-family="Times,serif" font-size="14.00">kwil&#45;db</text>
+<path fill="dodgerblue" stroke="black" d="M179,-108C179,-108 135,-108 135,-108 129,-108 123,-102 123,-96 123,-96 123,-84 123,-84 123,-78 129,-72 135,-72 135,-72 179,-72 179,-72 185,-72 191,-78 191,-84 191,-84 191,-96 191,-96 191,-102 185,-108 179,-108"/>
+<text text-anchor="middle" x="157" y="-86.3" font-family="Times,serif" font-size="14.00">kwil&#45;db</text>
 </g>
 <!-- test -->
 <g id="node4" class="node">
 <title>test</title>
-<path fill="lightsalmon" stroke="black" d="M84.25,-36C84.25,-36 54.25,-36 54.25,-36 48.25,-36 42.25,-30 42.25,-24 42.25,-24 42.25,-12 42.25,-12 42.25,-6 48.25,0 54.25,0 54.25,0 84.25,0 84.25,0 90.25,0 96.25,-6 96.25,-12 96.25,-12 96.25,-24 96.25,-24 96.25,-30 90.25,-36 84.25,-36"/>
-<text text-anchor="middle" x="69.25" y="-14.3" font-family="Times,serif" font-size="14.00">test</text>
+<path fill="lightsalmon" stroke="black" d="M141,-36C141,-36 111,-36 111,-36 105,-36 99,-30 99,-24 99,-24 99,-12 99,-12 99,-6 105,0 111,0 111,0 141,0 141,0 147,0 153,-6 153,-12 153,-12 153,-24 153,-24 153,-30 147,-36 141,-36"/>
+<text text-anchor="middle" x="126" y="-14.3" font-family="Times,serif" font-size="14.00">test</text>
 </g>
 <!-- kwildb&#45;&gt;test -->
-<g id="edge3" class="edge">
+<g id="edge4" class="edge">
 <title>kwildb&#45;&gt;test</title>
-<path fill="none" stroke="black" d="M81.25,-61.83C81.25,-61.83 81.25,-36.41 81.25,-36.41"/>
-<polygon fill="black" stroke="black" points="77.75,-61.83 81.25,-71.83 84.75,-61.83 77.75,-61.83"/>
+<path fill="none" stroke="black" d="M138,-61.83C138,-61.83 138,-36.41 138,-36.41"/>
+<polygon fill="black" stroke="black" points="134.5,-61.83 138,-71.83 141.5,-61.83 134.5,-61.83"/>
 </g>
 <!-- core -->
 <g id="node2" class="node">
 <title>core</title>
-<path fill="aquamarine" stroke="black" d="M104.25,-180C104.25,-180 34.25,-180 34.25,-180 28.25,-180 22.25,-174 22.25,-168 22.25,-168 22.25,-156 22.25,-156 22.25,-150 28.25,-144 34.25,-144 34.25,-144 104.25,-144 104.25,-144 110.25,-144 116.25,-150 116.25,-156 116.25,-156 116.25,-168 116.25,-168 116.25,-174 110.25,-180 104.25,-180"/>
-<text text-anchor="middle" x="69.25" y="-158.3" font-family="Times,serif" font-size="14.00">core (SDK)</text>
+<path fill="aquamarine" stroke="black" d="M130,-180C130,-180 60,-180 60,-180 54,-180 48,-174 48,-168 48,-168 48,-156 48,-156 48,-150 54,-144 60,-144 60,-144 130,-144 130,-144 136,-144 142,-150 142,-156 142,-156 142,-168 142,-168 142,-174 136,-180 130,-180"/>
+<text text-anchor="middle" x="95" y="-158.3" font-family="Times,serif" font-size="14.00">core (SDK)</text>
 </g>
 <!-- core&#45;&gt;kwildb -->
 <g id="edge1" class="edge">
 <title>core&#45;&gt;kwildb</title>
-<path fill="none" stroke="black" d="M91.25,-133.83C91.25,-133.83 91.25,-108.41 91.25,-108.41"/>
-<polygon fill="black" stroke="black" points="87.75,-133.83 91.25,-143.83 94.75,-133.83 87.75,-133.83"/>
-</g>
-<!-- core&#45;&gt;test -->
-<g id="edge2" class="edge">
-<title>core&#45;&gt;test</title>
-<path fill="none" stroke="black" d="M54.25,-133.76C54.25,-133.76 54.25,-36.09 54.25,-36.09"/>
-<polygon fill="black" stroke="black" points="50.75,-133.76 54.25,-143.76 57.75,-133.76 50.75,-133.76"/>
+<path fill="none" stroke="black" d="M132.5,-133.83C132.5,-133.83 132.5,-108.41 132.5,-108.41"/>
+<polygon fill="black" stroke="black" points="129,-133.83 132.5,-143.83 136,-133.83 129,-133.83"/>
 </g>
 <!-- parse -->
 <g id="node3" class="node">
 <title>parse</title>
-<path fill="cadetblue" stroke="black" d="M195.25,-180C195.25,-180 163.25,-180 163.25,-180 157.25,-180 151.25,-174 151.25,-168 151.25,-168 151.25,-156 151.25,-156 151.25,-150 157.25,-144 163.25,-144 163.25,-144 195.25,-144 195.25,-144 201.25,-144 207.25,-150 207.25,-156 207.25,-156 207.25,-168 207.25,-168 207.25,-174 201.25,-180 195.25,-180"/>
-<text text-anchor="middle" x="179.25" y="-158.3" font-family="Times,serif" font-size="14.00">parse</text>
+<path fill="cadetblue" stroke="black" d="M204,-180C204,-180 172,-180 172,-180 166,-180 160,-174 160,-168 160,-168 160,-156 160,-156 160,-150 166,-144 172,-144 172,-144 204,-144 204,-144 210,-144 216,-150 216,-156 216,-156 216,-168 216,-168 216,-174 210,-180 204,-180"/>
+<text text-anchor="middle" x="188" y="-158.3" font-family="Times,serif" font-size="14.00">parse</text>
+</g>
+<!-- core&#45;&gt;parse -->
+<g id="edge2" class="edge">
+<title>core&#45;&gt;parse</title>
+<path fill="none" stroke="black" d="M152.04,-162C152.04,-162 159.96,-162 159.96,-162"/>
+<polygon fill="black" stroke="black" points="152.04,-158.5 142.04,-162 152.04,-165.5 152.04,-158.5"/>
+</g>
+<!-- core&#45;&gt;test -->
+<g id="edge3" class="edge">
+<title>core&#45;&gt;test</title>
+<path fill="none" stroke="black" d="M111,-133.76C111,-133.76 111,-36.09 111,-36.09"/>
+<polygon fill="black" stroke="black" points="107.5,-133.76 111,-143.76 114.5,-133.76 107.5,-133.76"/>
 </g>
 <!-- parse&#45;&gt;kwildb -->
-<g id="edge4" class="edge">
-<title>parse&#45;&gt;kwildb</title>
-<path fill="none" stroke="black" d="M140.98,-162C140.98,-162 125.25,-162 125.25,-162 125.25,-162 125.25,-129.5 125.25,-108.17"/>
-<polygon fill="black" stroke="black" points="140.98,-165.5 150.98,-162 140.98,-158.5 140.98,-165.5"/>
-</g>
-<!-- kuneiform -->
-<g id="node5" class="node">
-<title>kuneiform</title>
-<path fill="lightgray" stroke="black" d="M229.75,-108C229.75,-108 164.75,-108 164.75,-108 158.75,-108 152.75,-102 152.75,-96 152.75,-96 152.75,-84 152.75,-84 152.75,-78 158.75,-72 164.75,-72 164.75,-72 229.75,-72 229.75,-72 235.75,-72 241.75,-78 241.75,-84 241.75,-84 241.75,-96 241.75,-96 241.75,-102 235.75,-108 229.75,-108"/>
-<text text-anchor="middle" x="197.25" y="-86.3" font-family="Times,serif" font-size="14.00">kuneiform</text>
-</g>
-<!-- parse&#45;&gt;kuneiform -->
 <g id="edge5" class="edge">
-<title>parse&#45;&gt;kuneiform</title>
-<path fill="none" stroke="gray" d="M180,-133.83C180,-133.83 180,-108.41 180,-108.41"/>
-<polygon fill="gray" stroke="gray" points="176.5,-133.83 180,-143.83 183.5,-133.83 176.5,-133.83"/>
+<title>parse&#45;&gt;kwildb</title>
+<path fill="none" stroke="black" d="M175.5,-133.83C175.5,-133.83 175.5,-108.41 175.5,-108.41"/>
+<polygon fill="black" stroke="black" points="172,-133.83 175.5,-143.83 179,-133.83 172,-133.83"/>
 </g>
 </g>
 </svg>

--- a/docs/release-notes/v0.8.1.md
+++ b/docs/release-notes/v0.8.1.md
@@ -1,0 +1,258 @@
+# Kwil DB v0.8.1
+
+This is a major new release of Kwil DB.
+
+The highlights are:
+
+- An new Kuneiform element (?) called "procedures" that uses a procedural language for building logic into schemas.
+- Added a JSON-RPC server.
+- Network migration support.
+- Enable state sync mode and snapshot creation.
+- Absorb the `kuneiform` and dependent repositories into the `parse` module in the `kwil-db` repository.
+
+Note that v0.8.0 was never publicly released due to issues with the upgrade procedures.
+
+## Important Upgrading Notes
+
+Upgrading to this release requires a network migration. See the
+[network migration documents](https://docs.kwil.com/docs/node/network-migrations) for
+instructions on how to perform a network migration. Only upgrading from v0.7 is supported.
+
+In certain cases, deployed schemas may not be compatible with v0.8. See
+[UPGRADING.md](https://github.com/kwilteam/kwil-db/blob/release-v0.8/UPGRADING.md) for details.
+
+## Notable Changes
+
+### Procedures
+
+In previous releases, SQL queries were specified entirely within Kuneiform
+"actions".  This release introduces the concept of "procedures", which use a
+basic procedural language for building logic into schemas. Procedures can be
+used for building access control logic, performing arithmetic, and managing
+control flow.
+
+Procedures are declared using the `procedure` keyword. A procedure may `return`
+either a single record (a tuple) or a `table`.
+
+A procedure body may contain variable declarations, basic arithmetic operations,
+calls to various built-in functions, control flow (e.g. `if`/`then`/`for`), and
+SQL queries.
+
+See the [procedure docs](https://docs.kwil.com/docs/kuneiform/procedures) for
+more information.
+
+#### Variable Types
+
+Procedures are strongly typed. The parameters, returns, and variables declared
+within a procedure must be assigned a type. The recognized types are:
+
+- `int` is a 64-bit signed integer
+- `text` is a variable length character array (a string)
+- `bool` is a boolean (true or false)
+- `blob` is a byte array
+- `uint256` is a 256-bit unsigned integer
+- `decimal` is a fixed precision type based
+- `uuid` is 128-bit universally unique identifier (UUID)
+
+Arrays of any of the above types are also permitted.
+
+Legacy actions only support `int` and `text` in table declarations, and use no types in their signatures or bodies.
+
+#### Foreign Procedure Calls
+
+It is now possible to interact with procedures in a different database using
+`foreign` procedure declarations.  For instance, to use a procedure called
+`target_procedure` in the database `'x_target_dbid'`, declare a foreign procedure
+in your database and specify the target database and procedure name when calling:
+
+```js
+foreign procedure get_user($id uuid) returns (text, int)
+
+procedure call_get_user($id uuid) public  {
+    $username, $age = get_user['x_target_dbid', 'target_procedure']($id);
+    // $username is a text and $age is an int
+}
+```
+
+### JSON-RPC Server and gRPC Gateway Deprecation
+
+This release of `kwild` adds a [JSON-RPC](https://www.jsonrpc.org/specification)
+server. It listens on TCP port 8484 of all network interfaces by default.
+JSON-RPC requests are handled by the `/rpc/v1` path.
+
+The CLI utilities, the Go SDK client, and the JS SDK now use the JSON-RPC server
+by default. RPC providers should expose TCP port 8484, and client configuration
+should be updated to use port 8484.
+
+The HTTP API, which is a REST gateway for the gRPC server, is now deprecated,
+although it listens on all network interfaces on port 8080 by default. The gRPC
+server, which was previously deprecated, now listens only on a loopback address
+to support the internal HTTP gateway (Swagger). The gRPC and the HTTP gateway
+will be removed in the next release.
+
+The OpenRPC specification document for the "user" RPC service may be found in the
+[source code repository](https://github.com/kwilteam/kwil-db/blob/release-v0.8/internal/services/jsonrpc/usersvc/user.openrpc.json).
+The server itself will also provide the server's active service specification at
+the `/spec/v1` HTTP endpoint and in the response to the `rpc.discover` JSON-RPC
+methods.
+
+The `"params"` value in all requests are *named* rather than *positional*. This
+means that the JSON-RPC 1.0 calling convention with an array `[]` for the
+parameters is not supported, only the JSON-RPC convention using an object `{}`.
+However, this is a detail that the Kwil clients hide from users. Only if doing
+manual HTTP POST requests, such as with `curl` or Postman, is this important.
+
+The "admin" service and the `kwil-admin` tool is also updated to use JSON-RPC.
+
+### SQL Syntax
+
+- Support for more built-in functions. See [Supported Functions](https://docs.kwil.com/docs/kuneiform/functions).
+- Conflicting column names in the returned values from a query are disallowed.
+  For example, this means that it is now an error if a `SELECT *` is used with a
+  `JOIN` between tables with an identical column name.
+- There is now a requirement that at least one side of a `JOIN` must be a
+  table's column. It is an error to have literal or computed values on both sides. (Q: does every joined column need to be just a column, or *all* joined columns. What about joining on a function of a column?)
+
+### Snapshots and State Sync
+
+State sync is a feature that allows a new node to bootstrap directly from a
+snapshot of the blockchain state instead of replaying all the blocks from the
+genesis. This reduces the time needed to sync a new node to a network. However,
+the node will only be aware of transactions after the snapshot height.
+
+`kwild` may now be configured to periodically generate state snapshots, which
+are provided to nodes that are joining the network. The `app.snapshots` config
+section adjust this functionality.
+
+To enable the use of state sync on a new node, trusted snapshot providers must
+be configured. The `chain.statesync` config section adjust this functionality.
+
+State sync is only used for a new node. Catch up after a previously-running node
+has restarted uses the standard "block sync" technique, which fully validates
+and executes all blockchain transactions to rebuild state.
+
+See the [State Sync docs](https://docs.kwil.com/docs/node/statesync) for details.
+
+### Network Migrations
+
+To launch a new network with an initial genesis state, special state snapshots may be generated using the `kwil-admin snapshot create` command.
+
+When launching a network from this genesis state, the `app_hash` field of the
+new genesis.json file will be non-`null`. The initial validator nodes must use
+the `genesis_state` config.toml setting to specify the snapshot that corresponds
+to the `app_hash` value. Once a trusted snapshot provider has generated an
+initial snapshot for the new running network, other nodes may rely on the state
+sync mechanism to join the network without having to manually distribute the
+`genesis_state` file.
+
+See [Network Migration documents](https://docs.kwil.com/docs/node/network-migrations) for details.
+
+### Coordinated Upgrades
+
+This release includes an experimental system for specifying 
+
+
+### Command Line Application Changes
+
+#### User CLI (`kwil-cli`) Changes
+
+##### Moved `kwil-cli` Configuration Folder
+
+The default config folder for `kwil-cli` is now called `kwil-cli` in the user's home directory.  It was previously called `kwil_cli`.
+
+##### New RPC Provider Setting
+
+Within `config.json`, the RPC provider is specified with a `"provider"` field. This was previously called `"grpc_url"`.
+
+The `--kwil-provider` command line flag is DEPRECATED and will be removed in the subsequent release. Use the `--provider` flag instead.
+
+When updating for the new `provider` setting, ensure it corresponds to the JSON-RPC server at port 8484 instead of the REST API at port 8080. Otherwise, ensure that the chosen RPC provider is updated to direct to the JSON-RPC server.
+
+#### Command Changes
+
+The result from the `utils query-tx` command no longer includes the transaction details for an unconfirmed transaction. Confirmed transactions will still include the decoded transaction. A new `--raw` flag may be provided with this command to retrieve the serialized transaction data given a transaction hash.
+
+Added the `utils parse` command to parse a Kuneiform file and output the schema as JSON.
+
+Added the `utils decode-tx` command to decode a serialized transaction provided as a base64 string.
+
+Many of the fields in the JSON objects returned by `query-tx` and other commands with the `--output json` option are renamed with consistent snake case formatting. See the See [UPGRADING.md](https://github.com/kwilteam/kwil-db/blob/release-v0.8/UPGRADING.md) for details on changes to the `core` module types and their JSON tags.
+
+The `account balance` command may not be given a `--pending` flag to return account information that includes changes that consider any unconfirmed transactions. This is useful for determining the next nonce for an account when broadcasting multiple transaction per block.
+
+#### Node Application (`kwild`) Changes
+
+The default setting for the admin service (`admin_listen_addr`) is now `"/tmp/kwild.socket"`.
+
+The `jsonrpc_listen_addr` setting replaces the `grpc_listen_addr` setting. The default value for `jsonrpc_listen_addr` is `0.0.0.0:8484` (listen on port 8484 on all network interfaces).
+
+In addition to standard output, `kwild` also writes the log to `"kwild.log"` in the application's root directory by default. The `output_paths` setting is used to change this.
+
+Two new timeouts are added:
+
+- `rpc_timeout` sets a timeout on requests on the user RPC servers
+- `db_read_timeout` sets a timeout on database reads initiated by the user RPC service
+
+To support [network migrations](#network-migrations), the `genesis_state` setting is added to specify the path to the snapshot file to restore the database from.
+
+A new `app.snapshots` section is added to configure snapshot creation, which supports other nodes using "state sync" when joining a network.
+
+A new `chain.statesync` section is added to configure the use of "state sync" if the node is joining a network.
+
+A new `broadcast_tx_timeout` setting is added to control the timeout used when a transaction is broadcast with the `--sync` flag to wait for it to be mined. If the timeout is exceeded, the RPC user should query the transaction status until it is confirmed. The default timeout is 15 seconds.
+
+See the [Node documentation](https://docs.kwil.com/docs/daemon/config/settings) for more information on the added and changed settings.
+
+### SDK (`core` module)
+
+This release of Kwil DB uses version 0.2.1 of the `core` Go module.
+
+A Go application that supports Kwil DB v0.8.0 should be developed using the
+`core` module specified in the go.mod as follows:
+
+```go
+require github.com/kwilteam/kwil-db/core v0.2.1
+require github.com/kwilteam/kwil-db/parse v0.2.1 // to parse Kuneiform files
+```
+
+See the example application in [`client/core/example`](https://github.com/kwilteam/kwil-db/tree/release-v0.8/core/client/example) for a demonstration.
+
+### Unified Parsing Module
+
+The `parse` module contains the new unified parser for Kuneiform and SQL.
+
+Previously there were separate repositories for parsing Kuneiform, action bodies, and SQL statements within actions and procedures. These are now combined into the `parse` module, which contains:
+
+1. ANTLR grammar definitions in `parse/grammar`
+2. Low-level Kuneiform parser and lexer Go package in `parse/gen`, generated from the ANTLR files
+3. Top-level parsers in `parse` that return `kwil-db` types and apply Kwil rules and analysis
+4. A WASM wrapper in `parse/wasm` for the top-level `parse.ParseAndValidate` function
+
+For testing purposes, the `parse/postgres` package provides SQL syntax checking when built with CGO.
+
+To build the WASM file, use the `kuneiform:wasm` [task](https://taskfile.dev/), which will create a `parse/wasm/kuneiform_wasm.tar.gz` file containing the .wasm file.
+
+### PostgreSQL Docker Image
+
+The latest `kwildb/postgres` Docker image is now version [`16.2-1`](https://hub.docker.com/r/kwildb/postgres/tags).
+
+- Updates the base `postgres` image from 16.1 to 16.2
+- Disables the default 60s timeout on the logical replication sender connections (`wal_sender_timeout=0`).
+
+To update or download the image, run `docker pull kwildb/postgres:16.2-1`.
+
+### Build System and CI
+
+Kwil Gateway (KGW) integration tests are now run for all changes in the `kwil-db` repository.
+
+The `golangci-lint` linter is updated to version 1.58.0.
+
+## Build Requirements
+
+This release requires Go version 1.21 or 1.22.
+
+## Code Change Summary
+
+This release consists of 164 commits changing 583 files, with a total of 67,719 lines of code added and 31,945 lines deleted.
+
+See the full list of changes since v0.7 at https://github.com/kwilteam/kwil-db/compare/v0.7.6...v0.8.1


### PR DESCRIPTION
Will get done with this tonight.  Still working on it.

Will render [here](https://github.com/jchappelow/kwil-db/blob/relnotes-0.8/docs/release-notes/v0.8.1.md), but again, not done at all.

I'm drafting in `docs/release-notes`, but I don't think we *have to* check them in.  It probably a good idea, but it can be awkward when release notes on GitHub diverge from what's checked in, or when the notes end up only on `main` because they frequently come after a release tag (they aren't code after all).