### PR TITLE
[v0.8] fix: in-line type assertions not comparable

### DIFF
--- a/internal/engine/execution/global.go
+++ b/internal/engine/execution/global.go
@@ -376,7 +376,12 @@ func (g *GlobalContext) Execute(ctx context.Context, tx sql.DB, dbid, query stri
 	args := orderAndCleanValueMap(values, params)
 	args = append([]any{pg.QueryModeExec}, args...)
 
-	return tx.Execute(ctx, sqlStmt, args...)
+	result, err := tx.Execute(ctx, sqlStmt, args...)
+	if err != nil {
+		return nil, decorateExecuteErr(err, query)
+	}
+
+	return result, nil
 }
 
 type dbQueryFn func(ctx context.Context, stmt string, args ...any) (*sql.ResultSet, error)

--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -313,6 +313,21 @@ type dmlStmt struct {
 	OrderedParameters []string
 }
 
+var ErrCannotInferType = errors.New("cannot infer type")
+
+// decorateExecuteErr parses an execute error from postgres and tries to give a more helpful error message.
+// this allows us to give a more helpful error message when users hit this,
+// since the Postgres error message is not helpful, and this is a common error.
+func decorateExecuteErr(err error, stmt string) error {
+	// this catches a common error case when execution in-line expressions in actions.
+	_, after, cut := strings.Cut(err.Error(), "could not determine data type of parameter ")
+	if cut {
+		return fmt.Errorf(`%w: could not dynamically determine the data type of the %sth parameter in statement "%s". try type casting using ::, e.g. $id::text`, ErrCannotInferType, strings.Split(after[1:], " ")[0], stmt)
+	}
+
+	return err
+}
+
 var _ instructionFunc = (&dmlStmt{}).execute
 
 func (e *dmlStmt) execute(scope *precompiles.ProcedureContext, _ *GlobalContext, db sql.DB) error {
@@ -321,7 +336,7 @@ func (e *dmlStmt) execute(scope *precompiles.ProcedureContext, _ *GlobalContext,
 	// args := append([]any{pg.QueryModeExec}, params...)
 	results, err := db.Execute(scope.Ctx, e.SQLStatement, append([]any{pg.QueryModeExec}, params...)...)
 	if err != nil {
-		return err
+		return decorateExecuteErr(err, e.SQLStatement)
 	}
 
 	// we need to check for any pg numeric types returned, and convert them to int64

--- a/internal/engine/generate/plpgsql.go
+++ b/internal/engine/generate/plpgsql.go
@@ -134,7 +134,12 @@ func (s *sqlGenerator) VisitExpressionVariable(p0 *parse.ExpressionVariable) any
 		// Postgres uses $1, $2, etc. for numbered parameters.
 
 		s.orderedParams = append(s.orderedParams, str)
-		return "$" + fmt.Sprint(len(s.orderedParams))
+
+		res := strings.Builder{}
+		res.WriteString("$")
+		res.WriteString(fmt.Sprint(len(s.orderedParams)))
+		typeCast(p0, &res)
+		return res.String()
 	}
 
 	str := strings.Builder{}

--- a/internal/engine/integration/sql_test.go
+++ b/internal/engine/integration/sql_test.go
@@ -207,7 +207,7 @@ func Test_SQL(t *testing.T) {
 			name: "inferred type - failure",
 			sql:  "select $id is null",
 			values: map[string]any{
-				"id": "4a67d6ea-7ac8-453c-964e-5a144f9e3004",
+				"$id": "4a67d6ea-7ac8-453c-964e-5a144f9e3004",
 			},
 			err: execution.ErrCannotInferType,
 		},
@@ -215,7 +215,7 @@ func Test_SQL(t *testing.T) {
 			name: "inferred type - success",
 			sql:  "select $id::text is null",
 			values: map[string]any{
-				"id": "4a67d6ea-7ac8-453c-964e-5a144f9e3004",
+				"$id": "4a67d6ea-7ac8-453c-964e-5a144f9e3004",
 			},
 			want: [][]any{{false}},
 		},
@@ -258,7 +258,6 @@ func Test_SQL(t *testing.T) {
 					require.Equal(t, tt.want[i][j], col)
 				}
 			}
-
 		})
 	}
 }

--- a/internal/engine/integration/sql_test.go
+++ b/internal/engine/integration/sql_test.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kwilteam/kwil-db/internal/engine/execution"
 	"github.com/stretchr/testify/require"
 )
 
@@ -201,6 +202,22 @@ func Test_SQL(t *testing.T) {
 			want: [][]any{
 				{"4a67d6ea-7ac8-453c-964e-5a144f9e3004"},
 			},
+		},
+		{
+			name: "inferred type - failure",
+			sql:  "select $id is null",
+			values: map[string]any{
+				"id": "4a67d6ea-7ac8-453c-964e-5a144f9e3004",
+			},
+			err: execution.ErrCannotInferType,
+		},
+		{
+			name: "inferred type - success",
+			sql:  "select $id::text is null",
+			values: map[string]any{
+				"id": "4a67d6ea-7ac8-453c-964e-5a144f9e3004",
+			},
+			want: [][]any{{false}},
 		},
 	}
 


### PR DESCRIPTION
Backports https://github.com/kwilteam/kwil-db/pull/880

This also includes a fix for parse. It is not time sensitive that we bump our parse module version on the release, as the parse fix simply fixes a non-critical bug that is not used in consensus, and isn't a super important feature.