### PR TITLE
make dollarsigns optional in engine

### DIFF
--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -467,6 +467,8 @@ func makeExecutables(params []*generate.InlineExpression) []evaluatable {
 // orderAndCleanValueMap takes a map of values and a slice of keys, and returns
 // a slice of values in the order of the keys. If a value can be converted to an
 // int, it will be. If a value does not exist, it will be set to nil.
+// They keys are expected to match Kwil's bind syntax, i.e. $key.
+// The values in the value map can be either $key or key.
 func orderAndCleanValueMap(values map[string]any, keys []string) []any {
 	// we need to iterate over all values, and see if it has a $. If not,
 	// we need to add one so that the keys (which have $) match the values

--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"strings"
 
@@ -467,6 +468,24 @@ func makeExecutables(params []*generate.InlineExpression) []evaluatable {
 // a slice of values in the order of the keys. If a value can be converted to an
 // int, it will be. If a value does not exist, it will be set to nil.
 func orderAndCleanValueMap(values map[string]any, keys []string) []any {
+	// we need to iterate over all values, and see if it has a $. If not,
+	// we need to add one so that the keys (which have $) match the values
+	// (which do not have $)
+	cloned := false
+	for k, v := range values {
+		if k[0] != '$' {
+			// we need to copy the values map to ensure
+			// we do not modify the original map
+			if !cloned {
+				values = maps.Clone(values)
+				cloned = true
+			}
+
+			delete(values, k)
+			values["$"+k] = v
+		}
+	}
+
 	ordered := make([]any, 0, len(keys))
 	for _, key := range keys {
 		val, ok := values[key]

--- a/internal/engine/execution/procedure_test.go
+++ b/internal/engine/execution/procedure_test.go
@@ -1,0 +1,59 @@
+package execution
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_OrderAndClean(t *testing.T) {
+	type testcase struct {
+		name   string
+		values map[string]any
+		keys   []string
+		res    []any
+	}
+
+	tests := []testcase{
+		{
+			name: "using $",
+			values: map[string]any{
+				"$key1": "value1",
+				"$key2": []byte("value2"),
+			},
+			keys: []string{"$key1", "$key2"},
+			res:  []any{"value1", []byte("value2")},
+		},
+		{
+			name: "using $ and without $",
+			values: map[string]any{
+				"$key1": "value1",
+				"key2":  []byte("value2"),
+			},
+			keys: []string{"$key1", "$key2"},
+			res:  []any{"value1", []byte("value2")},
+		},
+		{
+			name: "missing key",
+			values: map[string]any{
+				"$key1": "value1",
+				"key2":  []byte("value2"),
+			},
+			keys: []string{"$key1", "$key3"},
+			res:  []any{"value1", nil},
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// copy the values to check that the function does not modify the input
+			oldVals := maps.Clone(test.values)
+
+			res := orderAndCleanValueMap(test.values, test.keys)
+			require.EqualValues(t, test.res, res)
+
+			require.EqualValues(t, oldVals, test.values)
+		})
+	}
+}

--- a/internal/engine/generate/actions.go
+++ b/internal/engine/generate/actions.go
@@ -50,8 +50,8 @@ type ActionSQL struct {
 	Statement string
 	// ParameterOrder is a list of the parameters in the order they appear in the statement.
 	// This is set if the ReplaceNamedParameters flag is set.
-	// For example, if the statement is "SELECT * FROM table WHERE id = $id AND name = @caller",
-	// then the parameter order would be ["$id", "@caller"]
+	// For example, if the statement is "SELECT * FROM table WHERE id = $id AND name = $name",
+	// then the parameter order would be ["$id", "$name"]
 	ParameterOrder []string
 }
 


### PR DESCRIPTION
As discussed here https://kwilteam.slack.com/archives/C0578NPEU21/p1719337560326199?thread_ts=1718905393.728919&cid=C0578NPEU21, the idOS team got tripped up expecting the engine to accept values that do not have dollarsigns. This is understandable, because virtually all other Kwil tooling makes the $ optional. This PR makes the dollarsign optional for the engine.
