### PR TITLE
add parse_unix_timestamp

### DIFF
--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -243,6 +243,10 @@ func Test_Procedures(t *testing.T) {
 				if trim('a'||$val||'a', 'a') != 'hello world!' {
 					error('trim 2 failed');
 				}
+
+				if parse_unix_timestamp('2021-01-01 00:00:00:123456', 'YYYY-MM-DD HH24:MI:SS:US') != 1609459200.123456 {
+					error('parse_unix_timestamp failed');
+				}
 			}`,
 		},
 		{

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -247,6 +247,10 @@ func Test_Procedures(t *testing.T) {
 				if parse_unix_timestamp('2021-01-01 00:00:00:123456', 'YYYY-MM-DD HH24:MI:SS:US') != 1609459200.123456 {
 					error('parse_unix_timestamp failed');
 				}
+
+				if format_unix_timestamp(1609459200.123456, 'YYYY-MM-DD HH24:MI:SS:US') != '2021-01-01 00:00:00:123456' {
+					error('format_unix_timestamp failed');
+				}
 			}`,
 		},
 		{

--- a/internal/sql/pg/db.go
+++ b/internal/sql/pg/db.go
@@ -194,7 +194,7 @@ func NewDB(ctx context.Context, cfg *DBConfig) (*DB, error) {
 		return nil, fmt.Errorf("failed to create ERROR function: %w", err)
 	}
 
-	if err = ensureParseUnixTimestamp(ctx, conn); err != nil {
+	if err = ensureUnixTimestampFuncs(ctx, conn); err != nil {
 		return nil, fmt.Errorf("failed to create parse_unix_timestamp function: %w", err)
 	}
 

--- a/internal/sql/pg/db.go
+++ b/internal/sql/pg/db.go
@@ -194,6 +194,10 @@ func NewDB(ctx context.Context, cfg *DBConfig) (*DB, error) {
 		return nil, fmt.Errorf("failed to create ERROR function: %w", err)
 	}
 
+	if err = ensureParseUnixTimestamp(ctx, conn); err != nil {
+		return nil, fmt.Errorf("failed to create parse_unix_timestamp function: %w", err)
+	}
+
 	runCtx, cancel := context.WithCancelCause(context.Background())
 
 	db := &DB{

--- a/internal/sql/pg/db_live_test.go
+++ b/internal/sql/pg/db_live_test.go
@@ -830,4 +830,13 @@ func Test_ParseUnixTimestamp(t *testing.T) {
 	require.NoError(t, err)
 
 	require.EqualValues(t, expected, res.Rows[0][0])
+
+	// reverse it
+	res, err = tx.Execute(ctx, "select format_unix_timestamp(1718114052.123456::numeric(16,6), 'YYYY-MM-DD HH24:MI:SS.US')", QueryModeExec)
+	require.NoError(t, err)
+
+	require.Len(t, res.Rows, 1)
+	require.Len(t, res.Rows[0], 1)
+
+	require.EqualValues(t, "2024-06-11 13:54:12.123456", res.Rows[0][0])
 }

--- a/internal/sql/pg/db_live_test.go
+++ b/internal/sql/pg/db_live_test.go
@@ -807,3 +807,27 @@ func (c *changesetTestcase[T, T2]) run(t *testing.T) {
 	err = tx.Commit(ctx)
 	require.NoError(t, err)
 }
+
+// tests the custom parse_unix_timestamp function
+func Test_ParseUnixTimestamp(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := NewDB(ctx, cfg)
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx, err := db.BeginPreparedTx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx)
+
+	res, err := tx.Execute(ctx, "select parse_unix_timestamp('2024-06-11 13:54:12.123456', 'YYYY-MM-DD HH24:MI:SS.US')", QueryModeExec)
+	require.NoError(t, err)
+
+	require.Len(t, res.Rows, 1)
+	require.Len(t, res.Rows[0], 1)
+
+	expected, err := decimal.NewFromString("1718114052.123456")
+	require.NoError(t, err)
+
+	require.EqualValues(t, expected, res.Rows[0][0])
+}

--- a/internal/sql/pg/sql.go
+++ b/internal/sql/pg/sql.go
@@ -62,6 +62,18 @@ END$$;`
 		WHEN duplicate_object THEN null;
 	END $$;`
 
+	// postgres returns EXTRACT as a double precision, but will only at most have 6
+	// decimal places of precision (to measure microseconds). We cast to numeric(16, 6)
+	// which should allow for up to 6 decimal places of precision.
+	// Since max unix timestamp is 2147483648, we can cast to numeric(16, 6) to allow 10 digits
+	// before the decimal and 6 after.
+	sqlCreateParseUnixTimestampFunc = `CREATE OR REPLACE FUNCTION parse_unix_timestamp(timestamp_string text, format_string text)
+	RETURNS NUMERIC(16, 6) AS $$
+	BEGIN
+		RETURN EXTRACT(EPOCH FROM TO_TIMESTAMP(timestamp_string, format_string))::numeric(16, 6);
+	END;
+	$$ LANGUAGE plpgsql;`
+
 	sqlCreateOrReplaceReplicaIdentity = `CREATE OR REPLACE FUNCTION set_replica_identity()
 RETURNS event_trigger
 LANGUAGE plpgsql
@@ -118,6 +130,11 @@ func ensurePgCryptoExtension(ctx context.Context, conn *pgx.Conn) error {
 
 func ensureUint256Domain(ctx context.Context, conn *pgx.Conn) error {
 	_, err := conn.Exec(ctx, sqlCreateUint256Domain)
+	return err
+}
+
+func ensureParseUnixTimestamp(ctx context.Context, conn *pgx.Conn) error {
+	_, err := conn.Exec(ctx, sqlCreateParseUnixTimestampFunc)
 	return err
 }
 

--- a/internal/sql/pg/sql.go
+++ b/internal/sql/pg/sql.go
@@ -74,6 +74,14 @@ END$$;`
 	END;
 	$$ LANGUAGE plpgsql;`
 
+	// this is the inverse of parse_unix_timestamp
+	sqlCreateFormatUnixTimestampFunc = `CREATE OR REPLACE FUNCTION format_unix_timestamp(unix_timestamp NUMERIC(16, 6), format_string text)
+	RETURNS TEXT AS $$
+	BEGIN
+		RETURN TO_CHAR(TO_TIMESTAMP(unix_timestamp), format_string);
+	END;
+	$$ LANGUAGE plpgsql;`
+
 	sqlCreateOrReplaceReplicaIdentity = `CREATE OR REPLACE FUNCTION set_replica_identity()
 RETURNS event_trigger
 LANGUAGE plpgsql
@@ -133,8 +141,13 @@ func ensureUint256Domain(ctx context.Context, conn *pgx.Conn) error {
 	return err
 }
 
-func ensureParseUnixTimestamp(ctx context.Context, conn *pgx.Conn) error {
+func ensureUnixTimestampFuncs(ctx context.Context, conn *pgx.Conn) error {
 	_, err := conn.Exec(ctx, sqlCreateParseUnixTimestampFunc)
+	if err != nil {
+		return err
+	}
+
+	_, err = conn.Exec(ctx, sqlCreateFormatUnixTimestampFunc)
 	return err
 }
 

--- a/parse/functions.go
+++ b/parse/functions.go
@@ -54,9 +54,28 @@ var (
 					return nil, wrapErrArgumentType(types.TextType, args[1])
 				}
 
-				return types.NewDecimalType(16, 6) // see internal/sql/pg/sql.go/sqlCreateParseUnixTimestampFunc for more info
+				return decimal16_6, nil
 			},
 			PGFormat: defaultFormat("parse_unix_timestamp"),
+		},
+		"format_unix_timestamp": {
+			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
+				// first arg must be decimal(16, 6), second arg must be text
+				if len(args) != 2 {
+					return nil, wrapErrArgumentNumber(2, len(args))
+				}
+
+				if !args[0].EqualsStrict(decimal16_6) {
+					return nil, wrapErrArgumentType(decimal16_6, args[0])
+				}
+
+				if !args[1].EqualsStrict(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[1])
+				}
+
+				return types.TextType, nil
+			},
+			PGFormat: defaultFormat("format_unix_timestamp"),
 		},
 		"uuid_generate_v5": {
 			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
@@ -695,14 +714,25 @@ func defaultFormat(name string) FormatFunc {
 	}
 }
 
