### PR TITLE
chore: bump security policy for v0.8

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -5,8 +5,8 @@
 | Version | Supported |
 | ------- | --------- |
 | Latest beta or release candidate    | ✅        |
-| v0.6.x  | ✅        |
-| < v0.6  | ❌        |
+| v0.8.x  | ✅        |
+| < v0.8  | ❌        |
 
 ## Reporting a Vulnerability
 


### PR DESCRIPTION
Updating the security policy now that v0.8 is the official latest release.