### PR TITLE
added look back for token errors

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -102,7 +102,6 @@ func ParseAndValidate(kf []byte) (*SchemaParseResult, error) {
 // Most users should use ParseAndValidate instead.
 func ParseSchemaWithoutValidation(kf []byte) (res *SchemaParseResult, err error) {
 	errLis, stream, parser, deferFn := setupParser(string(kf), "schema")
-
 	res = &SchemaParseResult{
 		ParseErrs:        errLis,
 		ParsedActions:    make(map[string][]ActionStmt),
@@ -400,7 +399,9 @@ func setupParser(inputStream string, errLisName string) (errLis *errorListener,
 	stream = antlr.NewInputStream(inputStream)
 
 	lexer := gen.NewKuneiformLexer(stream)
-	parser = gen.NewKuneiformParser(antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel))
+	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	parser = gen.NewKuneiformParser(tokens)
+	errLis.toks = tokens
 
 	// remove defaults
 	lexer.RemoveErrorListeners()


### PR DESCRIPTION
This PR improves error positions for syntax errors. Currently, syntax errors are only present on a single line and column, which leads to them often being incorrect. This PR makes them appear for ranges.

If desirable, we could make the errors always appear at only the beginning (this is what Go does), however I am not sure of all of the edge cases of doing this in Antlr, and it could very well result in errors appearing too early.