-// decimal1000 is a decimal type with a precision of 1000.
-var decimal1000 *types.DataType
+var (
+	// decimal1000 is a decimal type with a precision of 1000.
+	decimal1000 *types.DataType
+	// decimal16_6 is a decimal type with a precision of 16 and a scale of 6.
+	// it is used to represent UNIX timestamps, allowing microsecond precision.
+	// see internal/sql/pg/sql.go/sqlCreateParseUnixTimestampFunc for more info
+	decimal16_6 *types.DataType
+)
 
 func init() {
 	var err error
 	decimal1000, err = types.NewDecimalType(1000, 0)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create decimal type: 1000, 0: %v", err))
+	}
+
+	decimal16_6, err = types.NewDecimalType(16, 6)
+	if err != nil {
+		panic(fmt.Sprintf("failed to create decimal type: 16, 6: %v", err))
 	}
 }
 

--- a/parse/functions.go
+++ b/parse/functions.go
@@ -39,6 +39,25 @@ var (
 			},
 			PGFormat: defaultFormat("error"),
 		},
+		"parse_unix_timestamp": {
+			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
+				// two args, both text
+				if len(args) != 2 {
+					return nil, wrapErrArgumentNumber(2, len(args))
+				}
+
+				if !args[0].EqualsStrict(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[0])
+				}
+
+				if !args[1].EqualsStrict(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[1])
+				}
+
+				return types.NewDecimalType(16, 6) // see internal/sql/pg/sql.go/sqlCreateParseUnixTimestampFunc for more info
+			},
+			PGFormat: defaultFormat("parse_unix_timestamp"),
+		},
 		"uuid_generate_v5": {
 			ValidateArgs: func(args []*types.DataType) (*types.DataType, error) {
 				// first argument must be a uuid, second argument must be text


### PR DESCRIPTION
Adds 2 functions:
- `parse_unix_timestamp(text, text) -> decimal(16,6)`: parses a datetime string to a UNIX timestamp. The first argument is the datetime string, the second is the formatting.
- `format_unix_timestamp(decimal(16,6), text) -> text`: formats a UNIX timestamp as a datetime string. The first argument is the UNIX timestamp, the second is the formatting for the result.

The formatting rules match Postgres's `to_timestamp` formatting: https://www.postgresql.org/docs/current/functions-formatting.html

This was requested by Truflation, and should be enough until we support a timestamp data type. It ended up being way easier to implement than I expected.