### PR TITLE
fix engine.Execute

### DIFF
--- a/internal/engine/integration/sql_test.go
+++ b/internal/engine/integration/sql_test.go
@@ -190,6 +190,18 @@ func Test_SQL(t *testing.T) {
 				{int64(1)},
 			},
 		},
+		{
+			// this is a regression test for a bug introduced
+			// in v0.8
+			name: "values",
+			sql:  "select $id",
+			values: map[string]any{
+				"id": "4a67d6ea-7ac8-453c-964e-5a144f9e3004",
+			},
+			want: [][]any{
+				{"4a67d6ea-7ac8-453c-964e-5a144f9e3004"},
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/parse/parse.go
+++ b/parse/parse.go
@@ -302,6 +302,7 @@ func ParseSQL(sql string, schema *types.Schema) (res *SQLParseResult, err error)
 		},
 		sqlCtx: newSQLContext(),
 	}
+	visitor.sqlCtx.inLoneSQL = true
 
 	defer func() {
 		err2 := deferFn(recover())

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -2614,6 +2614,25 @@ func Test_SQL(t *testing.T) {
 				},
 			},
 		},
+		{
+			// this is a regression test for a previous bug.
+			// when parsing just SQL, we can have unknown variables
+			name: "unknown variable is ok",
+			sql:  `SELECT $id;`,
+			want: &parse.SQLStatement{
+				SQL: &parse.SelectStatement{
+					SelectCores: []*parse.SelectCore{
+						{
+							Columns: []parse.ResultColumn{
+								&parse.ResultColumnExpression{
+									Expression: exprVar("$id"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Resolves the bug found in https://github.com/kwilteam/kwil-db/pull/868 where `engine.Execute` can't use parameterized SQL.
