### PR TITLE
use go 1.22

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kwilteam/kwil-db
 
-go 1.21.0
+go 1.22
 
 replace (
 	github.com/kwilteam/kwil-db/core => ./core


### PR DESCRIPTION
This pr set go version to 1.22 in go.mod, to avoid unexpected 'backward compatiable' behavior,  learn more at https://go.dev/doc/godebug.

I encountered this unexpected behavior in kgw https://github.com/kwilteam/kgw/pull/78#issuecomment-2257163435