### PR TITLE
removed an unneeded uuid case

### DIFF
--- a/parse/ast.go
+++ b/parse/ast.go
@@ -74,8 +74,6 @@ func literalToString(value any) (string, error) {
 		str.WriteString("'" + v + "'")
 	case int64, int, int32: // for int type
 		str.WriteString(fmt.Sprint(v))
-	case types.UUID:
-		str.WriteString(v.String())
 	case *types.Uint256:
 		str.WriteString(v.String())
 	case *decimal.Decimal:


### PR DESCRIPTION
While reviewing something with @Yaiba , I realized that we had an unnecessary case in a switch statement. We checked for a UUID literal, but Kuneiform doesn't support UUID literals due to a deficiency in the ANTLR Go target making it impossible to parse.
