### PR TITLE
fix: default time says 0s

### DIFF
--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -232,6 +232,9 @@ func (d *Duration) UnmarshalText(b []byte) error {
 }
 
 func (d *Duration) String() string {
+	// if not set, we need to return an empty string,
+	// so that the -h flag does not show it as a default
+	// value of 0s
 	if d == nil {
 		return ""
 	}

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -232,6 +232,12 @@ func (d *Duration) UnmarshalText(b []byte) error {
 }
 
 func (d *Duration) String() string {
+	if d == nil {
+		return ""
+	}
+	if *d == 0 {
+		return ""
+	}
 	return time.Duration(*d).String()
 }
 


### PR DESCRIPTION
In `kwild -h`, anything that was a Duration value returned the default as 0s. This is misleading, because the default is actually set elsewhere. This simply omits the default from being printed.
