### PR TITLE
Engine exec mode

### DIFF
--- a/internal/engine/execution/global.go
+++ b/internal/engine/execution/global.go
@@ -235,7 +235,7 @@ func (g *GlobalContext) Execute(ctx context.Context, tx sql.DB, dbid, query stri
 
 	args := orderAndCleanValueMap(values, parsed.ParameterOrder)
 
-	return tx.Execute(ctx, parsed.Statement, args...)
+	return tx.Execute(ctx, parsed.Statement, append([]any{pg.QueryModeInferredArgTypes}, args...))
 }
 
 type dbQueryFn func(ctx context.Context, stmt string, args ...any) (*sql.ResultSet, error)

--- a/internal/engine/execution/global.go
+++ b/internal/engine/execution/global.go
@@ -235,7 +235,7 @@ func (g *GlobalContext) Execute(ctx context.Context, tx sql.DB, dbid, query stri
 
 	args := orderAndCleanValueMap(values, parsed.ParameterOrder)
 
-	return tx.Execute(ctx, parsed.Statement, append([]any{pg.QueryModeExec}, args...))
+	return tx.Execute(ctx, parsed.Statement, append([]any{pg.QueryModeExec}, args...)...)
 }
 
 type dbQueryFn func(ctx context.Context, stmt string, args ...any) (*sql.ResultSet, error)

--- a/internal/engine/execution/global.go
+++ b/internal/engine/execution/global.go
@@ -235,7 +235,7 @@ func (g *GlobalContext) Execute(ctx context.Context, tx sql.DB, dbid, query stri
 
 	args := orderAndCleanValueMap(values, parsed.ParameterOrder)
 
-	return tx.Execute(ctx, parsed.Statement, append([]any{pg.QueryModeInferredArgTypes}, args...))
+	return tx.Execute(ctx, parsed.Statement, append([]any{pg.QueryModeExec}, args...))
 }
 
 type dbQueryFn func(ctx context.Context, stmt string, args ...any) (*sql.ResultSet, error)


### PR DESCRIPTION
Fixes a bug where pgx is unable to infer types when using `engine.Execute`.