### PR TITLE
added persistence of consensus params

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -57,6 +57,7 @@ import (
 	abciTypes "github.com/cometbft/cometbft/abci/types"
 	cmtEd "github.com/cometbft/cometbft/crypto/ed25519"
 	cmtlocal "github.com/cometbft/cometbft/rpc/client/local"
+	"github.com/kwilteam/kwil-db/core/types"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/health/grpc_health_v1"
 )
@@ -188,9 +189,9 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	// to get the comet node, we need the abci app
 	// to get the abci app, we need the tx router
 	// but the tx router needs the cometbft client
-	txApp := buildTxApp(d, db, e, ev, snapshotter, closers)
+	txApp := buildTxApp(d, db, e, ev)
 
-	abciApp := buildAbci(d, txApp, snapshotter, statesyncer)
+	abciApp := buildAbci(d, db, txApp, snapshotter, statesyncer)
 
 	// NOTE: buildCometNode immediately starts talking to the abciApp and
 	// replaying blocks (and using atomic db tx commits), i.e. calling
@@ -202,13 +203,13 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 		cl:    cometBftClient,
 		cache: abciApp,
 	}
-	txApp.SetReplayStatusChecker(cometBftNode.IsCatchup)
+	abciApp.SetReplayStatusChecker(cometBftNode.IsCatchup)
 
 	eventBroadcaster := buildEventBroadcaster(d, ev, wrappedCmtClient, txApp)
 	abciApp.SetEventBroadcaster(eventBroadcaster.RunBroadcast)
 
 	// listener manager
-	listeners := buildListenerManager(d, ev, cometBftNode, txApp)
+	listeners := buildListenerManager(d, ev, cometBftNode, txApp, db)
 
 	// user service and server
 	rpcSvcLogger := increaseLogLevel("user-json-svc", &d.log, d.cfg.Logging.RPCLevel)
@@ -335,24 +336,17 @@ func (c *closeFuncs) closeAll() error {
 	return err
 }
 
