### PR TITLE
added genesis and commit hooks

### DIFF
--- a/extensions/hooks/hooks.go
+++ b/extensions/hooks/hooks.go
@@ -73,3 +73,8 @@ func ListEndBlockHooks() []EndBlockHook {
 
 	return hooks
 }
+
+func init() {
+	genesisHooks = make(map[string]GenesisHook)
+	endBlockHooks = make(map[string]EndBlockHook)
+}

--- a/extensions/hooks/hooks.go
+++ b/extensions/hooks/hooks.go
@@ -1,0 +1,75 @@
+package hooks
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/core/utils/order"
+)
+
+// GenesisHook is a function that is run exactly once, at network genesis.
+// It can be used to create initial state or perform other setup tasks.
+// If it returns an error, the network will immediately halt. Any state
+// changed or error returned should be deterministic, as all nodes will
+// run the same GenesisHooks in the same order.
+type GenesisHook func(ctx *context.Context, app *common.App, chain *common.ChainContext) error
+
+// RegisterGenesisHook registers a GenesisHook to be run at network genesis.
+// The name can be anything, as long as it is unique. It is used to deterministically
+// order the hooks.
+func RegisterGenesisHook(name string, hook GenesisHook) error {
+	_, ok := genesisHooks[name]
+	if ok {
+		return fmt.Errorf("genesis hook with name %s already exists", name)
+	}
+
+	genesisHooks[name] = hook
+	return nil
+}
+
+var genesisHooks map[string]GenesisHook
+
+// ListGenesisHooks deterministically returns a list of all registered GenesisHooks.
+func ListGenesisHooks() []GenesisHook {
+	hooks := make([]GenesisHook, 0, len(genesisHooks))
+	for _, hook := range order.OrderMap(genesisHooks) {
+		hooks = append(hooks, hook.Value)
+	}
+
+	return hooks
+}
+
+// EndBlockHook is a function that is run at the end of each block, after
+// all of the transactions in the block have been processed, but before the
+// any state has been committed. It is meant to be used to alter state, send
+// data to external services, or perform cleanup tasks for other extensions.
+// An error returned will halt the local node. All state changes and errors
+// should be deterministic, as all nodes will run the same EndBlockHooks in
+// the same order.
+type EndBlockHook func(ctx *context.Context, app *common.App, block *common.BlockContext) error
+
+// RegisterEndBlockHook registers an EndBlockHook to be run at the end of each block.
+// The name can be anything, as long as it is unique. It is used to deterministically
+// order the hooks.
+func RegisterEndBlockHook(name string, hook EndBlockHook) error {
+	_, ok := endBlockHooks[name]
+	if ok {
+		return fmt.Errorf("end block hook with name %s already exists", name)
+	}
+
+	endBlockHooks[name] = hook
+	return nil
+}
+
+var endBlockHooks map[string]EndBlockHook
+
+// ListEndBlockHooks deterministically returns a list of all registered EndBlockHooks.
+func ListEndBlockHooks() []EndBlockHook {
+	var hooks []EndBlockHook
+	for _, hook := range order.OrderMap(endBlockHooks) {
+		hooks = append(hooks, hook.Value)
+	}
+
+	return hooks
+}

--- a/extensions/hooks/hooks.go
+++ b/extensions/hooks/hooks.go
@@ -13,7 +13,7 @@ import (
 // If it returns an error, the network will immediately halt. Any state
 // changed or error returned should be deterministic, as all nodes will
 // run the same GenesisHooks in the same order.
-type GenesisHook func(ctx *context.Context, app *common.App, chain *common.ChainContext) error
+type GenesisHook func(ctx context.Context, app *common.App, chain *common.ChainContext) error
 
 // RegisterGenesisHook registers a GenesisHook to be run at network genesis.
 // The name can be anything, as long as it is unique. It is used to deterministically
@@ -47,7 +47,7 @@ func ListGenesisHooks() []GenesisHook {
 // An error returned will halt the local node. All state changes and errors
 // should be deterministic, as all nodes will run the same EndBlockHooks in
 // the same order.
-type EndBlockHook func(ctx *context.Context, app *common.App, block *common.BlockContext) error
+type EndBlockHook func(ctx context.Context, app *common.App, block *common.BlockContext) error
 
 // RegisterEndBlockHook registers an EndBlockHook to be run at the end of each block.
 // The name can be anything, as long as it is unique. It is used to deterministically

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -415,7 +415,7 @@ func (m *mockTxApp) Finalize(ctx context.Context, db sql.DB, block *common.Block
 }
 
 func (m *mockTxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, accounts []*types.Account,
-	initialHeight int64) error {
+	initialHeight int64, chain *common.ChainContext) error {
 	return nil
 }
 

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -51,7 +51,7 @@ type TxApp interface {
 	Commit(ctx context.Context)
 	Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse
 	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators []*types.Validator, err error)
-	GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, genesisAccounts []*types.Account, initialHeight int64) error
+	GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, genesisAccounts []*types.Account, initialHeight int64, chain *common.ChainContext) error
 	GetValidators(ctx context.Context, db sql.DB) ([]*types.Validator, error)
 	ProposerTxs(ctx context.Context, db sql.DB, txNonce uint64, maxTxsSize int64, block *common.BlockContext) ([][]byte, error)
 	Reload(ctx context.Context, db sql.DB) error

--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -130,7 +130,7 @@ func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.
 
 	// genesis hooks
 	for _, hook := range hooks.ListGenesisHooks() {
-		err := hook(&ctx, &common.App{
+		err := hook(ctx, &common.App{
 			Service: &common.Service{
 				Logger:           r.log.Sugar(),
 				ExtensionConfigs: r.extensionConfigs,
@@ -352,7 +352,7 @@ func (r *TxApp) Finalize(ctx context.Context, db sql.DB, block *common.BlockCont
 
 	// end block hooks
 	for _, hook := range hooks.ListEndBlockHooks() {
-		err := hook(&ctx, &common.App{
+		err := hook(ctx, &common.App{
 			Service: &common.Service{
 				Logger:           r.log.Sugar(),
 				ExtensionConfigs: r.extensionConfigs,


### PR DESCRIPTION
As per a discussion with the idOS team, we found an issue that could have been pretty elegantly solved by hooks that run arbitrary logic at genesis and at the end of a block. This is not the first time we have wanted these: in February, we wanted these hooks to build an Arweave integration. For migrations, I was also planning on a genesis hook. Given how stupid simple they are to implement, I decided to throw them together.

This also fixes a bug where the node identity is not being passed as part of the `*common.App` to other extensions.