### PR TITLE
fix resolution body index

### DIFF
--- a/internal/voting/sql.go
+++ b/internal/voting/sql.go
@@ -43,7 +43,7 @@ const (
 		vote_body_proposer BYTEA, -- vote_body_proposer is the identifier of the node that supplied the vote body
 		expiration INT8 NOT NULL, -- expiration is the blockheight at which the resolution expires
 		extra_vote_id BOOLEAN NOT NULL DEFAULT FALSE, -- If vote_body_proposer had sent VoteID before VoteBody, this is set to true
-		UNIQUE (id, body, type),
+		UNIQUE (id, type),
 		FOREIGN KEY(type) REFERENCES ` + votingSchemaName + `.resolution_types(id) ON UPDATE CASCADE ON DELETE CASCADE
 	);`
 


### PR DESCRIPTION
@outerlook ran into an issue where Kwil indexes a column that we should not be indexing. This places an unnecessary constraint on the amount of data that can fit in an index.