-func buildTxApp(d *coreDependencies, db *pg.DB, engine *execution.GlobalContext, ev *voting.EventStore,
-	snapshotter *statesync.SnapshotStore, closers *closeFuncs) *txapp.TxApp {
-	var sh txapp.Snapshotter
-	if snapshotter != nil {
-		sh = snapshotter
-	}
+func buildTxApp(d *coreDependencies, db *pg.DB, engine *execution.GlobalContext, ev *voting.EventStore) *txapp.TxApp {
 
-	txApp, err := txapp.NewTxApp(d.ctx, db, engine, buildSigner(d), ev, sh, d.genesisCfg,
+	txApp, err := txapp.NewTxApp(d.ctx, db, engine, buildSigner(d), ev, d.genesisCfg,
 		d.cfg.AppCfg.Extensions, *d.log.Named("tx-router"))
 	if err != nil {
 		failBuild(err, "failed to build new TxApp")
 	}
-
-	closers.addCloser(txApp.Close, "ending any active txApp transactions")
 	return txApp
 }
 
-func buildAbci(d *coreDependencies, txApp abci.TxApp, snapshotter *statesync.SnapshotStore, statesyncer *statesync.StateSyncer) *abci.AbciApp {
+func buildAbci(d *coreDependencies, db *pg.DB, txApp abci.TxApp, snapshotter *statesync.SnapshotStore, statesyncer *statesync.StateSyncer) *abci.AbciApp {
 	var sh abci.SnapshotModule
 	if snapshotter != nil {
 		sh = snapshotter
@@ -361,23 +355,6 @@ func buildAbci(d *coreDependencies, txApp abci.TxApp, snapshotter *statesync.Sna
 	var ss abci.StateSyncModule
 	if statesyncer != nil {
 		ss = statesyncer
-	}
-
-	// we need to persist the genesis consensus params if they are not already
-	_, err := txApp.NetworkParams(d.ctx)
-	if err == meta.ErrParamsNotFound {
-		err = txApp.StoreNetworkParams(d.ctx, &common.NetworkParameters{
-			MaxBlockSize:     d.genesisCfg.ConsensusParams.Block.MaxBytes,
-			JoinExpiry:       d.genesisCfg.ConsensusParams.Validator.JoinExpiry,
-			VoteExpiry:       d.genesisCfg.ConsensusParams.Votes.VoteExpiry,
-			DisabledGasCosts: d.genesisCfg.ConsensusParams.WithoutGasCosts,
-		})
-
-		if err != nil {
-			failBuild(err, "failed to persist genesis consensus params")
-		}
-	} else if err != nil {
-		failBuild(err, "failed to get genesis consensus params")
 	}
 
 	cfg := &abci.AbciConfig{
@@ -389,7 +366,7 @@ func buildAbci(d *coreDependencies, txApp abci.TxApp, snapshotter *statesync.Sna
 		ForkHeights:        d.genesisCfg.ForkHeights,
 	}
 	app, err := abci.NewAbciApp(d.ctx, cfg, sh, ss, txApp,
-		d.genesisCfg.ConsensusParams, *d.log.Named("abci"))
+		d.genesisCfg.ConsensusParams, db, *d.log.Named("abci"))
 	if err != nil {
 		failBuild(err, "failed to build ABCI application")
 	}
@@ -397,7 +374,7 @@ func buildAbci(d *coreDependencies, txApp abci.TxApp, snapshotter *statesync.Sna
 }
 
 func buildEventBroadcaster(d *coreDependencies, ev broadcast.EventStore, b broadcast.Broadcaster, txapp *txapp.TxApp) *broadcast.EventBroadcaster {
-	return broadcast.NewEventBroadcaster(ev, b, txapp, txapp, buildSigner(d), d.genesisCfg.ChainID)
+	return broadcast.NewEventBroadcaster(ev, b, txapp, buildSigner(d), d.genesisCfg.ChainID)
 }
 
 func buildEventStore(d *coreDependencies, closers *closeFuncs) *voting.EventStore {
@@ -938,6 +915,34 @@ func failBuild(err error, msg string) {
 	}
 }
 
-func buildListenerManager(d *coreDependencies, ev *voting.EventStore, node *cometbft.CometBftNode, txapp *txapp.TxApp) *listeners.ListenerManager {
-	return listeners.NewListenerManager(d.cfg.AppCfg.Extensions, ev, node, d.privKey.PubKey().Bytes(), txapp, *d.log.Named("listener-manager"))
+func buildListenerManager(d *coreDependencies, ev *voting.EventStore, node *cometbft.CometBftNode, txapp *txapp.TxApp, db sql.ReadTxMaker) *listeners.ListenerManager {
+	vr := &validatorReader{db: db, txApp: txapp}
+
+	return listeners.NewListenerManager(d.cfg.AppCfg.Extensions, ev, node, d.privKey.PubKey().Bytes(), vr, *d.log.Named("listener-manager"))
+}
+
+// validatorReader reads the validator set from the chain state.
+type validatorReader struct {
+	db    sql.ReadTxMaker
+	txApp *txapp.TxApp
+}
+
+func (v *validatorReader) GetValidators(ctx context.Context) ([]*types.Validator, error) {
+	cached, ok := v.txApp.CachedValidators()
+	if ok {
+		return cached, nil
+	}
+
+	// if we don't have a cached validator set, we need to fetch it from the db
+	readTx, err := v.db.BeginReadTx(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer readTx.Rollback(ctx)
+
+	return v.txApp.GetValidators(ctx, readTx)
+}
+
+func (v *validatorReader) SubscribeValidators() <-chan []*types.Validator {
+	return v.txApp.SubscribeValidators()
 }

--- a/common/common.go
+++ b/common/common.go
@@ -124,3 +124,28 @@ func (e *ExecutionData) Clean() error {
 	e.Procedure = strings.ToLower(e.Procedure)
 	return nil
 }
+
+// NetworkParameters are network level configurations that can be
+// evolved over the lifetime of a network.
+type NetworkParameters struct {
+	// MaxBlockSize is the maximum size of a block in bytes.
+	MaxBlockSize int64
+	// JoinExpiry is the number of blocks after which the validators
+	// join request expires if not approved.
+	JoinExpiry int64
+	// VoteExpiry is the default number of blocks after which the validators
+	// vote expires if not approved.
+	VoteExpiry int64
+	// DisabledGasCosts dictates whether gas costs are disabled.
+	DisabledGasCosts bool
+}
+
+// Copy returns a deep copy of the network parameters.
+func (n *NetworkParameters) Copy() *NetworkParameters {
+	return &NetworkParameters{
+		MaxBlockSize:     n.MaxBlockSize,
+		JoinExpiry:       n.JoinExpiry,
+		VoteExpiry:       n.VoteExpiry,
+		DisabledGasCosts: n.DisabledGasCosts,
+	}
+}

--- a/common/common.go
+++ b/common/common.go
@@ -41,13 +41,11 @@ type App struct {
 // router and extension implementations in extensions/consensus.
 type TxContext struct {
 	Ctx context.Context
-	// BlockHeight gets the height of the current block.
-	BlockHeight int64
-	// Proposer gets the proposer public key of the current block.
-	Proposer []byte
 	// ConsensusParams holds network level parameters that can be evolved
 	// over the lifetime of a network.
 	ConsensusParams *chain.ConsensusParams
+	// BlockContext is the context of the current block.
+	BlockContext *BlockContext
 	// TxID is the ID of the current transaction.
 	TxID []byte
 }

--- a/common/context.go
+++ b/common/context.go
@@ -1,0 +1,20 @@
+package common
+
+// ChainContext provides context for all chain operations.
+type ChainContext struct {
+	// ChainID is the unique identifier for the chain.
+	ChainID string
+	// NetworkParams holds network level parameters that can be evolved
+	// over the lifetime of a network.
+	NetworkParameters *NetworkParameters
+}
+
+// BlockContext provides context for all block operations.
+type BlockContext struct {
+	// ChainContext contains information about the chain.
+	ChainContext *ChainContext
+	// Height gets the height of the current block.
+	Height int64
+	// Proposer gets the proposer public key of the current block.
+	Proposer []byte
+}

--- a/extensions/resolutions/credit/credit.go
+++ b/extensions/resolutions/credit/credit.go
@@ -79,7 +79,7 @@ var resolutionConfig = resolutions.ResolutionConfig{
 	// ResolveFunc defines what will happen if the resolution is approved by the network.
 	// For the credit_account resolution, we will credit the account with the given amount.
 	// The amount cannot be negative.
-	ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error {
+	ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution, block *common.BlockContext) error {
 		// Unmarshal the resolution payload into an AccountCreditResolution
 		var credit AccountCreditResolution
 		err := credit.UnmarshalBinary(resolution.Body)

--- a/extensions/resolutions/resolutions.go
+++ b/extensions/resolutions/resolutions.go
@@ -117,7 +117,7 @@ type ResolutionConfig struct {
 	// been confirmed. All nodes will call this function as a part of
 	// block execution. It is therefore expected that the function is
 	// deterministic, regardless of a node's local configuration.
-	ResolveFunc func(ctx context.Context, app *common.App, resolution *Resolution) error
+	ResolveFunc func(ctx context.Context, app *common.App, resolution *Resolution, block *common.BlockContext) error
 }
 
 // Resolution contains information for a resolution that can be voted

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 
 	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/common/sql"
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/log"
@@ -85,6 +86,7 @@ func Test_prepareMempoolTxns(t *testing.T) {
 
 	abciApp := &AbciApp{
 		txApp: &mockTxApp{},
+		db:    &mockDB{},
 	}
 	logger := log.NewStdOut(log.DebugLevel)
 
@@ -217,7 +219,7 @@ func Test_prepareMempoolTxns(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := abciApp.prepareBlockTransactions(context.Background(), tt.txs, &logger, 1e6, []byte("proposer"))
+			got := abciApp.prepareBlockTransactions(context.Background(), tt.txs, &logger, 1e6, []byte("proposer"), 0)
 			if len(got) != len(tt.want) {
 				t.Errorf("got %d txns, expected %d", len(got), len(tt.want))
 			}
@@ -236,6 +238,7 @@ func Test_ProcessProposal_UnfundedAccount(t *testing.T) {
 		cfg: AbciConfig{
 			GasEnabled: true,
 		},
+		db: &mockDB{},
 	}
 	logger := log.NewStdOut(log.DebugLevel)
 
@@ -247,7 +250,7 @@ func Test_ProcessProposal_UnfundedAccount(t *testing.T) {
 	txA1 := newTxBts(t, 1, signerA)
 
 	// Unfunded account
-	txs := abciApp.prepareBlockTransactions(context.Background(), [][]byte{txA1}, &logger, 1e6, []byte("proposer"))
+	txs := abciApp.prepareBlockTransactions(context.Background(), [][]byte{txA1}, &logger, 1e6, []byte("proposer"), 0)
 	assert.Len(t, txs, 0)
 
 }
@@ -256,6 +259,7 @@ func Test_ProcessProposal_TxValidation(t *testing.T) {
 	ctx := context.Background()
 	abciApp := &AbciApp{
 		txApp: &mockTxApp{},
+		db:    &mockDB{},
 	}
 	logger := log.NewStdOut(log.DebugLevel)
 
@@ -388,15 +392,11 @@ func (m *mockTxApp) MarkBroadcasted(ctx context.Context, ids []types.UUID) error
 	return nil
 }
 
-func (m *mockTxApp) AccountInfo(ctx context.Context, acctID []byte, getUncommitted bool) (balance *big.Int, nonce int64, err error) {
+func (m *mockTxApp) AccountInfo(ctx context.Context, db sql.DB, acctID []byte, getUncommitted bool) (balance *big.Int, nonce int64, err error) {
 	return big.NewInt(0), 0, nil
 }
 
-func (m *mockTxApp) ConsensusAccountInfo(ctx context.Context, acctID []byte) (balance *big.Int, nonce int64, err error) {
-	return big.NewInt(0), 0, nil
-}
-
-func (m *mockTxApp) ApplyMempool(ctx context.Context, tx *transactions.Transaction) error {
+func (m *mockTxApp) ApplyMempool(ctx context.Context, db sql.DB, tx *transactions.Transaction) error {
 	return nil
 }
 
@@ -404,55 +404,79 @@ func (m *mockTxApp) Begin(ctx context.Context, height int64) error {
 	return nil
 }
 
-func (m *mockTxApp) Commit(ctx context.Context) (int64, error) {
-	return 1, nil
-}
+func (m *mockTxApp) Commit(ctx context.Context) {}
 
-func (m *mockTxApp) Execute(ctx txapp.TxContext, tx *transactions.Transaction) *txapp.TxResponse {
+func (m *mockTxApp) Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse {
 	return nil
 }
 
-func (m *mockTxApp) Finalize(ctx context.Context, blockHeight int64, oldNetworkParams, newNetworkParams *common.NetworkParameters) (apphash []byte, validatorUpgrades []*types.Validator, err error) {
-	return nil, nil, nil
-}
-
-func (m *mockTxApp) GenesisInit(ctx context.Context, validators []*types.Validator, accounts []*types.Account,
-	initialHeight int64, appHash []byte) error {
-	return nil
-}
-
-func (m *mockTxApp) ChainInfo(ctx context.Context) (height int64, appHash []byte, err error) {
-	return 1, nil, nil
-}
-
-func (m *mockTxApp) GetValidators(ctx context.Context) ([]*types.Validator, error) {
+func (m *mockTxApp) Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (validatorUpgrades []*types.Validator, err error) {
 	return nil, nil
 }
 
-func (m *mockTxApp) ConsensusValidators(ctx context.Context) ([]*types.Validator, error) {
-	return nil, nil
-}
-
-func (m *mockTxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxSz int64, proposerAddr []byte) ([][]byte, error) {
-	return nil, nil
-}
-
-func (m *mockTxApp) Price(ctx context.Context, tx *transactions.Transaction) (*big.Int, error) {
-	return big.NewInt(0), nil
-}
-
-func (m *mockTxApp) UpdateValidator(ctx context.Context, validator []byte, power int64) error {
+func (m *mockTxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, accounts []*types.Account,
+	initialHeight int64) error {
 	return nil
 }
 
-func (m *mockTxApp) Reload(ctx context.Context) error {
-	return nil
-}
-
-func (m *mockTxApp) NetworkParams(ctx context.Context) (*common.NetworkParameters, error) {
+func (m *mockTxApp) GetValidators(ctx context.Context, db sql.DB) ([]*types.Validator, error) {
 	return nil, nil
 }
 
-func (m *mockTxApp) StoreNetworkParams(ctx context.Context, params *common.NetworkParameters) error {
+func (m *mockTxApp) ProposerTxs(ctx context.Context, db sql.DB, txNonce uint64, maxTxSz int64, block *common.BlockContext) ([][]byte, error) {
+	return nil, nil
+}
+
+func (m *mockTxApp) UpdateValidator(ctx context.Context, db sql.DB, validator []byte, power int64) error {
 	return nil
+}
+
+func (m *mockTxApp) Reload(ctx context.Context, db sql.DB) error {
+	return nil
+}
+
+type mockDB struct{}
+
+func (m *mockDB) BeginOuterTx(ctx context.Context) (sql.OuterTx, error) {
+	return &mockTx{}, nil
+}
+
+func (m *mockDB) BeginReadTx(ctx context.Context) (sql.Tx, error) {
+	return &mockTx{}, nil
+}
+
+func (m *mockDB) BeginSnapshotTx(ctx context.Context) (sql.Tx, string, error) {
+	return &mockTx{}, "", nil
+}
+
+func (m *mockDB) Execute(ctx context.Context, stmt string, args ...any) (*sql.ResultSet, error) {
+	return nil, nil
+}
+
+func (m *mockDB) BeginTx(ctx context.Context) (sql.Tx, error) {
+	return &mockTx{}, nil
+}
+
+func (m *mockDB) AutoCommit(on bool) {}
+
+type mockTx struct{}
+
+func (m *mockTx) Rollback(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockTx) Commit(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockTx) Execute(ctx context.Context, stmt string, args ...any) (*sql.ResultSet, error) {
+	return nil, nil
+}
+
+func (m *mockTx) BeginTx(ctx context.Context) (sql.Tx, error) {
+	return &mockTx{}, nil
+}
+
+func (m *mockTx) Precommit(ctx context.Context) ([]byte, error) {
+	return nil, nil
 }

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -6,6 +6,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/log"
@@ -411,7 +412,7 @@ func (m *mockTxApp) Execute(ctx txapp.TxContext, tx *transactions.Transaction) *
 	return nil
 }
 
-func (m *mockTxApp) Finalize(ctx context.Context, blockHeight int64) (apphash []byte, validatorUpgrades []*types.Validator, err error) {
+func (m *mockTxApp) Finalize(ctx context.Context, blockHeight int64, oldNetworkParams, newNetworkParams *common.NetworkParameters) (apphash []byte, validatorUpgrades []*types.Validator, err error) {
 	return nil, nil, nil
 }
 
@@ -446,4 +447,8 @@ func (m *mockTxApp) UpdateValidator(ctx context.Context, validator []byte, power
 
 func (m *mockTxApp) Reload(ctx context.Context) error {
 	return nil
+}
+
+func (m *mockTxApp) NetworkParams(ctx context.Context) (*common.NetworkParameters, error) {
+	return nil, nil
 }

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -452,3 +452,7 @@ func (m *mockTxApp) Reload(ctx context.Context) error {
 func (m *mockTxApp) NetworkParams(ctx context.Context) (*common.NetworkParameters, error) {
 	return nil, nil
 }
+
+func (m *mockTxApp) StoreNetworkParams(ctx context.Context, params *common.NetworkParameters) error {
+	return nil
+}

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"math/big"
 
+	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 
@@ -58,7 +59,7 @@ type TxApp interface {
 	Begin(ctx context.Context, height int64) error
 	Execute(ctx txapp.TxContext, tx *transactions.Transaction) *txapp.TxResponse
 	UpdateValidator(ctx context.Context, validator []byte, power int64) error
-	Finalize(ctx context.Context, height int64) (appHash []byte, validatorUpgrades []*types.Validator, err error)
+	Finalize(ctx context.Context, height int64, oldNetworkParams, newNetworkParams *common.NetworkParameters) (appHash []byte, validatorUpgrades []*types.Validator, err error)
 	Commit(ctx context.Context) (int64, error)
 
 	// ConsensusAccountInfo and ConsensusValidators are used in two different
@@ -71,6 +72,8 @@ type TxApp interface {
 
 	// Reload reloads the state of engine and txapp.
 	Reload(ctx context.Context) error
+	// NetworkParams returns the current network parameters.
+	NetworkParams(ctx context.Context) (*common.NetworkParameters, error)
 }
 
 // ConsensusParams returns kwil specific consensus parameters.

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -74,6 +74,8 @@ type TxApp interface {
 	Reload(ctx context.Context) error
 	// NetworkParams returns the current network parameters.
 	NetworkParams(ctx context.Context) (*common.NetworkParameters, error)
+	// StoreNetworkParams stores the consensus params in the store.
+	StoreNetworkParams(ctx context.Context, params *common.NetworkParameters) error
 }
 
 // ConsensusParams returns kwil specific consensus parameters.

--- a/internal/services/grpc/txsvc/v1/pricing.go
+++ b/internal/services/grpc/txsvc/v1/pricing.go
@@ -15,7 +15,14 @@ func (s *Service) EstimatePrice(ctx context.Context, req *txpb.EstimatePriceRequ
 	if err != nil {
 		return nil, fmt.Errorf("failed to convert transaction: %w", err)
 	}
-	price, err := s.nodeApp.Price(ctx, tx)
+
+	readTx, err := s.db.BeginReadTx(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to begin read tx: %w", err)
+	}
+	defer readTx.Rollback(ctx)
+
+	price, err := s.nodeApp.Price(ctx, readTx, tx)
 	if err != nil {
 		return nil, fmt.Errorf("failed to estimate price: %w", err)
 	}

--- a/internal/services/grpc/txsvc/v1/service.go
+++ b/internal/services/grpc/txsvc/v1/service.go
@@ -64,6 +64,6 @@ type BlockchainTransactor interface {
 }
 
 type NodeApplication interface {
-	AccountInfo(ctx context.Context, identifier []byte, getUncommitted bool) (balance *big.Int, nonce int64, err error)
-	Price(ctx context.Context, tx *transactions.Transaction) (*big.Int, error)
+	AccountInfo(ctx context.Context, db sql.DB, identifier []byte, getUncommitted bool) (balance *big.Int, nonce int64, err error)
+	Price(ctx context.Context, db sql.DB, tx *transactions.Transaction) (*big.Int, error)
 }

--- a/internal/txapp/interfaces.go
+++ b/internal/txapp/interfaces.go
@@ -67,6 +67,8 @@ var (
 	// chain metadata
 	getChainState = meta.GetChainState
 	setChainState = meta.SetChainState
+	storeDiff     = meta.StoreDiff
+	loadParams    = meta.LoadParams
 
 	// account functions
 	getAccount = accounts.GetAccount

--- a/internal/txapp/interfaces.go
+++ b/internal/txapp/interfaces.go
@@ -69,6 +69,7 @@ var (
 	setChainState = meta.SetChainState
 	storeDiff     = meta.StoreDiff
 	loadParams    = meta.LoadParams
+	storeParams   = meta.StoreParams
 
 	// account functions
 	getAccount = accounts.GetAccount

--- a/internal/txapp/interfaces.go
+++ b/internal/txapp/interfaces.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/kwilteam/kwil-db/common/sql"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/internal/abci/meta"
 	"github.com/kwilteam/kwil-db/internal/accounts"
 	"github.com/kwilteam/kwil-db/internal/voting"
 )
@@ -63,13 +62,6 @@ var (
 	createResolution                 = voting.CreateResolution
 	approveResolution                = voting.ApproveResolution
 	getVoterPower                    = voting.GetValidatorPower
-
-	// chain metadata
-	getChainState = meta.GetChainState
-	setChainState = meta.SetChainState
-	storeDiff     = meta.StoreDiff
-	loadParams    = meta.LoadParams
-	storeParams   = meta.StoreParams
 
 	// account functions
 	getAccount = accounts.GetAccount

--- a/internal/txapp/mempool_test.go
+++ b/internal/txapp/mempool_test.go
@@ -117,14 +117,6 @@ func (m *mockTx) Rollback(ctx context.Context) error {
 	return nil
 }
 
-type mockOuterTx struct {
-	*mockTx
-}
-
-func (m *mockOuterTx) Precommit(ctx context.Context) ([]byte, error) {
-	return nil, nil
-}
-
 type mockRebroadcast struct{}
 
 func (m *mockRebroadcast) MarkRebroadcast(ctx context.Context, ids []*types.UUID) error {

--- a/internal/txapp/routes_test.go
+++ b/internal/txapp/routes_test.go
@@ -7,6 +7,7 @@ import (
 
 	"math/big"
 
+	"github.com/kwilteam/kwil-db/common"
 	sql "github.com/kwilteam/kwil-db/common/sql"
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
@@ -199,7 +200,9 @@ func Test_Routes(t *testing.T) {
 				},
 			},
 			ctx: TxContext{
-				Proposer: validatorSigner1().Identity(),
+				BlockContext: &common.BlockContext{
+					Proposer: validatorSigner1().Identity(),
+				},
 			},
 			from: validatorSigner1(),
 		},
@@ -235,7 +238,9 @@ func Test_Routes(t *testing.T) {
 				},
 			},
 			ctx: TxContext{
-				Proposer: validatorSigner1().Identity(),
+				BlockContext: &common.BlockContext{
+					Proposer: validatorSigner1().Identity(),
+				},
 			},
 			from: validatorSigner2(),
 			err:  ErrCallerNotProposer,
@@ -277,7 +282,7 @@ func Test_Routes(t *testing.T) {
 			}
 
 			tc.fn(t, func(app *TxApp) {
-				app.currentTx = &mockOuterTx{&mockTx{&mockDb{}}} // hack to trick txapp that we are in a session
+				db := &mockTx{&mockDb{}}
 
 				// since every test case needs an account store, we'll just create a mock one here
 				// if one isn't provided
@@ -288,7 +293,7 @@ func Test_Routes(t *testing.T) {
 					app.signer = validatorSigner1()
 				}
 
-				res := app.Execute(tc.ctx, tx)
+				res := app.Execute(tc.ctx, db, tx)
 				if tc.err != nil {
 					require.ErrorIs(t, tc.err, res.Error)
 				} else {

--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -1185,3 +1185,20 @@ func (r *TxApp) NetworkParams(ctx context.Context) (*common.NetworkParameters, e
 
 	return params, nil
 }
+
+// StoreNetworkParams stores the consensus parameters in the database.
+// It should be called when the node is started. It will make and commit
+// a transaction to store the parameters.
+func (r *TxApp) StoreNetworkParams(ctx context.Context, params *common.NetworkParameters) error {
+	tx, err := r.Database.BeginOuterTx(ctx)
+	if err != nil {
+		return err
+	}
+
+	err = storeParams(ctx, tx, params)
+	if err != nil {
+		return errors.Join(err, tx.Rollback(ctx))
+	}
+
+	return tx.Commit(ctx)
+}

--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -4,7 +4,6 @@ package txapp
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -15,12 +14,12 @@ import (
 	"github.com/kwilteam/kwil-db/common/chain"
 	"github.com/kwilteam/kwil-db/common/chain/forks"
 	"github.com/kwilteam/kwil-db/common/sql"
-	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/serialize"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
+	"github.com/kwilteam/kwil-db/core/utils/order"
 	authExt "github.com/kwilteam/kwil-db/extensions/auth"
 	"github.com/kwilteam/kwil-db/extensions/consensus"
 	"github.com/kwilteam/kwil-db/extensions/resolutions"
@@ -29,8 +28,8 @@ import (
 )
 
 // NewTxApp creates a new router.
-func NewTxApp(ctx context.Context, db DB, engine common.Engine, signer *auth.Ed25519Signer,
-	events Rebroadcaster, snapshotter Snapshotter, chainParams *chain.GenesisConfig,
+func NewTxApp(ctx context.Context, db sql.Executor, engine common.Engine, signer *auth.Ed25519Signer,
+	events Rebroadcaster, chainParams *chain.GenesisConfig,
 	extensionConfigs map[string]map[string]string, log log.Logger) (*TxApp, error) {
 	voteBodyTxSize, err := computeEmptyVoteBodyTxSize(chainParams.ChainID)
 	if err != nil {
@@ -41,17 +40,15 @@ func NewTxApp(ctx context.Context, db DB, engine common.Engine, signer *auth.Ed2
 	slices.Sort(resTypes)
 
 	t := &TxApp{
-		Database: db,
-		Engine:   engine,
-		events:   events,
-		log:      log,
+		Engine: engine,
+		events: events,
+		log:    log,
 		mempool: &mempool{
 			accounts:   make(map[string]*types.Account),
 			gasEnabled: !chainParams.ConsensusParams.WithoutGasCosts,
 			nodeAddr:   signer.Identity(),
 		},
 		signer:              signer,
-		snapshotter:         snapshotter,
 		chainID:             chainParams.ChainID,
 		GasEnabled:          !chainParams.ConsensusParams.WithoutGasCosts,
 		extensionConfigs:    extensionConfigs,
@@ -59,10 +56,6 @@ func NewTxApp(ctx context.Context, db DB, engine common.Engine, signer *auth.Ed2
 		resTypes:            resTypes,
 	}
 	t.forks.FromMap(chainParams.ForkHeights)
-	t.height, t.appHash, err = t.ChainInfo(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get chain info: %w", err)
-	}
 	return t, nil
 }
 
@@ -71,8 +64,7 @@ func NewTxApp(ctx context.Context, db DB, engine common.Engine, signer *auth.Ed2
 // maintaining a mempool for uncommitted accounts, pricing transactions,
 // managing atomicity of the database, and managing the validator set.
 type TxApp struct {
-	Database DB            // postgres database
-	Engine   common.Engine // tracks deployed schemas
+	Engine common.Engine // tracks deployed schemas
 	// The various internal stores (accounts, votes, etc.) are accessed through
 	// the Database via the functions defined in relevant packages.
 
@@ -86,89 +78,27 @@ type TxApp struct {
 
 	log log.Logger
 
-	mempool *mempool
-
-	// appHash is the last block's apphash, set for genesis in GenesisInit
-	// updated in FinalizeBlock by combining with new engine hash.
-	appHash []byte
-	height  int64
-
+	mempool    *mempool
 	validators []*types.Validator // used to optimize reads, gets updated at the block boundaries
 	valMtx     sync.RWMutex       // protects validators access
 	valChans   []chan []*types.Validator
 
 	// transaction that exists between Begin and Commit
-	currentTx sql.OuterTx
-
-	// Abci.InitChain can be called multiple times from comet when the node fails
-	// before the first block is committed.
-	// Therefore any changes in the Genesis must be committed only
-	// upon calling Commit at the end of the first block.
-	// For more information, see: https://github.com/cometbft/cometbft/issues/203
-	// genesisTx is the transaction that is used to apply the genesis state changes
-	// along with the updates by the transactions in the first block.
-	genesisTx sql.OuterTx
+	// currentTx sql.OuterTx
 
 	extensionConfigs map[string]map[string]string
 
-	snapshotter    Snapshotter
-	replayStatusFn ReplayStatusChecker
 	// precomputed variables
 	emptyVoteBodyTxSize int64
 	resTypes            []string
-}
-
-func (r *TxApp) Log() *log.Logger {
-	return &r.log
-}
-
-// Close is used to end any active database transaction that may exist if the
-// application tries to shut down before closing the transaction with a call to
-// Commit. Neglecting to rollback such a transaction may prevent the DB
-// connection from being closed and released to the connection pool.
-func (r *TxApp) Close() error {
-	var err error
-	if r.genesisTx != nil {
-		err = errors.Join(err, r.genesisTx.Rollback(context.Background()))
-	}
-	if r.currentTx != nil {
-		err = errors.Join(err, r.currentTx.Rollback(context.Background()))
-	}
-	return err
 }
 
 // GenesisInit initializes the TxApp. It must be called outside of a session,
 // and before any session is started.
 // It can assign the initial validator set and initial account balances.
 // It is only called once for a new chain.
-func (r *TxApp) GenesisInit(ctx context.Context, validators []*types.Validator, genesisAccounts []*types.Account,
-	initialHeight int64, genesisAppHash []byte) error {
-	tx, err := r.Database.BeginOuterTx(ctx)
-	if err != nil {
-		return err
-	}
-	r.genesisTx = tx
-
-	// With the genesisTx not being committed until the first FinalizeBlock, we
-	// expect no existing chain state in the application (postgres).
-	height, appHash, err := getChainState(ctx, tx)
-	if err != nil {
-		err2 := tx.Rollback(ctx)
-		if err2 != nil {
-			return fmt.Errorf("error rolling back transaction: %s, error: %s", err.Error(), err2.Error())
-		}
-		return fmt.Errorf("error getting database height: %s", err.Error())
-	}
-
-	// First app hash and height are stored in FinalizeBlock for first block.
-	if height != -1 {
-		return fmt.Errorf("expected database to be uninitialized, but had height %d", height)
-	}
-	if len(appHash) != 0 {
-		return fmt.Errorf("expected NULL app hash, got %x", appHash)
-	}
-
-	r.appHash = genesisAppHash // combined with first block's apphash and stored in FinalizeBlock
+func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, genesisAccounts []*types.Account,
+	initialHeight int64) error {
 
 	// Add Genesis Validators
 	var voters []*types.Validator
@@ -176,12 +106,8 @@ func (r *TxApp) GenesisInit(ctx context.Context, validators []*types.Validator, 
 	defer r.valMtx.Unlock()
 
 	for _, validator := range validators {
-		err := setVoterPower(ctx, tx, validator.PubKey, validator.Power)
+		err := setVoterPower(ctx, db, validator.PubKey, validator.Power)
 		if err != nil {
-			err2 := tx.Rollback(ctx)
-			if err2 != nil {
-				return fmt.Errorf("error rolling back transaction: %s, error: %s", err.Error(), err2.Error())
-			}
 			return err
 		}
 		voters = append(voters, validator)
@@ -190,91 +116,30 @@ func (r *TxApp) GenesisInit(ctx context.Context, validators []*types.Validator, 
 
 	// Fund Genesis Accounts
 	for _, account := range genesisAccounts {
-		err := credit(ctx, tx, account.Identifier, account.Balance)
+		err := credit(ctx, db, account.Identifier, account.Balance)
 		if err != nil {
-			err2 := tx.Rollback(ctx)
-			if err2 != nil {
-				return fmt.Errorf("error rolling back transaction: %s, error: %s", err.Error(), err2.Error())
-			}
 			return err
 		}
 	}
 	return nil
 }
 
-// ChainInfo is called be the ABCI application's Info method, which is called
-// once on startup except when the node is at genesis, in which case GenesisInit
-// is called by the application's ChainInit method. At genesis, when there are
-// no blocks yet, the height will be zero, never negative.
-func (r *TxApp) ChainInfo(ctx context.Context) (int64, []byte, error) {
-	tx, err := r.Database.BeginReadTx(ctx)
-	if err != nil {
-		return 0, nil, err
-	}
-	defer tx.Rollback(ctx)
-
-	// MAYBE: return r.height, r.appHash from the exported method and only query
-	// the DB from an unexported method that c'tor uses. Needs mutex. Hitting DB
-	// always may also be good to ensure the exported method gets committed.
-
-	// return getChainState(ctx, tx)
-	height, appHash, err := getChainState(ctx, tx)
-	if err != nil {
-		return 0, nil, err
-	}
-	// r.log.Debug("ChainInfo", log.Int("height", height), log.String("appHash", hex.EncodeToString(appHash)),
-	// 	log.Int("height_x", r.height), log.String("appHash_x", hex.EncodeToString(r.appHash)))
-	if height == -1 {
-		height = 0 // for ChainInfo caller, non-negative is expected for genesis
-	}
-	return height, appHash, nil
-}
-
 // Reload reloads the database state into the engine.
-func (r *TxApp) Reload(ctx context.Context) error {
-	tx, err := r.Database.BeginReadTx(ctx)
-	if err != nil {
-		return err
-	}
-	defer tx.Rollback(ctx)
-
+func (r *TxApp) Reload(ctx context.Context, db sql.DB) error {
 	// Reload the engine internal state from the updated database state
-	err = r.Engine.Reload(ctx, tx)
+	err := r.Engine.Reload(ctx, db)
 	if err != nil {
 		return err
 	}
 
-	// Update the height and apphash from the updated database state
-	r.height, r.appHash, err = getChainState(ctx, tx)
-	if err != nil {
-		return err
-	}
-
-	return tx.Commit(ctx)
+	return nil
 }
 
 // UpdateValidator updates a validator's power.
 // It can only be called in between Begin and Finalize.
 // The value passed as power will simply replace the current power.
-func (r *TxApp) UpdateValidator(ctx context.Context, validator []byte, power int64) error {
-	if r.currentTx == nil {
-		return errors.New("txapp misuse: cannot update a validator without a transaction in progress")
-	}
-
-	// since validators are used for voting, we also must update the vote store. this should be atomic.
-
-	sp, err := r.currentTx.BeginTx(ctx)
-	if err != nil {
-		return err
-	}
-	defer sp.Rollback(ctx)
-
-	err = setVoterPower(ctx, r.currentTx, validator, power)
-	if err != nil {
-		return err
-	}
-
-	return sp.Commit(ctx)
+func (r *TxApp) UpdateValidator(ctx context.Context, db sql.DB, validator []byte, power int64) error {
+	return setVoterPower(ctx, db, validator, power)
 }
 
 // SubscribeValidators creates and returns a new channel on which the current
@@ -316,33 +181,9 @@ func (r *TxApp) announceValidators() {
 	}
 }
 
-// ConsensusValidators gets the current validator set from the database. It will
-// use the active write transaction if it exists (meaning it is called from
-// FinalizeBlock, etc. between Commit and Begin), otherwise it uses a reserved
-// reader connection to avoid contention with user requests.
-func (r *TxApp) ConsensusValidators(ctx context.Context) ([]*types.Validator, error) {
-	// NOTE: this method is meant ONLY for use from methods on ABCI's consensus
-	// connection, which ensures no use (no data race on r.currentTx).
-	var tx sql.Executor
-	if r.currentTx == nil { // coming from PrepareProposal / ProcessProposal, which does not happen presently
-		rtx, err := r.Database.BeginReservedReadTx(ctx)
-		if err != nil {
-			return nil, err
-		}
-		defer rtx.Rollback(ctx)
-		tx = rtx
-	} else { // coming from FinalizeBlock
-		tx = r.currentTx
-		// We're not making a nested tx since an error in the consensus thread
-		// will halt the node (and rollback) anyway.
-	}
-
-	return getAllVoters(ctx, tx)
-}
-
 // GetValidators returns a shallow copy of the current validator set.
 // It will return ONLY committed changes.
-func (r *TxApp) GetValidators(ctx context.Context) ([]*types.Validator, error) {
+func (r *TxApp) GetValidators(ctx context.Context, db sql.DB) ([]*types.Validator, error) {
 	r.valMtx.Lock()
 	defer r.valMtx.Unlock()
 
@@ -351,15 +192,20 @@ func (r *TxApp) GetValidators(ctx context.Context) ([]*types.Validator, error) {
 		return slices.Clone(r.validators), nil
 	}
 
-	// otherwise, we need to get the validator set from the database
-	// This is done especially when a node restarts
-	readTx, err := r.Database.BeginReadTx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer readTx.Rollback(ctx) // always rollback read tx
 	// NOTE: we aren't saving this to r.validators, leaving that to next FinalizeBlock. We could though...
-	return getAllVoters(ctx, readTx)
+	return getAllVoters(ctx, db)
+}
+
+// CachedValidators returns the current validator set that is cached, and whether or not it is valid.
+// This can be used by TxApp consumers to try to get a validator set without hitting the database.
+func (r *TxApp) CachedValidators() ([]*types.Validator, bool) {
+	r.valMtx.RLock()
+	defer r.valMtx.RUnlock()
+	if r.validators == nil {
+		return nil, false
+	}
+
+	return slices.Clone(r.validators), true
 }
 
 func validatorSetPower(validators []*types.Validator) int64 {
@@ -384,7 +230,7 @@ func (r *TxApp) validatorSetPower(ctx context.Context, tx sql.Executor) (int64, 
 // appropriate module(s) and return the response. This method must only be
 // called from the consensus engine, sequentially, when executing transactions
 // in a block.
-func (r *TxApp) Execute(ctx TxContext, tx *transactions.Transaction) *TxResponse {
+func (r *TxApp) Execute(ctx TxContext, db sql.DB, tx *transactions.Transaction) *TxResponse {
 	route, ok := routes[tx.Body.PayloadType.String()] // and RegisterRoute call is not concurrent
 	if !ok {
 		return txRes(nil, transactions.CodeInvalidTxType, fmt.Errorf("unknown payload type: %s", tx.Body.PayloadType.String()))
@@ -392,11 +238,7 @@ func (r *TxApp) Execute(ctx TxContext, tx *transactions.Transaction) *TxResponse
 
 	r.log.Debug("executing transaction", log.Any("tx", tx))
 
-	if r.currentTx == nil {
-		return txRes(nil, transactions.CodeUnknownError, errors.New("txapp misuse: cannot execute a blockchain transaction without a db transaction in progress"))
-	}
-
-	return route.Execute(ctx, r, tx)
+	return route.Execute(ctx, r, db, tx)
 }
 
 // Begin signals that a new block has begun. This creates an outer database
@@ -404,17 +246,8 @@ func (r *TxApp) Execute(ctx TxContext, tx *transactions.Transaction) *TxResponse
 // It is given the starting networkParams, and is expected to use them to
 // use them to store any changes to the network parameters in the database during Finalize.
 func (r *TxApp) Begin(ctx context.Context, height int64) error {
-	if r.currentTx != nil {
-		return errors.New("txapp misuse: cannot begin a new block while a transaction is in progress")
-	}
-
-	if r.genesisTx != nil {
-		r.currentTx = r.genesisTx
-		return nil
-	}
-
 	// Before executing transaction in this block, add/remove/update functionality.
-	forks := r.Activations(height)
+	forks := r.activations(height)
 	if len(forks) > 0 {
 		r.log.Infof("Forks activating at height %d: %v", height, len(forks))
 	}
@@ -442,20 +275,13 @@ func (r *TxApp) Begin(ctx context.Context, height int64) error {
 		}
 	}
 
-	tx, err := r.Database.BeginOuterTx(ctx)
-	if err != nil {
-		return err
-	}
-
-	r.currentTx = tx
-
 	return nil
 }
 
 // Activations consults chain config for the names of hard forks that activate
 // *at* the given block height, and retrieves the associated changes from the
 // consensus package that contains the canonical and extended fork definitions.
-func (r *TxApp) Activations(height int64) []*consensus.Hardfork {
+func (r *TxApp) activations(height int64) []*consensus.Hardfork {
 	var activations []*consensus.Hardfork
 	activationNames := r.forks.ActivatesAt(uint64(height)) // chain.Forks.ActivatesAt()
 	for _, name := range activationNames {
@@ -474,44 +300,21 @@ func (r *TxApp) Activations(height int64) []*consensus.Hardfork {
 // state modifications specified by hardforks activating at this height are
 // applied. It is given the old and new network parameters, and is expected to
 // use them to store any changes to the network parameters in the database.
-func (r *TxApp) Finalize(ctx context.Context, blockHeight int64, oldNetworkParams, newNetworkParams *common.NetworkParameters) (appHash []byte, finalValidators []*types.Validator, err error) {
-	if r.currentTx == nil {
-		return nil, nil, errors.New("txapp misuse: cannot finalize a block without a transaction in progress")
-	}
-
-	defer func() {
-		if err != nil {
-			err2 := r.currentTx.Rollback(ctx)
-			r.currentTx = nil
-			if err2 != nil {
-				err = fmt.Errorf("error rolling back transaction: %s, error: %s", err.Error(), err2.Error())
-			}
-
-			return
-		}
-	}()
-
-	r.log.Debug("Finalize(start)", log.Int("height", r.height), log.String("appHash", hex.EncodeToString(r.appHash)))
-
-	// Check that the block height is correct
-	if blockHeight != r.height+1 {
-		return nil, nil, fmt.Errorf("Finalize was expecting height %d, got %d", r.height+1, blockHeight)
-	}
-
-	err = r.processVotes(ctx, blockHeight)
+func (r *TxApp) Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators []*types.Validator, err error) {
+	err = r.processVotes(ctx, db, block)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
-	finalValidators, err = getAllVoters(ctx, r.currentTx)
+	finalValidators, err = getAllVoters(ctx, db)
 	if err != nil {
-		return nil, nil, err
+		return nil, err
 	}
 
 	// Execute state modifications for the hard forks that activate at this
 	// height. These changes are associated with other consensus logic or
 	// parameters changes, otherwise a resolution might be more sensible.
-	for _, fork := range r.Activations(blockHeight) {
+	for _, fork := range r.activations(block.Height) {
 		if fork.StateMod == nil {
 			continue
 		}
@@ -521,49 +324,23 @@ func (r *TxApp) Finalize(ctx context.Context, blockHeight int64, oldNetworkParam
 				Logger:           r.log.Sugar(),
 				ExtensionConfigs: r.extensionConfigs,
 			},
-			DB:     r.currentTx,
+			DB:     db,
 			Engine: r.Engine,
 		}); err != nil {
-			return nil, nil, err
+			return nil, err
 		}
 	}
-
-	// While still in the DB transaction, update to this next height but dummy
-	// app hash. If we crash before Commit can store the next app hash that we
-	// get after Precommit, the startup handshake's call to Info will detect the
-	// mismatch. That requires manual recovery (drop state and reapply), but it
-	// at least detects this recorded height rather than not recognizing that we
-	// have committed the data for this block at all.
-	err = setChainState(ctx, r.currentTx, blockHeight, []byte{0x42})
-	if err != nil {
-		return nil, nil, err
-	}
-
-	err = storeDiff(ctx, r.currentTx, oldNetworkParams, newNetworkParams)
-
-	engineHash, err := r.currentTx.Precommit(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	r.appHash = crypto.Sha256(append(r.appHash, engineHash...))
-	r.height = blockHeight
 
 	r.valMtx.Lock()
 	r.validators = finalValidators
 	r.valMtx.Unlock()
 
-	r.log.Debug("Finalize(end)", log.Int("height", r.height), log.String("appHash", hex.EncodeToString(r.appHash)))
-
-	// I'd really like to setChainState here with appHash, but we can't use
-	// currentTx for anything now except Commit.
-
-	return r.appHash, finalValidators, nil
+	return finalValidators, nil
 }
 
 // processVotes confirms resolutions that have been approved by the network,
 // expires resolutions that have expired, and properly credits proposers and voters.
-func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
+func (r *TxApp) processVotes(ctx context.Context, db sql.DB, block *common.BlockContext) error {
 	credits := make(creditMap)
 
 	var finalizedIDs []*types.UUID
@@ -576,10 +353,10 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 	// for subsequent resolutions in the same block, which should not happen.
 	var resolveFuncs []*struct {
 		Resolution  *resolutions.Resolution
-		ResolveFunc func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error
+		ResolveFunc func(ctx context.Context, app *common.App, resolution *resolutions.Resolution, block *common.BlockContext) error
 	}
 
-	totalPower, err := r.validatorSetPower(ctx, r.currentTx)
+	totalPower, err := r.validatorSetPower(ctx, db)
 	if err != nil {
 		return err
 	}
@@ -590,7 +367,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 			return err
 		}
 
-		finalized, err := getResolutionsByThresholdAndType(ctx, r.currentTx, cfg.ConfirmationThreshold, resolutionType, totalPower)
+		finalized, err := getResolutionsByThresholdAndType(ctx, db, cfg.ConfirmationThreshold, resolutionType, totalPower)
 		if err != nil {
 			return err
 		}
@@ -606,7 +383,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 
 			resolveFuncs = append(resolveFuncs, &struct {
 				Resolution  *resolutions.Resolution
-				ResolveFunc func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error
+				ResolveFunc func(ctx context.Context, app *common.App, resolution *resolutions.Resolution, block *common.BlockContext) error
 			}{
 				Resolution:  resolution,
 				ResolveFunc: cfg.ResolveFunc,
@@ -618,7 +395,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 	for _, resolveFunc := range resolveFuncs {
 		r.log.Debug("resolving resolution", log.String("type", resolveFunc.Resolution.Type), log.String("id", resolveFunc.Resolution.ID.String()))
 
-		tx, err := r.currentTx.BeginTx(ctx)
+		tx, err := db.BeginTx(ctx)
 		if err != nil {
 			return err
 		}
@@ -630,7 +407,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 			},
 			DB:     tx,
 			Engine: r.Engine,
-		}, resolveFunc.Resolution)
+		}, resolveFunc.Resolution, block)
 		if err != nil {
 			err2 := tx.Rollback(ctx)
 			if err2 != nil {
@@ -650,7 +427,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 	}
 
 	// now we will expire resolutions
-	expired, err := getExpired(ctx, r.currentTx, blockHeight)
+	expired, err := getExpired(ctx, db, block.Height)
 	if err != nil {
 		return err
 	}
@@ -671,7 +448,7 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 			}
 
 			// we need to use each configured resolutions refund threshold
-			requiredPowerMap[resolution.Type] = requiredPower(ctx, r.currentTx, cfg.RefundThreshold, totalPower)
+			requiredPowerMap[resolution.Type] = requiredPower(ctx, db, cfg.RefundThreshold, totalPower)
 		}
 		// if it has enough power, we will still refund
 		refunded := resolution.ApprovedPower >= threshold
@@ -684,12 +461,12 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 	}
 
 	allIDs := append(finalizedIDs, expiredIDs...)
-	err = deleteResolutions(ctx, r.currentTx, allIDs...)
+	err = deleteResolutions(ctx, db, allIDs...)
 	if err != nil {
 		return err
 	}
 
-	err = markProcessed(ctx, r.currentTx, markProcessedIDs...)
+	err = markProcessed(ctx, db, markProcessedIDs...)
 	if err != nil {
 		return err
 	}
@@ -698,15 +475,16 @@ func (r *TxApp) processVotes(ctx context.Context, blockHeight int64) error {
 	// per block vote sizes, they never get to vote and essentially delete the event
 	// So this is handled instead when the nodes are approved.
 	// TODO: We need to figure out the consequences of resolutions getting expired due to the vote limits set per block. There can be scenarios where the events are observed by the nodes, but before they can vote, the event gets expired. rare but possible in the situations with higher event traffic.
-	err = deleteEvents(ctx, r.currentTx, markProcessedIDs...)
+	err = deleteEvents(ctx, db, markProcessedIDs...)
 	if err != nil {
 		return err
 	}
 
-	// now we will apply credits if gas is enabled
+	// now we will apply credits if gas is enabled.
+	// Since it is a map, we need to order it for deterministic results.
 	if r.GasEnabled {
-		for pubKey, amount := range credits {
-			err = credit(ctx, r.currentTx, []byte(pubKey), amount)
+		for _, kv := range order.OrderMap(credits) {
+			err = credit(ctx, db, []byte(kv.Key), kv.Value)
 			if err != nil {
 				return err
 			}
@@ -755,129 +533,30 @@ func (c creditMap) applyResolution(res *resolutions.Resolution) {
 }
 
 // Commit signals that a block's state changes should be committed.
-func (r *TxApp) Commit(ctx context.Context) (int64, error) {
-	if r.currentTx == nil {
-		return 0, errors.New("txapp misuse: cannot commit a block without a transaction in progress")
-	}
-	defer r.mempool.reset()
-
-	// r.log.Debug("Commit(start)", log.Int("height", r.height), log.String("appHash", hex.EncodeToString(r.appHash)))
-
-	err := r.currentTx.Commit(ctx)
-	if err != nil {
-		return 0, err
-	}
-
-	r.currentTx = nil
-	r.genesisTx = nil
-
-	// Now we can store the app hash computed in FinalizeBlock after Precommit.
-	// Note that if we crash here, Info on startup will immediately detect an
-	// unexpected app hash since we've saved this height in the Commit above.
-	// While this takes manual recovery, it does not go undetected as if we had
-	// not updated to the new height in that Commit. We could improve this with
-	// some refactoring to pg.DB to allow multiple simultaneous uncommitted
-	// prepared transactions to make this an actual two-phase commit, but it is
-	// just a single row so the difference is minor.
-	ctx = context.Background() // don't let them cancel us now, we need consistency with consensus tx commit
-	tx, err := r.Database.BeginOuterTx(ctx)
-	if err != nil {
-		return 0, err
-	}
-	defer tx.Rollback(ctx)
-
-	err = setChainState(ctx, tx, r.height, r.appHash) // unchanged height, known appHash
-	if err != nil {
-		return 0, err
-	}
-
-	err = tx.Commit(ctx) // no Precommit for this one
-	if err != nil {
-		return 0, err
-	}
-
+func (r *TxApp) Commit(ctx context.Context) {
 	r.announceValidators()
-
-	// Take a snapshot of the database if node is not in the catchup mode and snapshots are enabled
-	if r.snapshotter != nil && r.replayStatusFn != nil &&
-		r.snapshotter.IsSnapshotDue(uint64(r.height)) && !r.replayStatusFn() {
-		err = r.snapshotDatabase(ctx)
-		if err != nil {
-			return 0, err
-		}
-	}
-	return r.height, nil
-}
-
-func (r *TxApp) snapshotDatabase(ctx context.Context) error {
-	snapTx, snapshotID, err := r.Database.BeginSnapshotTx(ctx)
-	if err != nil {
-		return err
-	}
-	defer snapTx.Rollback(ctx)
-
-	err = r.snapshotter.CreateSnapshot(ctx, uint64(r.height), snapshotID)
-	if err != nil {
-		r.log.Error("failed to dump logical snapshot", log.Error(err))
-	}
-
-	r.log.Info("Snapshot created successfully", log.Int("height", r.height))
-
-	return nil
+	r.mempool.reset()
 }
 
 // ApplyMempool applies the transactions in the mempool.
 // If it returns an error, then the transaction is invalid.
-func (r *TxApp) ApplyMempool(ctx context.Context, tx *transactions.Transaction) error {
+func (r *TxApp) ApplyMempool(ctx context.Context, db sql.DB, tx *transactions.Transaction) error {
 	// check that payload type is valid
 	if getRoute(tx.Body.PayloadType.String()) == nil {
 		return fmt.Errorf("unknown payload type: %s", tx.Body.PayloadType.String())
 	}
-	readTx, err := r.Database.BeginReadTx(ctx)
-	if err != nil {
-		return err
-	}
-	defer readTx.Rollback(ctx) // always rollback read tx
 
-	return r.mempool.applyTransaction(ctx, tx, readTx, r.events)
-}
-
-func (r *TxApp) ConsensusAccountInfo(ctx context.Context, acctID []byte) (balance *big.Int, nonce int64, err error) {
-	// NOTE: this method is meant ONLY for use from methods on ABCI's consensus
-	// connection, which ensures no use (no data race on r.currentTx).
-	var tx sql.Executor
-	if r.currentTx == nil { // coming from PrepareProposal / ProcessProposal, which is always the case presently
-		rtx, err := r.Database.BeginReservedReadTx(ctx)
-		if err != nil {
-			return nil, 0, err
-		}
-		defer rtx.Rollback(ctx)
-		tx = rtx
-	} else { // coming from FinalizeBlock
-		tx = r.currentTx
-	}
-
-	acct, err := getAccount(ctx, tx, acctID)
-	if err != nil {
-		return nil, 0, err
-	}
-	return acct.Balance, acct.Nonce, nil
+	return r.mempool.applyTransaction(ctx, tx, db, r.events)
 }
 
 // AccountInfo gets account info from either the mempool or the account store.
 // It takes a flag to indicate whether it should check the mempool first.
-func (r *TxApp) AccountInfo(ctx context.Context, acctID []byte, getUnconfirmed bool) (balance *big.Int, nonce int64, err error) {
-	readTx, err := r.Database.BeginReadTx(ctx)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer readTx.Rollback(ctx) // always rollback read tx
-
+func (r *TxApp) AccountInfo(ctx context.Context, db sql.DB, acctID []byte, getUnconfirmed bool) (balance *big.Int, nonce int64, err error) {
 	var a *types.Account
 	if getUnconfirmed {
-		a, err = r.mempool.accountInfoSafe(ctx, readTx, acctID)
+		a, err = r.mempool.accountInfoSafe(ctx, db, acctID)
 	} else {
-		a, err = getAccount(ctx, readTx, acctID)
+		a, err = getAccount(ctx, db, acctID)
 	}
 	if err != nil {
 		return nil, 0, err
@@ -893,14 +572,8 @@ func (r *TxApp) AccountInfo(ctx context.Context, acctID []byte, getUnconfirmed b
 // largest nonce of the transactions included in the block that are authored by the proposer.
 // This transaction only includes voteBodies for events whose bodies have not been received by the network.
 // Therefore, there won't be more than 1 VoteBody transaction per event.
-func (r *TxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxsSize int64, proposerAddr []byte) ([][]byte, error) {
-	readTx, err := r.Database.BeginReservedReadTx(ctx)
-	if err != nil {
-		return nil, err
-	}
-	defer readTx.Rollback(ctx) // always rollback read tx
-
-	acct, err := getAccount(ctx, readTx, proposerAddr)
+func (r *TxApp) ProposerTxs(ctx context.Context, db sql.DB, txNonce uint64, maxTxsSize int64, block *common.BlockContext) ([][]byte, error) {
+	acct, err := getAccount(ctx, db, block.Proposer)
 	if err != nil {
 		return nil, err
 	}
@@ -916,7 +589,7 @@ func (r *TxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxsSize int6
 	}
 
 	maxTxsSize -= r.emptyVoteBodyTxSize + 1000 // empty payload size + 1000 safety buffer
-	events, err := getEvents(ctx, readTx)
+	events, err := getEvents(ctx, db)
 	if err != nil {
 		return nil, err
 	}
@@ -973,7 +646,7 @@ func (r *TxApp) ProposerTxs(ctx context.Context, txNonce uint64, maxTxsSize int6
 	}
 
 	// Fee Estimate
-	amt, err := r.Price(ctx, tx)
+	amt, err := r.Price(ctx, db, tx)
 	if err != nil {
 		return nil, err
 	}
@@ -1032,7 +705,7 @@ type TxResponse struct {
 
 // Price estimates the price of a transaction.
 // It returns the estimated price in tokens.
-func (r *TxApp) Price(ctx context.Context, tx *transactions.Transaction) (*big.Int, error) {
+func (r *TxApp) Price(ctx context.Context, dbTx sql.DB, tx *transactions.Transaction) (*big.Int, error) {
 	if !r.GasEnabled {
 		return big.NewInt(0), nil
 	}
@@ -1042,7 +715,7 @@ func (r *TxApp) Price(ctx context.Context, tx *transactions.Transaction) (*big.I
 		return nil, fmt.Errorf("unknown payload type: %s", tx.Body.PayloadType.String())
 	}
 
-	return route.Price(ctx, r, tx)
+	return route.Price(ctx, r, dbTx, tx)
 }
 
 // checkAndSpend checks the price of a transaction.
@@ -1057,12 +730,12 @@ func (r *TxApp) Price(ctx context.Context, tx *transactions.Transaction) (*big.I
 // It also returns an error code.
 // if we allow users to implement their own routes, this function will need to
 // be exported.
-func (r *TxApp) checkAndSpend(ctx TxContext, tx *transactions.Transaction, pricer Pricer, dbTx sql.Executor) (*big.Int, transactions.TxCode, error) {
+func (r *TxApp) checkAndSpend(ctx TxContext, tx *transactions.Transaction, pricer Pricer, dbTx sql.DB) (*big.Int, transactions.TxCode, error) {
 	amt := big.NewInt(0)
 	var err error
 
 	if r.GasEnabled {
-		amt, err = pricer.Price(ctx.Ctx, r, tx)
+		amt, err = pricer.Price(ctx.Ctx, r, dbTx, tx)
 		if err != nil {
 			return nil, transactions.CodeUnknownError, err
 		}
@@ -1162,43 +835,4 @@ func computeEmptyVoteBodyTxSize(chainID string) (int64, error) {
 		return 0, err
 	}
 	return int64(len(sz)), nil
-}
-
-type ReplayStatusChecker func() bool
-
-// SetreplayStatusChecker sets the function to check if the node is in replay mode
-func (r *TxApp) SetReplayStatusChecker(fn ReplayStatusChecker) {
-	r.replayStatusFn = fn
-}
-
-// NetworkParams returns the network parameters for the current block height.
-func (r *TxApp) NetworkParams(ctx context.Context) (*common.NetworkParameters, error) {
-	readTx, err := r.Database.BeginReadTx(ctx)
-	if err != nil {
-		return nil, err
-	}
-
-	params, err := loadParams(ctx, readTx)
-	if err != nil {
-		return nil, err
-	}
-
-	return params, nil
-}
-
-// StoreNetworkParams stores the consensus parameters in the database.
-// It should be called when the node is started. It will make and commit
-// a transaction to store the parameters.
-func (r *TxApp) StoreNetworkParams(ctx context.Context, params *common.NetworkParameters) error {
-	tx, err := r.Database.BeginOuterTx(ctx)
-	if err != nil {
-		return err
-	}
-
-	err = storeParams(ctx, tx, params)
-	if err != nil {
-		return errors.Join(err, tx.Rollback(ctx))
-	}
-
-	return tx.Commit(ctx)
 }

--- a/internal/voting/validators.go
+++ b/internal/voting/validators.go
@@ -20,7 +20,7 @@ const (
 func init() {
 	err := resolutions.RegisterResolution(ValidatorJoinEventType, resolutions.ModAdd, resolutions.ResolutionConfig{
 		ConfirmationThreshold: big.NewRat(2, 3),
-		ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error {
+		ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution, block *common.BlockContext) error {
 			joinReq := &UpdatePowerRequest{}
 			if err := joinReq.UnmarshalBinary(resolution.Body); err != nil {
 				return fmt.Errorf("failed to unmarshal join request: %w", err)
@@ -35,7 +35,7 @@ func init() {
 
 	err = resolutions.RegisterResolution(ValidatorRemoveEventType, resolutions.ModAdd, resolutions.ResolutionConfig{
 		ConfirmationThreshold: big.NewRat(2, 3),
-		ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error {
+		ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution, block *common.BlockContext) error {
 			removeReq := &UpdatePowerRequest{}
 			if err := removeReq.UnmarshalBinary(resolution.Body); err != nil {
 				return fmt.Errorf("failed to unmarshal remove request: %w", err)

--- a/test/nodes/spamd/resoln.go
+++ b/test/nodes/spamd/resoln.go
@@ -10,7 +10,7 @@ import (
 func init() {
 	// Register a resolution
 	err := resolutions.RegisterResolution("spam-resolution", resolutions.ModAdd, resolutions.ResolutionConfig{
-		ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution) error {
+		ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution, block *common.BlockContext) error {
 			// This is where the resolution logic goes
 			app.Service.Logger.Info("Spam resolution logic approved")
 			return nil


### PR DESCRIPTION
This adds a separate consensus params struct that is used to persist Kwil specific consensus params. I am going to use this struct in the migrations PR, which will allow us to change these values.

As an aside, this PR was really really messy to make, somewhat unnecessarily. I think it would be way better if we managed the db and transaction creation in ABCI, rather than TxApp. It seems like we do a lot of hacking around this, and it has made the entire thing pretty confusing.