### PR TITLE
abci: skip repeated tx sig verification in proposal processing

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -622,6 +622,11 @@ func buildStatesyncer(d *coreDependencies) *statesync.StateSyncer {
 			continue
 		}
 
+		if res.Header.Height == 0 {
+			d.log.Warnf("zero height from provider %v", p)
+			continue
+		}
+
 		// Get the trust height and trust hash from the remote server
 		d.cfg.ChainCfg.StateSync.TrustHeight = res.Header.Height
 		d.cfg.ChainCfg.StateSync.TrustHash = res.Header.Hash().String()

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -35,7 +35,6 @@ import (
 
 	abciTypes "github.com/cometbft/cometbft/abci/types"
 	"github.com/cometbft/cometbft/crypto/ed25519"
-	cmtTypes "github.com/cometbft/cometbft/types"
 	"go.uber.org/zap"
 )
 
@@ -65,9 +64,9 @@ func NewAbciApp(ctx context.Context, cfg *AbciConfig, snapshotter SnapshotModule
 		log: log,
 
 		validatorAddressToPubKey: make(map[string][]byte),
-		txCache:                  make(map[string]bool),
-		verifiedSigs:             make(map[[32]byte]struct{}),
+		verifiedTxns:             make(map[chainHash]struct{}),
 	}
