### PR TITLE
fix generated unary

### DIFF
--- a/internal/engine/generate/plpgsql.go
+++ b/internal/engine/generate/plpgsql.go
@@ -221,6 +221,7 @@ func (s *sqlGenerator) VisitExpressionArithmetic(p0 *parse.ExpressionArithmetic)
 func (s *sqlGenerator) VisitExpressionUnary(p0 *parse.ExpressionUnary) any {
 	str := strings.Builder{}
 	str.WriteString(string(p0.Operator))
+	str.WriteString(" ")
 	str.WriteString(p0.Expression.Accept(s).(string))
 	// cannot be typecasted
 	return str.String()
@@ -802,7 +803,7 @@ func (p *procedureGenerator) VisitProcedureStmtForLoop(p0 *parse.ProcedureStmtFo
 		s.WriteString(stmt.Accept(p).(string))
 	}
 
-	s.WriteString("END LOOP;\n")
+	s.WriteString(" END LOOP;\n")
 
 	return s.String()
 }
@@ -855,6 +856,7 @@ func (p *procedureGenerator) VisitIfThen(p0 *parse.IfThen) any {
 	for _, stmt := range p0.Then {
 		s.WriteString(stmt.Accept(p).(string))
 	}
+	s.WriteString("\n")
 
 	return s.String()
 }

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -336,6 +336,14 @@ func Test_Procedures(t *testing.T) {
 			err:      execution.ErrMutativeProcedure,
 			readOnly: true,
 		},
+		{
+			// this is a regression test for a previous bug
+			name: "unary",
+			procedure: `procedure unary() public view returns (bool) {
+				return !true;
+			}`,
+			outputs: [][]any{{false}},
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
While working on a separate PR, I found a bug with unary expressions in procedures. The generated PL/pgSQL is missing a space, which generates invalid syntax.

I've fixed this and added a test case. I also re-read the PL/pgSQL generation code to check for other places where we might find this. I found two places where we _might_, but couldn't actually make negative cases for them. I added spaces to protect against them anyways.