### PR TITLE
[v0.8.2] added look back for token errors

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -102,7 +102,6 @@ func ParseAndValidate(kf []byte) (*SchemaParseResult, error) {
 // Most users should use ParseAndValidate instead.
 func ParseSchemaWithoutValidation(kf []byte) (res *SchemaParseResult, err error) {
 	errLis, stream, parser, deferFn := setupParser(string(kf), "schema")
-
 	res = &SchemaParseResult{
 		ParseErrs:        errLis,
 		ParsedActions:    make(map[string][]ActionStmt),
@@ -400,7 +399,9 @@ func setupParser(inputStream string, errLisName string) (errLis *errorListener,
 	stream = antlr.NewInputStream(inputStream)
 
 	lexer := gen.NewKuneiformLexer(stream)
-	parser = gen.NewKuneiformParser(antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel))
+	tokens := antlr.NewCommonTokenStream(lexer, antlr.TokenDefaultChannel)
+	parser = gen.NewKuneiformParser(tokens)
+	errLis.toks = tokens
 
 	// remove defaults
 	lexer.RemoveErrorListeners()


### PR DESCRIPTION
Backport https://github.com/kwilteam/kwil-db/pull/838 to release-v0.8