+	app.forks.FromMap(cfg.ForkHeights)
 
 	tx, err := db.BeginOuterTx(ctx)
 	if err != nil {
@@ -75,12 +74,20 @@ func NewAbciApp(ctx context.Context, cfg *AbciConfig, snapshotter SnapshotModule
 	}
 	defer tx.Rollback(ctx)
 
-	app.forks.FromMap(cfg.ForkHeights)
+	// Populate the validatorAddressToPubKey field.
+	validators, err := txRouter.GetValidators(ctx, tx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get validators: %w", err)
+	}
+	for _, val := range validators {
+		addr, err := pubkeyToAddr(val.PubKey)
+		if err != nil {
+			return nil, fmt.Errorf("failed to convert pubkey to address: %w", err)
+		}
 
-	// Enable any dynamically registered payloads, encoders, etc. from
-	// extension-defined forks that must be enabled by the current height. In
-	// addition to node restart, this is where forks with genesis height (0)
-	// activation are enabled since the first FinalizeBlock is for height 1.
+		app.validatorAddressToPubKey[addr] = val.PubKey
+	}
+
 	height, appHash, err := meta.GetChainState(ctx, tx)
 	if err != nil {
 		return nil, err
@@ -92,6 +99,10 @@ func NewAbciApp(ctx context.Context, cfg *AbciConfig, snapshotter SnapshotModule
 
 	app.log.Infof("Preparing ABCI application at height %v, appHash %x", height, appHash)
 
+	// Enable any dynamically registered payloads, encoders, etc. from
+	// extension-defined forks that must be enabled by the current height. In
+	// addition to node restart, this is where forks with genesis height (0)
+	// activation are enabled since the first FinalizeBlock is for height 1.
 	activeForks := app.forks.ActivatedBy(uint64(height))
 	slices.SortStableFunc(activeForks, forks.ForkSortFunc)
 	for _, fork := range activeForks {
@@ -195,6 +206,8 @@ func proposerAddrToString(addr []byte) string {
 	return strings.ToUpper(hex.EncodeToString(addr))
 }
 
+type chainHash = [32]byte
+
 type AbciApp struct {
 	// db is a connection to the database
 	db DB
@@ -229,16 +242,18 @@ type AbciApp struct {
 
 	broadcastFn EventBroadcaster
 
-	// validatorAddressToPubKey is a map of validator addresses to their public keys
+	// validatorAddressToPubKey is a map of validator addresses to their public
+	// keys. It should only be accessed from consensus connection methods, which
+	// are not called concurrently, or the constructor.
 	validatorAddressToPubKey map[string][]byte
 
-	// txCache stores hashes of all the transactions currently in the mempool.
-	// This is used to avoid recomputing the hash for all mempool transactions
-	// on every TxQuery request (to mitigate Potential DDOS attack vector).
+	// verifiedTxns stores hashes of all the transactions currently in the
+	// mempool, which have passed signature verification. This is used to avoid
+	// recomputing the hash for all mempool transactions on every TxQuery
+	// request (to mitigate Potential DDOS attack vector).
 	// https://github.com/kwilteam/kwil-db/issues/714
-	txCache      map[string]bool
-	txCacheMu    sync.RWMutex
-	verifiedSigs map[[32]byte]struct{}
+	verifiedTxnsMtx sync.RWMutex
+	verifiedTxns    map[chainHash]struct{}
 
 	// halted is set to true when the network is halted for migration.
 	halted atomic.Bool
@@ -304,8 +319,6 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 	var err error
 	code := codeOk
 
-	txHash := sha256.Sum256(incoming.Tx)
-
 	// NOTE about the error logging here: These transactions are from users, so
 	// most of these are not server errors, but client errors, so we ideally do
 	// not want to log them at all in production. We'll keep a few for now to
@@ -342,9 +355,6 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 			logger.Debug("failed to verify transaction", zap.Error(err))
 			return &abciTypes.ResponseCheckTx{Code: code.Uint32(), Log: err.Error()}, nil
 		}
-		a.txCacheMu.Lock()
-		a.verifiedSigs[txHash] = struct{}{} // tx.Signature.Signature
-		a.txCacheMu.Unlock()
 	} else {
 		logger.Debug("Recheck", zap.String("sender", hex.EncodeToString(tx.Sender)), zap.Uint64("nonce", tx.Body.Nonce), zap.String("payloadType", tx.Body.PayloadType.String()))
 	}
@@ -370,18 +380,20 @@ func (a *AbciApp) CheckTx(ctx context.Context, incoming *abciTypes.RequestCheckT
 			code = codeUnknownError
 			logger.Warn("unexpected failure to verify transaction against local mempool state", zap.Error(err))
 		}
-		a.txCacheMu.Lock()
-		delete(a.verifiedSigs, txHash)
-		a.txCacheMu.Unlock()
+		// Evicting transaction from mempool.
+		txHash := sha256.Sum256(incoming.Tx)
+		a.verifiedTxnsMtx.Lock()
+		delete(a.verifiedTxns, txHash)
+		a.verifiedTxnsMtx.Unlock()
 		return &abciTypes.ResponseCheckTx{Code: code.Uint32(), Log: err.Error()}, nil
 	}
 
 	// Cache the transaction hash
 	if newTx {
-		txHash := cmtTypes.Tx(incoming.Tx).Hash()
-		a.txCacheMu.Lock()
-		a.txCache[string(txHash)] = true
-		a.txCacheMu.Unlock()
+		txHash := sha256.Sum256(incoming.Tx)
+		a.verifiedTxnsMtx.Lock()
+		a.verifiedTxns[txHash] = struct{}{}
+		a.verifiedTxnsMtx.Unlock()
 	}
 	return &abciTypes.ResponseCheckTx{Code: code.Uint32()}, nil
 }
@@ -489,11 +501,9 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 		res.TxResults = append(res.TxResults, abciRes)
 
 		// Remove the transaction from the cache as it has been included in a block
-		// hash := cmtTypes.Tx(tx).Hash()
-		a.txCacheMu.Lock()
-		delete(a.txCache, string(txHash[:]))
-		delete(a.verifiedSigs, txHash)
-		a.txCacheMu.Unlock()
+		a.verifiedTxnsMtx.Lock()
+		delete(a.verifiedTxns, txHash)
+		a.verifiedTxnsMtx.Unlock()
 	}
 
 	// If at activation height, submit any consensus params updates associated
@@ -716,20 +726,6 @@ func (a *AbciApp) Info(ctx context.Context, _ *abciTypes.RequestInfo) (*abciType
 	}
 	if height == -1 {
 		height = 0 // for ChainInfo caller, non-negative is expected for genesis
-	}
-
-	validators, err := a.txApp.GetValidators(ctx, readTx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get validators: %w", err)
-	}
-
-	for _, val := range validators {
-		addr, err := pubkeyToAddr(val.PubKey)
-		if err != nil {
-			return nil, fmt.Errorf("failed to convert pubkey to address: %w", err)
-		}
-
-		a.validatorAddressToPubKey[addr] = val.PubKey
 	}
 
 	a.log.Info("ABCI application is ready", zap.Int64("height", height))
@@ -1258,16 +1254,13 @@ func (a *AbciApp) validateProposalTransactions(ctx context.Context, txns [][]byt
 
 			// This block proposal may include transactions that did not pass
 			// through our mempool, so we have to verify all signatures.
-			a.txCacheMu.Lock()
-			if _, have := a.verifiedSigs[txO.hash]; have {
-				// bytes.Equal(knownSig, tx.Signature.Signature)
-			} else {
+			if !a.TxSigVerified(txO.hash) {
 				if err = ident.VerifyTransaction(tx); err != nil {
-					a.txCacheMu.Unlock()
 					return fmt.Errorf("transaction signature verification failed: %w", err)
 				}
+				// We won't bother to insert this hash into the map since it is
+				// very likely that this transaction is about to be executed.
 			}
-			a.txCacheMu.Unlock()
 		}
 	}
 	return nil
@@ -1355,20 +1348,27 @@ func (a *AbciApp) SetEventBroadcaster(fn EventBroadcaster) {
 }
 
 // TxSigVerified indicates if ABCI has verified this unconfirmed transaction's
-// signature. This logic is not broadly applicable, but since the tx hash is
-// computed over the entire serialized transaction including the signature, the
-// same hash implies the same signature.
-func (a *AbciApp) TxSigVerified(txHash [32]byte) bool {
-	a.txCacheMu.Lock()
-	defer a.txCacheMu.Unlock()
-	_, ok := a.verifiedSigs[txHash]
+// signature. This also returns false if the transaction is not in mempool. This
+// logic is not broadly applicable, but since the tx hash is computed over the
+// entire serialized transaction including the signature, the same hash implies
+// the same signature.
+func (a *AbciApp) TxSigVerified(txHash chainHash) bool {
+	a.verifiedTxnsMtx.Lock()
+	defer a.verifiedTxnsMtx.Unlock()
+	_, ok := a.verifiedTxns[txHash]
 	return ok
 }
 
+// TxInMempool wraps TxSigVerified for callers that require a slice to check if
+// a transaction is (still) in mempool.
 func (a *AbciApp) TxInMempool(txHash []byte) bool {
-	a.txCacheMu.Lock()
-	defer a.txCacheMu.Unlock()
-	_, ok := a.txCache[string(txHash)]
+	if len(txHash) != 32 {
+		return false
+	}
+	hash := [32]byte(txHash) // requires go 1.20
+	a.verifiedTxnsMtx.Lock()
+	defer a.verifiedTxnsMtx.Unlock()
+	_, ok := a.verifiedTxns[hash]
 	return ok
 }
 


### PR DESCRIPTION
Profiling (`http/pprof`) under heavy transaction load revealed that there was major CPU utilization in `ProcessProposal` -> `validateProposalTransactions` at `ident.VerifyTransaction`.  This PR allows to skip that if the transaction (identified by hash) has already gone through this check in `CheckTx`, which would happen either via p2p gossip or rpc broadcast of the transaction.

WIP since there's a `txCache` map with a slightly different purpose that I may try to remove.

With this change, in a network with multiple validators that have to process another validator's block proposal, transaction throughput is much higher on account of much faster block proposal processing (can vanish almost 2 seconds).