### PR TITLE
start of v0.9 devel cycle

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0.8.0-pre"
+const kwilVersion = "0.9.0-pre"
 
 // KwildVersion may be set at compile time by:
 //


### PR DESCRIPTION
We're well into the v0.9 development cycle, so this PR makes `main` builds self-report as `v0.9.0-pre`.
This should always happen at the start of a new dev cycle, but it's extra helpful right now since users like to test `main` and `preview`.