### PR TITLE
add foreign caller

### DIFF
--- a/cmd/kwil-cli/cmds/utils/parse.go
+++ b/cmd/kwil-cli/cmds/utils/parse.go
@@ -179,7 +179,7 @@ func generateAll(schema *types.Schema) *genResult {
 	}
 
 	for _, proc := range schema.ForeignProcedures {
-		r.ForeignProcedures[proc.Name], err = generate.GenerateForeignProcedure(proc, schema.Name)
+		r.ForeignProcedures[proc.Name], err = generate.GenerateForeignProcedure(proc, schema.Name, schema.DBID())
 		if err != nil {
 			r.Errors = append(r.Errors, wrapErr("foreign procedure "+proc.Name, err))
 		}

--- a/internal/engine/generate/foreign_procedure.go
+++ b/internal/engine/generate/foreign_procedure.go
@@ -241,9 +241,7 @@ func GenerateForeignProcedure(proc *types.ForeignProcedure, pgSchema string, dbi
 
 	// set the foreign caller back to what it was
 	str.WriteString(`;`)
-	// this is a hack, since simply running SET LOCAL ctx.foreign_caller = __old_foreign_caller
-	// will set it to the string "__old_foreign_caller", not the value of the variable.
-	str.WriteString(`EXECUTE 'SET LOCAL ctx.foreign_caller = ' || quote_literal(__old_foreign_caller);`)
+	str.WriteString(`PERFORM set_config('ctx.foreign_caller', __old_foreign_caller, true);`)
 
 	// end block
 	str.WriteString(` END; $$ LANGUAGE plpgsql;`)

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -439,139 +439,139 @@ func Test_ForeignProcedures(t *testing.T) {
 	}
 
 	tests := []testcase{
+		{
+			name:    "foreign procedure takes nothing, returns nothing",
+			foreign: `foreign procedure do_something()`,
+			otherProc: `procedure call_foreign() public {
+				do_something['%s', 'delete_users']();
+			}`,
+		},
+		{
+			name:    "foreign procedure takes nothing, returns table",
+			foreign: `foreign procedure get_users() returns table(id uuid, name text, wallet_address text)`,
+			otherProc: `procedure call_foreign() public returns table(username text) {
+				return select name as username from get_users['%s', 'get_users']();
+			}`,
+			outputs: [][]any{
+				{"satoshi"},
+				{"wendys_drive_through_lady"},
+				{"zeus"},
+			},
+		},
+		{
+			name:    "foreign procedure takes values, returns values",
+			foreign: `foreign procedure id_from_name($name text) returns (id uuid)`,
+			otherProc: `procedure call_foreign($name text) public returns (id uuid) {
+				return id_from_name['%s', 'id_from_name']($name);
+			}`,
+			inputs:  []any{"satoshi"},
+			outputs: [][]any{{satoshisUUID}},
+		},
+		{
+			name:    "foreign procedure expects no args, implementation expects some",
+			foreign: `foreign procedure id_from_name() returns (id uuid)`,
+			otherProc: `procedure call_foreign() public returns (id uuid) {
+				return id_from_name['%s', 'id_from_name']();
+			}`,
+			wantErr: `requires 1 arg(s)`,
+		},
+		{
+			name:    "foreign procedure expects args, implementation expects none",
+			foreign: `foreign procedure get_users($name text) returns table(id uuid, name text, wallet_address text)`,
+			otherProc: `procedure call_foreign() public returns table(username text) {
+				return select name as username from get_users['%s', 'get_users']('satoshi');
+			}`,
+			wantErr: "requires no args",
+		},
+		{
+			name:    "foreign procedure expects 2 args, implementation expects 2",
+			foreign: `foreign procedure id_from_name($name text, $name2 text) returns (id uuid)`,
+			otherProc: `procedure call_foreign() public returns (id uuid) {
+				return id_from_name['%s', 'id_from_name']('satoshi', 'zeus');
+			}`,
+			wantErr: "requires 1 arg(s)",
+		},
+		{
+			name:    "foreign procedure returns 1 arg, implementation returns none",
+			foreign: `foreign procedure delete_users() returns (text)`,
+			otherProc: `procedure call_foreign() public returns (text) {
+				return delete_users['%s', 'delete_users']();
+			}`,
+			wantErr: "returns nothing",
+		},
+		{
+			name:    "foreign procedure returns 0 args, implementation returns 1",
+			foreign: `foreign procedure id_from_name($name text)`,
+			otherProc: `procedure call_foreign() public {
+				id_from_name['%s', 'id_from_name']('satoshi');
+			}`,
+			wantErr: "returns non-nil value(s)",
+		},
+		{
+			name:    "foreign procedure returns table, implementation returns non-table",
+			foreign: `foreign procedure id_from_name($name text) returns table(id uuid)`,
+			otherProc: `procedure call_foreign() public {
+				select id from id_from_name['%s', 'id_from_name']('satoshi');
+			}`,
+			wantErr: "does not return a table",
+		},
+		{
+			name:    "foreign procedure does not return table, implementation returns table",
+			foreign: `foreign procedure get_users() returns (id uuid, name text, wallet_address text)`,
+			otherProc: `procedure call_foreign() public returns table(username text) {
+				$id, $name, $wallet := get_users['%s', 'get_users']();
+			}`,
+			wantErr: "returns a table",
+		},
+		{
+			name:    "foreign procedure returns table, implementation returns nothing",
+			foreign: `foreign procedure create_user($name text) returns table(id uuid)`,
+			otherProc: `procedure call_foreign() public {
+				create_user['%s', 'create_user']('satoshi');
+			}`,
+			wantErr: "does not return a table",
+		},
+		{
+			name: "procedures returning scalar return different named values (ok)",
+			// returns value "uid" instead of impl's "id"
+			foreign: `foreign procedure id_from_name($name text) returns (uid uuid)`,
+			otherProc: `procedure call_foreign() public returns (id uuid) {
+				return id_from_name['%s', 'id_from_name']('satoshi');
+			}`,
+			outputs: [][]any{{satoshisUUID}},
+		},
+		{
+			name:    "procedure returning table return different column names (failure)",
+			foreign: `foreign procedure get_users() returns table(uid uuid, name text, wallet_address text)`,
+			otherProc: `procedure call_foreign() public returns table(name text) {
+				return select name from get_users['%s', 'get_users']();
+			}`,
+			wantErr: "returns id",
+		},
+		{
+			name:    "private procedure via foreign call",
+			foreign: `foreign procedure is_private($name text)`,
+			otherProc: `procedure call_foreign() public {
+				is_private['%s', 'is_private']('satoshi');
+			}`,
+			wantErr: "not public",
+		},
 		// {
-		// 	name:    "foreign procedure takes nothing, returns nothing",
-		// 	foreign: `foreign procedure do_something()`,
-		// 	otherProc: `procedure call_foreign() public {
-		// 		do_something['%s', 'delete_users']();
-		// 	}`,
-		// },
-		// {
-		// 	name:    "foreign procedure takes nothing, returns table",
-		// 	foreign: `foreign procedure get_users() returns table(id uuid, name text, wallet_address text)`,
-		// 	otherProc: `procedure call_foreign() public returns table(username text) {
-		// 		return select name as username from get_users['%s', 'get_users']();
-		// 	}`,
-		// 	outputs: [][]any{
-		// 		{"satoshi"},
-		// 		{"wendys_drive_through_lady"},
-		// 		{"zeus"},
-		// 	},
-		// },
-		// {
-		// 	name:    "foreign procedure takes values, returns values",
-		// 	foreign: `foreign procedure id_from_name($name text) returns (id uuid)`,
-		// 	otherProc: `procedure call_foreign($name text) public returns (id uuid) {
-		// 		return id_from_name['%s', 'id_from_name']($name);
-		// 	}`,
-		// 	inputs:  []any{"satoshi"},
-		// 	outputs: [][]any{{satoshisUUID}},
-		// },
-		// {
-		// 	name:    "foreign procedure expects no args, implementation expects some",
-		// 	foreign: `foreign procedure id_from_name() returns (id uuid)`,
-		// 	otherProc: `procedure call_foreign() public returns (id uuid) {
-		// 		return id_from_name['%s', 'id_from_name']();
-		// 	}`,
-		// 	wantErr: `requires 1 arg(s)`,
-		// },
-		// {
-		// 	name:    "foreign procedure expects args, implementation expects none",
-		// 	foreign: `foreign procedure get_users($name text) returns table(id uuid, name text, wallet_address text)`,
-		// 	otherProc: `procedure call_foreign() public returns table(username text) {
-		// 		return select name as username from get_users['%s', 'get_users']('satoshi');
-		// 	}`,
-		// 	wantErr: "requires no args",
-		// },
-		// {
-		// 	name:    "foreign procedure expects 2 args, implementation expects 2",
-		// 	foreign: `foreign procedure id_from_name($name text, $name2 text) returns (id uuid)`,
-		// 	otherProc: `procedure call_foreign() public returns (id uuid) {
-		// 		return id_from_name['%s', 'id_from_name']('satoshi', 'zeus');
-		// 	}`,
-		// 	wantErr: "requires 1 arg(s)",
-		// },
-		// {
-		// 	name:    "foreign procedure returns 1 arg, implementation returns none",
-		// 	foreign: `foreign procedure delete_users() returns (text)`,
-		// 	otherProc: `procedure call_foreign() public returns (text) {
-		// 		return delete_users['%s', 'delete_users']();
-		// 	}`,
-		// 	wantErr: "returns nothing",
-		// },
-		// {
-		// 	name:    "foreign procedure returns 0 args, implementation returns 1",
-		// 	foreign: `foreign procedure id_from_name($name text)`,
-		// 	otherProc: `procedure call_foreign() public {
-		// 		id_from_name['%s', 'id_from_name']('satoshi');
-		// 	}`,
-		// 	wantErr: "returns non-nil value(s)",
-		// },
-		// {
-		// 	name:    "foreign procedure returns table, implementation returns non-table",
-		// 	foreign: `foreign procedure id_from_name($name text) returns table(id uuid)`,
-		// 	otherProc: `procedure call_foreign() public {
-		// 		select id from id_from_name['%s', 'id_from_name']('satoshi');
-		// 	}`,
-		// 	wantErr: "does not return a table",
-		// },
-		// {
-		// 	name:    "foreign procedure does not return table, implementation returns table",
-		// 	foreign: `foreign procedure get_users() returns (id uuid, name text, wallet_address text)`,
-		// 	otherProc: `procedure call_foreign() public returns table(username text) {
-		// 		$id, $name, $wallet := get_users['%s', 'get_users']();
-		// 	}`,
-		// 	wantErr: "returns a table",
-		// },
-		// {
-		// 	name:    "foreign procedure returns table, implementation returns nothing",
-		// 	foreign: `foreign procedure create_user($name text) returns table(id uuid)`,
-		// 	otherProc: `procedure call_foreign() public {
-		// 		create_user['%s', 'create_user']('satoshi');
-		// 	}`,
-		// 	wantErr: "does not return a table",
-		// },
-		// {
-		// 	name: "procedures returning scalar return different named values (ok)",
-		// 	// returns value "uid" instead of impl's "id"
-		// 	foreign: `foreign procedure id_from_name($name text) returns (uid uuid)`,
-		// 	otherProc: `procedure call_foreign() public returns (id uuid) {
-		// 		return id_from_name['%s', 'id_from_name']('satoshi');
-		// 	}`,
-		// 	outputs: [][]any{{satoshisUUID}},
-		// },
-		// {
-		// 	name:    "procedure returning table return different column names (failure)",
-		// 	foreign: `foreign procedure get_users() returns table(uid uuid, name text, wallet_address text)`,
-		// 	otherProc: `procedure call_foreign() public returns table(name text) {
-		// 		return select name from get_users['%s', 'get_users']();
-		// 	}`,
-		// 	wantErr: "returns id",
-		// },
-		// {
-		// 	name:    "private procedure via foreign call",
-		// 	foreign: `foreign procedure is_private($name text)`,
-		// 	otherProc: `procedure call_foreign() public {
-		// 		is_private['%s', 'is_private']('satoshi');
-		// 	}`,
-		// 	wantErr: "not public",
-		// },
-		// // {
-		// // 	name:    "foreign call owner - fail",
-		// // 	foreign: `foreign procedure is_owner($name text)`,
-		// // 	otherProc: `procedure call_foreign() public owner {
-		// // 		is_owner['%s', 'is_owner']('satoshi');
-		// // 	}`,
-		// // 	caller:  "some_other_wallet",
-		// // 	wantErr: "is owner-only",
-		// // },
-		// {
-		// 	name:    "foreign call owner - success",
+		// 	name:    "foreign call owner - fail",
 		// 	foreign: `foreign procedure is_owner($name text)`,
 		// 	otherProc: `procedure call_foreign() public owner {
 		// 		is_owner['%s', 'is_owner']('satoshi');
 		// 	}`,
+		// 	caller:  "some_other_wallet",
+		// 	wantErr: "is owner-only",
 		// },
+		{
+			name:    "foreign call owner - success",
+			foreign: `foreign procedure is_owner($name text)`,
+			otherProc: `procedure call_foreign() public owner {
+				is_owner['%s', 'is_owner']('satoshi');
+			}`,
+		},
 		// this test tests that foreign caller properly works, and is unset at the end of the
 		// foreign call.
 		{

--- a/parse/contextual.go
+++ b/parse/contextual.go
@@ -13,13 +13,16 @@ var (
 	SignerVar = "signer"
 	// height is the session variable for the block height.
 	HeightVar = "height"
+	// foreign_caller is the dbid of the schema that made a foreign call.
+	ForeignCaller = "foreign_caller"
 	// SessionVars are the session variables that are available in the engine.
 	// It maps the variable name to its type.
 	SessionVars = map[string]*types.DataType{
-		CallerVar: types.TextType,
-		TxidVar:   types.TextType,
-		SignerVar: types.BlobType,
-		HeightVar: types.IntType,
+		CallerVar:     types.TextType,
+		TxidVar:       types.TextType,
+		SignerVar:     types.BlobType,
+		HeightVar:     types.IntType,
+		ForeignCaller: types.TextType,
 	}
 )
 


### PR DESCRIPTION
This PR adds `@foreign_caller`, which gives information about what schema called another. If it is an outermost call, it will be an empty string (I tried to make it null, but due to Postgres not allowing unsettling of config parameters, and not allowing null config parameters, it does not appear possible).

This was requested by Truflation, as it is needed for their desired governance mechanisms for their schemas (https://github.com/truflation/tsn/issues/221). I can see how this would be useful information, so I felt it was appropriate to add.

This cannot be backported to v0.8.