### PR TITLE
fix: extensions with sql whitespace fail

### DIFF
--- a/parse/parse.go
+++ b/parse/parse.go
@@ -341,6 +341,10 @@ func setupSQLParser(sql string, schema *types.Schema) (parser *gen.KuneiformPars
 	if sql == "" {
 		return nil, nil, nil, nil, nil, fmt.Errorf("empty SQL statement")
 	}
+
+	// trim whitespace
+	sql = strings.TrimSpace(sql)
+
 	// add semicolon to the end of the statement, if it is not there
 	if !strings.HasSuffix(sql, ";") {
 		sql += ";"

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -2678,6 +2678,25 @@ func Test_SQL(t *testing.T) {
 				},
 			},
 		},
+		{
+			// regression tests for a previous bug, where whitespace after
+			// the semicolon would cause the parser to add an extra semicolon
+			name: "whitespace after semicolon",
+			sql:  "SELECT 1;     ",
+			want: &parse.SQLStatement{
+				SQL: &parse.SelectStatement{
+					SelectCores: []*parse.SelectCore{
+						{
+							Columns: []parse.ResultColumn{
+								&parse.ResultColumnExpression{
+									Expression: exprLit(1),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
@sapience noted a bug where a SQL statement that has a semicolon and whitespace after fails to parse if it is used with `enigne.Execute`. This is because `engine.Execute` directly uses the `parse.ParseSQL` function. This function allows SQL statements to optionally include a semicolon, and adds one if it is missing. It added an extra semicolon if the statement had whitespace.

The reason we had not run into this before is because all of the other parse functions (full schema, action, and procedure) remove the whitespace during tokenization. This error can _only_ occur if `engine.Execute` is called with whitespace trailing the semicolon.