### PR TITLE
Fix/kwil admin config

### DIFF
--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -160,8 +160,6 @@ func GenerateNodeFiles(outputDir string, originalCfg *config.KwildConfig, silenc
 		return nil, fmt.Errorf("failed to get absolute path for output directory: %w", err)
 	}
 	cfg.RootDir = rootDir
-	// output logs to file, this will be located in given root dir
-	//cfg.Logging.OutputPaths = append(cfg.Logging.OutputPaths, "kwild.log")
 
 	cometbftRoot := filepath.Join(outputDir, abciDir)
 
@@ -256,7 +254,6 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 			return fmt.Errorf("failed to merge config file %s: %w", genCfg.ConfigFile, err)
 		}
 	}
-	//cfg.Logging.OutputPaths = append(cfg.Logging.OutputPaths, "kwild.log")
 
 	privateKeys := make([]cmtEd.PrivKey, nNodes)
 	for i := range privateKeys {

--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -161,7 +161,7 @@ func GenerateNodeFiles(outputDir string, originalCfg *config.KwildConfig, silenc
 	}
 	cfg.RootDir = rootDir
 	// output logs to file, this will be located in given root dir
-	cfg.Logging.OutputPaths = append(cfg.Logging.OutputPaths, "kwild.log")
+	//cfg.Logging.OutputPaths = append(cfg.Logging.OutputPaths, "kwild.log")
 
 	cometbftRoot := filepath.Join(outputDir, abciDir)
 
@@ -256,7 +256,7 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 			return fmt.Errorf("failed to merge config file %s: %w", genCfg.ConfigFile, err)
 		}
 	}
-	cfg.Logging.OutputPaths = append(cfg.Logging.OutputPaths, "kwild.log")
+	//cfg.Logging.OutputPaths = append(cfg.Logging.OutputPaths, "kwild.log")
 
 	privateKeys := make([]cmtEd.PrivKey, nNodes)
 	for i := range privateKeys {

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -286,7 +286,7 @@ func defaultMoniker() string {
 // It also takes a flag to indicate if the caller wants to modify the defaults
 // for "quickstart" mode. Presently this just makes the HTTP RPC service listen
 // on all interfaces instead of the default of localhost.
-func GetCfg(flagCfg *KwildConfig, quickStart bool) (*KwildConfig, bool, error) {
+func GetCfg(flagCfg *KwildConfig) (*KwildConfig, bool, error) {
 	/*
 		the process here is:
 		1. identify the root dir.  This requires reading in the env and command line flags

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -77,7 +77,7 @@ func RootCmd() *cobra.Command {
 			}
 			flagCfg.AppCfg.Extensions = extensionConfig
 
-			kwildCfg, configFileExists, err := config.GetCfg(flagCfg, autoGen)
+			kwildCfg, configFileExists, err := config.GetCfg(flagCfg)
 			if err != nil {
 				cmd.Usage()
 				return err


### PR DESCRIPTION
*  d60bfabc6f2155c9045e7f6a914c59dd62d5ab9e fix `kwild --autogen` or `kwil-admin setup init` generated configure `output_paths = ["stdout", "kwild.log", "kwild.log"]`
* 223595d8aa199dd44b11cd3a00200fef4d4d3638 remove non use arg

~~NOTE: not ready to review~~