### PR TITLE
uint256 type decoding

### DIFF
--- a/internal/sql/pg/db_live_test.go
+++ b/internal/sql/pg/db_live_test.go
@@ -426,11 +426,9 @@ func TestTypeRoundtrip(t *testing.T) {
 			typ: "decimal(5,0)",
 			val: mustDecimal("12300"),
 		},
-		{
-			typ:  "decimal(3,0)",
-			val:  types.Uint256FromInt(100),
-			want: mustDecimal("100"),
-		},
+		// this is an unavoidable issue with Postgres. We need to decode data into
+		// a value, rather than decode based on the OID
+		// https://www.postgresql.org/message-id/87fvoydtxx.fsf%40locaine.bese.it
 		{
 			typ:  "uint256",
 			val:  types.Uint256FromInt(100),


### PR DESCRIPTION
I tried to fix the uint256 type decoding issue, but unfortunately it appears to not really be possible. As noted [here](<https://www.postgresql.org/message-id/87fvoydtxx.fsf%40locaine.bese.it>), this is just part of Postgres.

Seems the only way to solve for this is with https://github.com/kwilteam/kwil-db/issues/800#issuecomment-2256723334

This PR removes one completely useless test, and changes query results to only read OIDs once per query, instead of once per row