### PR TITLE
ci: update release workflow support v0.8 version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -21,8 +21,8 @@ jobs:
         shell: bash
         run: |
           version=`echo ${{ github.event.release.tag_name }} | sed 's/^v//' | cut -d '.' -f 2`
-          kgw_version=$(v7="2"; v6="1"; eval echo \${v$version})
-          kjs_version=$(v7="6"; v6="5"; eval echo \${v$version})
+          kgw_version=$(v8="3"; v7="2"; v6="1"; eval echo \${v$version})
+          kjs_version=$(v8="7"; v7="6"; v6="5"; eval echo \${v$version})
           echo "kdb_version=v0.$version" >> $GITHUB_OUTPUT
           echo "kgw_version=v0.$kgw_version" >> $GITHUB_OUTPUT
           echo "kjs_version=v0.$kjs_version" >> $GITHUB_OUTPUT


### PR DESCRIPTION
This update release workflow, to support kwil-db v0.8 mapping to kgw and kwil-js version


This should be backported to release-v0.8 branch