### PR TITLE
feature(core): option to skip checking chain info

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -33,6 +33,10 @@ type Client struct {
 	// signatures will only be valid on this network.
 	chainID string
 
+	// skipCheckChainID skip checking chain ID against remote node's chain ID.
+	// This is only effective when chain ID is set.
+	skipCheckChainID bool
+
 	noWarnings bool // silence warning logs
 }
 
@@ -95,25 +99,41 @@ func WrapClient(ctx context.Context, client user.TxSvcClient, options *clientTyp
 	clientOptions.Apply(options)
 
 	c := &Client{
-		txClient:   client,
-		Signer:     clientOptions.Signer,
-		logger:     clientOptions.Logger,
-		chainID:    clientOptions.ChainID,
-		noWarnings: clientOptions.Silence,
+		txClient:         client,
+		Signer:           clientOptions.Signer,
+		logger:           clientOptions.Logger,
+		chainID:          clientOptions.ChainID,
+		noWarnings:       clientOptions.Silence,
+		skipCheckChainID: clientOptions.TrustLocalChainID,
 	}
 
-	chainInfo, err := c.ChainInfo(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("chain_info: %w", err)
-	}
-	chainID := chainInfo.ChainID
-	if c.chainID == "" {
-		if !c.noWarnings {
-			c.logger.Warn("chain ID not set, trusting chain ID from remote host!", zap.String("chainID", chainID))
+	if c.chainID == "" { // always use chain ID from remote host
+		chainInfo, err := c.ChainInfo(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("chain_info: %w", err)
 		}
-		c.chainID = chainID
-	} else if c.chainID != chainID {
-		return nil, fmt.Errorf("remote host chain ID %q != client configured %q", chainID, c.chainID)
+
+		if !c.noWarnings {
+			c.logger.Warn("chain ID not set, trusting chain ID from remote host!",
+				zap.String("chainID", chainInfo.ChainID))
+		}
+
+		c.chainID = chainInfo.ChainID
+	} else {
+		if c.skipCheckChainID {
+			if !c.noWarnings {
+				c.logger.Warn("chain ID is set, skip check against remote chain ID", zap.String("chainID", c.chainID))
+			}
+		} else {
+			chainInfo, err := c.ChainInfo(ctx)
+			if err != nil {
+				return nil, fmt.Errorf("chain_info: %w", err)
+			}
+
+			if chainInfo.ChainID == c.chainID {
+				return nil, fmt.Errorf("remote host chain ID %q != client configured %q", chainInfo.ChainID, c.chainID)
+			}
+		}
 	}
 
 	return c, nil

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -130,7 +130,7 @@ func WrapClient(ctx context.Context, client user.TxSvcClient, options *clientTyp
 				return nil, fmt.Errorf("chain_info: %w", err)
 			}
 
-			if chainInfo.ChainID == c.chainID {
+			if chainInfo.ChainID != c.chainID {
 				return nil, fmt.Errorf("remote host chain ID %q != client configured %q", chainInfo.ChainID, c.chainID)
 			}
 		}

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -33,9 +33,9 @@ type Client struct {
 	// signatures will only be valid on this network.
 	chainID string
 
-	// skipCheckChainID skip checking chain ID against remote node's chain ID.
-	// This is only effective when chain ID is set.
-	skipCheckChainID bool
+	// skipVerifyChainID skip checking chain ID against remote node's chain ID.
+	// This is only effective when chainID is set.
+	skipVerifyChainID bool
 
 	noWarnings bool // silence warning logs
 }
@@ -99,12 +99,12 @@ func WrapClient(ctx context.Context, client user.TxSvcClient, options *clientTyp
 	clientOptions.Apply(options)
 
 	c := &Client{
-		txClient:         client,
-		Signer:           clientOptions.Signer,
-		logger:           clientOptions.Logger,
-		chainID:          clientOptions.ChainID,
-		noWarnings:       clientOptions.Silence,
-		skipCheckChainID: clientOptions.TrustLocalChainID,
+		txClient:          client,
+		Signer:            clientOptions.Signer,
+		logger:            clientOptions.Logger,
+		chainID:           clientOptions.ChainID,
+		noWarnings:        clientOptions.Silence,
+		skipVerifyChainID: clientOptions.SkipVerifyChainID,
 	}
 
 	if c.chainID == "" { // always use chain ID from remote host
@@ -120,7 +120,7 @@ func WrapClient(ctx context.Context, client user.TxSvcClient, options *clientTyp
 
 		c.chainID = chainInfo.ChainID
 	} else {
-		if c.skipCheckChainID {
+		if c.skipVerifyChainID {
 			if !c.noWarnings {
 				c.logger.Warn("chain ID is set, skip check against remote chain ID", zap.String("chainID", c.chainID))
 			}

--- a/core/types/client/opts.go
+++ b/core/types/client/opts.go
@@ -24,6 +24,10 @@ type Options struct {
 	// communication with a trusted node (using TLS or Unix sockets).
 	ChainID string
 
+	// TrustLocalChainID will trust the chain ID passed from the user, i.e. no check
+	// against remote node's chain ID. This option is only be effective when ChainID is set.
+	TrustLocalChainID bool
+
 	// Silence silences warnings logged from the client.
 	Silence bool
 
@@ -52,6 +56,8 @@ func (c *Options) Apply(opts *Options) {
 	if opts.Conn != nil {
 		c.Conn = opts.Conn
 	}
+
+	c.TrustLocalChainID = opts.TrustLocalChainID
 
 	c.Silence = opts.Silence
 }
@@ -89,6 +95,14 @@ func WithSigner(signer auth.Signer) Option {
 func WithChainID(chainID string) Option {
 	return func(c *Options) {
 		c.ChainID = chainID
+	}
+}
+
+// WithTrustLocalChainID will trust the chain ID passed from the user, i.e. no check
+// against remote node's chain ID. This option is only be effective when ChainID is set.
+func WithTrustLocalChainID() Option {
+	return func(c *Options) {
+		c.TrustLocalChainID = true
 	}
 }
 

--- a/core/types/client/opts.go
+++ b/core/types/client/opts.go
@@ -70,56 +70,6 @@ func DefaultOptions() *Options {
 	}
 }
 
-type Option func(*Options)
-
-func WithLogger(logger log.Logger) Option {
-	return func(c *Options) {
-		c.Logger = logger
-	}
-}
-
-// WithSigner sets a signer to use when authoring transactions.
-func WithSigner(signer auth.Signer) Option {
-	return func(c *Options) {
-		c.Signer = signer
-	}
-}
-
-// WithChainID sets the chain ID to use when authoring transactions. The chain ID
-// will be used in all transactions, which helps prevent replay attacks on
-// different chains. On the initial connection, the remote node's chain ID is
-// checked against ours to ensure were are on the right network. If the chain ID
-// is empty, we will create and sign transactions for whatever network the
-// remote node claims, which should only be done for testing or when in secure
-// communication with a trusted node (using TLS or Unix sockets).
-func WithChainID(chainID string) Option {
-	return func(c *Options) {
-		c.ChainID = chainID
-	}
-}
-
-// WithTrustLocalChainID will trust the chain ID passed from the user, i.e. no check
-// against remote node's chain ID. This option is only be effective when ChainID is set.
-func WithTrustLocalChainID() Option {
-	return func(c *Options) {
-		c.TrustLocalChainID = true
-	}
-}
-
-// WithHTTPClient sets the http client for the client.
-func WithHTTPClient(client *http.Client) Option {
-	return func(c *Options) {
-		c.Conn = client
-	}
-}
-
-// SilenceWarnings silences warnings from the client.
-func SilenceWarnings() Option {
-	return func(c *Options) {
-		c.Silence = true
-	}
-}
-
 type TxOptions struct {
 	Nonce int64
 	Fee   *big.Int

--- a/core/types/client/opts.go
+++ b/core/types/client/opts.go
@@ -24,9 +24,9 @@ type Options struct {
 	// communication with a trusted node (using TLS or Unix sockets).
 	ChainID string
 
-	// TrustLocalChainID will trust the chain ID passed from the user, i.e. no check
-	// against remote node's chain ID. This option is only be effective when ChainID is set.
-	TrustLocalChainID bool
+	// SkipVerifyChainID will skip check against remote node's chain ID.
+	// This option is only effective when ChainID is set.
+	SkipVerifyChainID bool
 
 	// Silence silences warnings logged from the client.
 	Silence bool
@@ -57,7 +57,7 @@ func (c *Options) Apply(opts *Options) {
 		c.Conn = opts.Conn
 	}
 
-	c.TrustLocalChainID = opts.TrustLocalChainID
+	c.SkipVerifyChainID = opts.SkipVerifyChainID
 
 	c.Silence = opts.Silence
 }


### PR DESCRIPTION
This pr adds an option to skip checking chain info when create Client, this is useful to KGW to reduce the API calls to kwild.