### PR TITLE
kwild: failBuild was no-op if error was nil

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -922,12 +922,17 @@ func (pe panicErr) Unwrap() error {
 }
 
 func failBuild(err error, msg string) {
-	if err != nil {
+	if err == nil {
 		panic(panicErr{
-			err: err,
-			msg: fmt.Sprintf("%s: %s", msg, err),
+			err: errors.New(msg),
+			msg: msg,
 		})
 	}
+
+	panic(panicErr{
+		err: err,
+		msg: fmt.Sprintf("%s: %s", msg, err),
+	})
 }
 
 func buildListenerManager(d *coreDependencies, ev *voting.EventStore, node *cometbft.CometBftNode, txapp *txapp.TxApp, db sql.ReadTxMaker) *listeners.ListenerManager {


### PR DESCRIPTION
This fixes the bug where the kwild server build would not fail as intended if none of the trusted snapshot providers were valid.  We would see this:

```
2024-07-15T22:15:49.16Z warn    kwild   server/build.go:619     failed to get header from snap provider: post failed: Post "http://3.80.52.120:26657/": dial tcp 3.80.52.120:26657: connect: connection timed out
2024-07-15T22:15:49.162Z        info    kwild.abci      abci/abci.go:76 Preparing ABCI application at height 0, appHash
2024-07-15T22:15:49.188Z        info    kwild   server/build.go:323     closing signing store
2024-07-15T22:15:49.202Z        info    kwild   server/build.go:323     ending any active txApp transactions
2024-07-15T22:15:49.202Z        info    kwild   server/build.go:323     closing event store
2024-07-15T22:15:49.203Z        info    kwild   server/build.go:323     closing main DB
Error: panic while building kwild: failed to build comet node: invalid node config: error in [statesync] section: trusted_height is required
```

The `trusted_height is required` part didn't make sense since it should not have been left as zero.  The issue is that `failBuild` was being called with a `nil` `error`, which made `failBuild` a no-op.  The expectation when calling `failBuild` is to *fail the build*, so this PR changes that function so it will make an anonymous error based on the message that was passed.

I audited every call to `failBuild` and it is always inside a failure condition branch, never just called where the error may or may not be nil.