### PR TITLE
pg: advanced query feats, table inspection, and stats

### DIFF
--- a/common/sql/sql.go
+++ b/common/sql/sql.go
@@ -35,6 +35,25 @@ type Executor interface {
 	Execute(ctx context.Context, stmt string, args ...any) (*ResultSet, error)
 }
 
+// QueryScanner represents a type that provides the ability to execute an SQL
+// statement, where for each row:
+//
+//  1. result values are scanned into the variables in the scans slice
+//  2. the provided function is then called
+//
+// The function would typically capture the variables in the scans slice,
+// allowing it to operator on the values. For instance, append the values to
+// slices allocated by the caller, or perform reduction operations like
+// sum/mean/min/etc.
+//
+// NOTE: This method may end up being included in the Tx interface alongside
+// Executor since all of the concrete transaction implementations provided by
+// this package implement this method.
+type QueryScanner interface {
+	QueryScanFn(ctx context.Context, stmt string,
+		scans []any, fn func() error, args ...any) error
+}
+
 // TxMaker is an interface that creates a new transaction. In the context of the
 // recursive Tx interface, is creates a nested transaction.
 type TxMaker interface {

--- a/common/sql/statistics.go
+++ b/common/sql/statistics.go
@@ -1,0 +1,73 @@
+package sql
+
+// NOTE: this file is TRANSITIONAL! These types are lifted from the
+// unmerged internal/engine/costs/datatypes package.
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Statistics contains statistics about a table or a Plan. A Statistics can be
+// derived directly from the underlying table, or derived from the statistics of
+// its children.
+type Statistics struct {
+	RowCount int64
+
+	ColumnStatistics []ColumnStatistics
+
+	//Selectivity, for plan statistics
+}
+
+func (s *Statistics) String() string {
+	var st strings.Builder
+	fmt.Fprintf(&st, "RowCount: %d", s.RowCount)
+	if len(s.ColumnStatistics) > 0 {
+		fmt.Fprintln(&st, "")
+	}
+	for i, cs := range s.ColumnStatistics {
+		fmt.Fprintf(&st, " Column %d:\n", i)
+		fmt.Fprintf(&st, " - Min/Max = %v / %v\n", cs.Min, cs.Max)
+		fmt.Fprintf(&st, " - NULL count = %v\n", cs.NullCount)
+	}
+	return st.String()
+}
+
+type ValCount struct {
+	Val   any
+	Count int
+}
+
+// ColumnStatistics contains statistics about a column.
+type ColumnStatistics struct {
+	NullCount int64
+
+	Min      any
+	MinCount int
+
+	Max      any
+	MaxCount int
+
+	// MCVs are the most common values. It should be sorted by the value. It
+	// should also be limited capacity, which means scan order has to be
+	// deterministic since we have to throw out same-frequency observations.
+	// (crap) Solution: multi-pass scan, merge lists, continue until no higher
+	// freq values observed? OR when capacity reached, use a histogram? Do not
+	// throw away MCVs, just start putting additional observations in to the
+	// histogram instead.
+	// MCVs []ValCount
+	// MCVs map[cmp.Ordered]
+
+	// MCVals  []any
+	// MCFreqs []int
+
+	// DistinctCount is harder. For example, unless we sub-sample
+	// (deterministically), tracking distinct values could involve a data
+	// structure with the same number of elements as rows in the table.
+	DistinctCount int64
+
+	AvgSize int64 // maybe: length of text, length of array, otherwise not used for scalar?
+
+	// without histogram, we can make uniformity assumption to simplify the cost model
+	//Histogram     []HistogramBucket
+}

--- a/go.mod
+++ b/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/grpc-ecosystem/go-grpc-middleware/v2 v2.1.0
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.19.1
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9
-	github.com/jackc/pgx/v5 v5.5.5
+	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jpillora/backoff v1.0.0
 	github.com/kwilteam/kwil-db/core v0.2.0
 	github.com/kwilteam/kwil-db/parse v0.2.0-beta.1

--- a/go.sum
+++ b/go.sum
@@ -245,8 +245,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
-github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=

--- a/internal/sql/pg/conn.go
+++ b/internal/sql/pg/conn.go
@@ -292,6 +292,13 @@ func (p *Pool) Close() error {
 // BeginTx starts a read-write transaction. It is an error to call this twice
 // without first closing the initial transaction.
 func (p *Pool) BeginTx(ctx context.Context) (sql.Tx, error) {
+	return p.begin(ctx)
+}
+
+// begin is the unexported version of BeginTx that returns a concrete type
+// instead of an interface, which is required of the exported method to satisfy
+// the sql.TxMaker interface.
+func (p *Pool) begin(ctx context.Context) (*nestedTx, error) {
 	tx, err := p.writer.BeginTx(ctx, pgx.TxOptions{
 		AccessMode: pgx.ReadWrite,
 		IsoLevel:   pgx.ReadCommitted,

--- a/internal/sql/pg/stats.go
+++ b/internal/sql/pg/stats.go
@@ -1,0 +1,428 @@
+package pg
+
+import (
+	"bytes"
+	"cmp"
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+	"strings"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/kwilteam/kwil-db/common/sql"
+	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/kwilteam/kwil-db/core/types/decimal"
+)
+
+// RowCount gets a precise row count for the named fully qualified table. If the
+// Executor satisfies the RowCounter interface, that method will be used
+// directly. Otherwise a simple select query is used.
+func RowCount(ctx context.Context, qualifiedTable string, db sql.Executor) (int64, error) {
+	stmt := fmt.Sprintf(`SELECT count(1) FROM %s`, qualifiedTable)
+	res, err := db.Execute(ctx, stmt)
+	if err != nil {
+		return 0, fmt.Errorf("unable to count rows: %w", err)
+	}
+	if len(res.Rows) != 1 || len(res.Rows[0]) != 1 {
+		return 0, errors.New("exactly one value not returned by row count query")
+	}
+	count, ok := sql.Int64(res.Rows[0][0])
+	if !ok {
+		return 0, fmt.Errorf("no row count for %s", qualifiedTable)
+	}
+	return count, nil
+}
+
+// TableStatser is an interface that the implementation of a sql.Executor may
+// implement.
+type TableStatser interface {
+	TableStats(ctx context.Context, schema, table string) (*sql.Statistics, error)
+}
+
+// TableStats collects deterministic statistics for a table. If schema is empty,
+// the "public" schema is assumed. This method is used to obtain the ground
+// truth statistics for a table; incremental statistics updates should be
+// preferred when possible. If the sql.Executor implementation is a
+// TableStatser, it's method is used directly. This is primarily to allow a stub
+// DB for testing.
+func TableStats(ctx context.Context, schema, table string, db sql.Executor) (*sql.Statistics, error) {
+	if ts, ok := db.(TableStatser); ok {
+		return ts.TableStats(ctx, schema, table)
+	}
+
+	if schema == "" {
+		schema = "public"
+	}
+	qualifiedTable := schema + "." + table
+
+	count, err := RowCount(ctx, qualifiedTable, db)
+	if err != nil {
+		return nil, err
+	}
+	// TODO: We needs a schema-table stats database so we don't ever have to do
+	// a full table scan for column stats.
+
+	colInfo, err := ColumnInfo(ctx, db, schema, table)
+	if err != nil {
+		return nil, err
+	}
+
+	// Column statistics
+	colStats, err := colStats(ctx, qualifiedTable, colInfo, db)
+	if err != nil {
+		return nil, err
+	}
+
+	return &sql.Statistics{
+		RowCount:         count,
+		ColumnStatistics: colStats,
+	}, nil
+}
+
+// rough outline for postgresql extension w/ a full stats function:
+//
+//  - function: collect_stats(tablename)
+//  - iterate over each row, perform computations defined in the extension code
+//  - SPI_connect() -> SPI_cursor_open(... query ...) -> SPI_cursor_fetch ->
+//    SPI_processed -> SPI_tuptable -> SPI_getbinval
+
+// colStats collects column-wise statistics for the specified table, using the
+// provided column definitions to instantiate scan values used by the full scan
+// that iterates over all rows of the table.
+func colStats(ctx context.Context, qualifiedTable string, colInfo []ColInfo, db sql.Executor) ([]sql.ColumnStatistics, error) {
+	// rowCount is unused now, and can seemingly be computed via the scan
+	// itself, but I intend to use it in for more complex statistics building algos.
+
+	// https://wiki.postgresql.org/wiki/Retrieve_primary_key_columns
+	getIndBase := `SELECT a.attname::text, i.indexrelid::int8
+		FROM pg_index i
+		JOIN pg_attribute a ON a.attnum = ANY(i.indkey) AND a.attrelid = i.indrelid
+		WHERE i.indrelid = '` + qualifiedTable + `'::regclass`
+	// use primary key columns first
+	getPK := getIndBase + ` AND i.indisprimary;`
+	// then unique+not-null index cols?
+	// getUniqueInds := getIndBase + ` AND i.indisunique;`
+	res, err := db.Execute(ctx, getPK)
+	if err != nil {
+		return nil, err
+	}
+	// IMPORTANT NOTE: if the iteration over all rows of the table involves *no*
+	// ORDER BY clause, the scan order is not guaranteed. This should be an
+	// error for tables where stats must be deterministic.
+	//
+	// if len(res.Rows) == 0 {
+	// 	return nil, errors.New("no suitable orderby column")
+	// }
+	pkCols := make([]string, len(res.Rows))
+	for i, row := range res.Rows {
+		pkCols[i] = row[0].(string)
+	}
+
+	numCols := len(colInfo)
+	colTypes := make([]ColType, numCols)
+	for i := range colInfo {
+		colTypes[i] = colInfo[i].Type()
+	}
+
+	colStats := make([]sql.ColumnStatistics, numCols)
+
+	// iterate over all rows (select *)
+	var scans []any
+	for _, col := range colInfo {
+		scans = append(scans, col.scanVal())
+	}
+	stmt := `SELECT * FROM ` + qualifiedTable
+	if len(pkCols) > 0 {
+		stmt += ` ORDER BY ` + strings.Join(pkCols, ",")
+	}
+	err = QueryRowFunc(ctx, db, stmt, scans,
+		func() error {
+			var err error
+			for i, val := range scans {
+				stat := &colStats[i]
+				if val == nil { // with QueryRowFuncAny and vals []any, or with QueryRowFunc where scans are native type pointers
+					stat.NullCount++
+					continue
+				}
+
+				// TODO: do something with array types (num elements stats????)
+
+				switch colTypes[i] {
+				case ColTypeInt: // use int64 in stats
+					var valInt int64
+					switch it := val.(type) {
+					case interface{ Int64Value() (pgtype.Int8, error) }: // several of the pgtypes int types
+						i8, err := it.Int64Value()
+						if err != nil {
+							return fmt.Errorf("bad int64: %T", val)
+						}
+						if !i8.Valid {
+							stat.NullCount++
+							continue
+						}
+						valInt = i8.Int64
+
+					default:
+						var ok bool
+						valInt, ok = sql.Int64(val)
+						if !ok {
+							return fmt.Errorf("not int: %T", val)
+						}
+					}
+
+					ins(stat, valInt, cmp.Compare[int64])
+
+				case ColTypeText: // use string in stats
+					valStr, null, ok := TextValue(val) // val.(string)
+					if !ok {
+						return fmt.Errorf("not string: %T", val)
+					}
+					if null {
+						stat.NullCount++
+						continue
+					}
+
+					ins(stat, valStr, strings.Compare)
+
+				case ColTypeByteA: // use []byte in stats
+					var valBytea []byte
+					switch vt := val.(type) {
+					// Presently we're just using []byte, not pgtype.Array, but
+					// might need to for NULL...
+
+					// case *pgtype.Array[byte]:
+					// 	if !vt.Valid {
+					// 		stat.NullCount++
+					// 		continue
+					// 	}
+					// 	valBytea = vt.Elements
+					// case pgtype.Array[byte]:
+					// 	if !vt.Valid {
+					// 		stat.NullCount++
+					// 		continue
+					// 	}
+					// 	valBytea = vt.Elements
+					case *[]byte:
+						if vt == nil || *vt == nil {
+							stat.NullCount++
+							continue
+						}
+						valBytea = slices.Clone(*vt)
+					case []byte:
+						if vt == nil {
+							stat.NullCount++
+							continue
+						}
+						valBytea = slices.Clone(vt)
+					default:
+						return fmt.Errorf("not bytea: %T", val)
+					}
+
+					ins(stat, valBytea, bytes.Compare)
+
+				case ColTypeBool: // use bool in stats
+					var b bool
+					switch v := val.(type) {
+					case *pgtype.Bool:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						b = v.Bool
+					case pgtype.Bool:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						b = v.Bool
+					case *bool:
+						b = *v
+					case bool:
+						b = v
+
+					default:
+						return fmt.Errorf("invalid bool (%T)", val)
+					}
+
+					ins(stat, b, cmpBool)
+
+				case ColTypeNumeric: // use *decimal.Decimal in stats
+					var dec *decimal.Decimal
+					switch v := val.(type) {
+					case *pgtype.Numeric:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						if v.NaN {
+							continue
+						}
+
+						dec, err = pgNumericToDecimal(*v)
+						if err != nil {
+							continue
+						}
+
+					case pgtype.Numeric:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						if v.NaN {
+							continue
+						}
+
+						dec, err = pgNumericToDecimal(v)
+						if err != nil {
+							continue
+						}
+
+					case *decimal.Decimal:
+						if v.NaN() { // we're pretending this is NULL by our sql.Scanner's convetion
+							stat.NullCount++
+							continue
+						}
+						if v != nil {
+							v2 := *v // clone!
+							v = &v2
+						}
+						dec = v
+					case decimal.Decimal:
+						if v.NaN() { // we're pretending this is NULL by our sql.Scanner's convetion
+							stat.NullCount++
+							continue
+						}
+						v2 := v
+						dec = &v2
+					}
+
+					ins(stat, dec, cmpDecimal)
+
+				case ColTypeUINT256:
+					v, ok := val.(*types.Uint256)
+					if !ok {
+						return fmt.Errorf("not a *types.Uint256: %T", val)
+					}
+
+					if v.Null {
+						stat.NullCount++
+						continue
+					}
+
+					ins(stat, v.Clone(), types.CmpUint256)
+
+				case ColTypeFloat: // we don't want, don't have
+					var varFloat float64
+					switch v := val.(type) {
+					case *pgtype.Float8:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						varFloat = v.Float64
+					case *pgtype.Float4:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						varFloat = float64(v.Float32)
+					case pgtype.Float8:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						varFloat = v.Float64
+					case pgtype.Float4:
+						if !v.Valid {
+							stat.NullCount++
+							continue
+						}
+						varFloat = float64(v.Float32)
+					case float32:
+						varFloat = float64(v)
+					case float64:
+						varFloat = v
+					case *float32:
+						varFloat = float64(*v)
+					case *float64:
+						varFloat = *v
+
+					default:
+						return fmt.Errorf("invalid float (%T)", val)
+					}
+
+					ins(stat, varFloat, cmp.Compare[float64])
+
+				case ColTypeUUID:
+					fallthrough // TODO
+				default: // arrays and such
+					// fmt.Println("unknown", colTypes[i])
+				}
+			}
+
+			return nil
+		},
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return colStats, nil
+}
+
+func cmpBool(a, b bool) int {
+	if b {
+		if a { // true == true
+			return 0
+		}
+		return -1 // false < true
+	}
+	if a {
+		return 1 // true > false
+	}
+	return 0 // false == false
+}
+
+func cmpDecimal(val, mm *decimal.Decimal) int {
+	d, err := val.Cmp(mm)
+	if err != nil {
+		panic(fmt.Sprintf("%s: (nan decimal?) %v or %v", err, val, mm))
+	}
+	return d
+}
+
+func ins[T any](stats *sql.ColumnStatistics, val T, comp func(v, m T) int) error {
+	if stats.Min == nil {
+		stats.Min = val
+		stats.MinCount = 1
+	} else if mn, ok := stats.Min.(T); ok {
+		switch comp(val, mn) {
+		case -1: // new MINimum
+			stats.Min = val
+			stats.MinCount = 1
+		case 0: // another of the same
+			stats.MinCount++
+		}
+	} else {
+		return fmt.Errorf("invalid stats value type %T for tuple of type %T", val, stats.Min)
+	}
+
+	if stats.Max == nil {
+		stats.Max = val
+		stats.MaxCount = 1
+	} else if mx, ok := stats.Max.(T); ok {
+		switch comp(val, mx) {
+		case 1: // new MAXimum
+			stats.Max = val
+			stats.MaxCount = 1
+		case 0: // another of the same
+			stats.MaxCount++
+		}
+	} else {
+		return fmt.Errorf("invalid stats value type %T for tuple of type %T", val, stats.Max)
+	}
+
+	return nil
+}

--- a/internal/sql/pg/stats_test.go
+++ b/internal/sql/pg/stats_test.go
@@ -1,0 +1,157 @@
+//go:build pglive
+
+package pg
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTableStats(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := NewDB(ctx, cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	tx, err := db.BeginTx(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+
+	tbl := "colcheck"
+	_, err = tx.Execute(ctx, `drop table if exists `+tbl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = tx.Execute(ctx, `create table if not exists `+tbl+
+		` (a int8 primary key, b int4 default 42, c text, d bytea, e numeric(20,5), f int8[], g uint256, h uint256[])`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cols, err := ColumnInfo(ctx, tx, "", tbl)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	wantCols := []ColInfo{
+		{Pos: 1, Name: "a", DataType: "bigint", Nullable: false},
+		{Pos: 2, Name: "b", DataType: "integer", Nullable: true, defaultVal: "42"},
+		{Pos: 3, Name: "c", DataType: "text", Nullable: true},
+		{Pos: 4, Name: "d", DataType: "bytea", Nullable: true},
+		{Pos: 5, Name: "e", DataType: "numeric", Nullable: true},
+		{Pos: 6, Name: "f", DataType: "bigint", Array: true, Nullable: true},
+		{Pos: 7, Name: "g", DataType: "uint256", Nullable: true},
+		{Pos: 8, Name: "h", DataType: "uint256", Array: true, Nullable: true},
+	}
+
+	assert.Equal(t, wantCols, cols)
+	// t.Logf("%#v", cols)
+
+	_, err = tx.Execute(ctx, `insert into `+tbl+` values `+
+		`(5, null, '', '\xabab', 12.6, '{99}', 30, '{}'), `+
+		`(-1, 0, 'B', '\x01', -7, '{1, 2}', 20, '{184467440737095516150}'), `+
+		`(3, 1, null, '\x', 8.1, NULL, NULL, NULL), `+
+		`(0, 0, 'Q', NULL, NULL, NULL, NULL, NULL), `+
+		`(7, -4, 'c', '\x0001', 0.3333, '{2,3,4}', 40, '{5,4,3}')`)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := TableStats(ctx, "", tbl, tx)
+	require.NoError(t, err)
+
+	t.Log(stats)
+
+	fmt.Println(stats.ColumnStatistics[4].Min)
+	fmt.Println(stats.ColumnStatistics[4].Max)
+}
+
+/*func TestScanBig(t *testing.T) {
+// This test is commented, but helpful for benchmarking performance with a large table.
+	ctx := context.Background()
+
+	cfg := *cfg
+	cfg.User = "kwild"
+	cfg.Pass = "kwild"
+	cfg.DBName = "kwil_test_db"
+
+	db, err := NewPool(ctx, &cfg.PoolConfig)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer db.Close()
+
+	tx, err := db.BeginTx(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer tx.Rollback(ctx)
+
+	tbl := `giant`
+	cols, err := ColumnInfo(ctx, tx, tbl)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Logf("%#v", cols)
+
+	stats, err := TableStats(ctx, tbl, tx)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log(stats)
+}*/
+
+func TestCmpBool(t *testing.T) {
+	tests := []struct {
+		name     string
+		a        bool
+		b        bool
+		expected int
+	}{
+		{"true_true", true, true, 0},
+		{"false_false", false, false, 0},
+		{"true_false", true, false, 1},
+		{"false_true", false, true, -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := cmpBool(tt.a, tt.b)
+			assert.Equal(t, tt.expected, result, "cmpBool(%v, %v) = %v; want %v", tt.a, tt.b, result, tt.expected)
+		})
+	}
+}
+
+func TestCmpBoolSymmetry(t *testing.T) {
+	booleans := []bool{true, false}
+
+	for _, a := range booleans {
+		for _, b := range booleans {
+			t.Run(fmt.Sprintf("a=%v,b=%v", a, b), func(t *testing.T) {
+				result1 := cmpBool(a, b)
+				result2 := cmpBool(b, a)
+				assert.Equal(t, -result2, result1, "cmpBool(%v, %v) and cmpBool(%v, %v) are not symmetric", a, b, b, a)
+			})
+		}
+	}
+}
+
+func TestCmpBoolTransitivity(t *testing.T) {
+	a, b, c := false, true, true
+
+	ab := cmpBool(a, b)
+	bc := cmpBool(b, c)
+	ac := cmpBool(a, c)
+
+	assert.True(t, (ab < 0 && bc <= 0) == (ac < 0), "cmpBool lacks transitivity")
+}

--- a/test/go.mod
+++ b/test/go.mod
@@ -148,7 +148,7 @@ require (
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 // indirect
-	github.com/jackc/pgx/v5 v5.5.5 // indirect
+	github.com/jackc/pgx/v5 v5.6.0 // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
 	github.com/jmhodges/levigo v1.0.0 // indirect
 	github.com/jonboulle/clockwork v0.4.0 // indirect

--- a/test/go.sum
+++ b/test/go.sum
@@ -438,8 +438,8 @@ github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsI
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9 h1:L0QtFUgDarD7Fpv9jeVMgy/+Ec0mtnmYuImjTz6dtDA=
 github.com/jackc/pgservicefile v0.0.0-20231201235250-de7065d80cb9/go.mod h1:5TJZWKEWniPve33vlWYSoGYefn3gLQRzjfDlhSJ9ZKM=
-github.com/jackc/pgx/v5 v5.5.5 h1:amBjrZVmksIdNjxGW/IiIMzxMKZFelXbUoPNb+8sjQw=
-github.com/jackc/pgx/v5 v5.5.5/go.mod h1:ez9gk+OAat140fv9ErkZDYFWmXLfV+++K0uAOiwgm1A=
+github.com/jackc/pgx/v5 v5.6.0 h1:SWJzexBzPL5jb0GEsrPMLIsi/3jOo7RHlzTjcAeDrPY=
+github.com/jackc/pgx/v5 v5.6.0/go.mod h1:DNZ/vlrUnhWCoFGxHAG8U2ljioxukquj7utPDgtQdTw=
 github.com/jackc/puddle/v2 v2.2.1 h1:RhxXJtFG022u4ibrCSMSiu5aOq1i77R3OHKNJj77OAk=
 github.com/jackc/puddle/v2 v2.2.1/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/jackpal/go-nat-pmp v1.0.2 h1:KzKSgb7qkJvOUTqYl9/Hg/me3pWgBmERKrTGD7BdWus=


### PR DESCRIPTION
This at least partially resolves #800, and provides some foundational components for table statistics collection (https://github.com/kwilteam/kwil-db/issues/410).  I have more work done on stats in both engine and pg for incremental updates, but the pieces in this PR were substantial, so I pulled them out for easier review.

This adds functionality to the `pg` package:

- Table inspection: the `ColumnInfo` function and the `ColInfo` and `ColType` types provide a way to inspect any postgresql table without knowledge of the scheme. The `(*ColInfo).ScanVal` method provides an instance of a suitable type into which a column expression may be scanned in one of the new advanced query methods described below.
- Advanced query execution:
    * the `sql.QueryScanner` interface is the advanced version of `Execute` that uses caller-provided scan values and a function to run for each scanned row:

        ```go
        // QueryScanner represents a type that provides the ability to execute an SQL
        // statement, where for each row:
        //
        //  1. result values are scanned into the variables in the scans slice
        //  2. the provided function is then called
        //
        // The function would typically capture the variables in the scans slice,
        // allowing it to operator on the values. For instance, append the values to
        // slices allocated by the caller, or perform reduction operations like
        // sum/mean/min/etc.
        //
        // NOTE: This method may end up being included in the Tx interface alongside
        // Executor since all of the concrete transaction implementations provided by
        // this package implement this method.
        type QueryScanner interface {
        	QueryScanFn(ctx context.Context, stmt string,
        		scans []any, fn func() error, args ...any) error
        }
        ```

    * each transaction type in the `pg` package satisfies the `sql.QueryScanner` interface
    * the `pg.QueryRowFunc` function executes an SQL statement, handling the rows and returned values as described by the `sql.QueryScanner` interface.
    * the `pg.QueryRowFuncAny` is similar to `pg.QueryRowFunc`, except that no scan values slice is provided. The provided function is called for each row of the result. The caller does not determine the types of the Go variables in the values slice. In this way it behaves similar to `Execute`, but providing "for each row" semantics so that every row does not need to be loaded into memory.

- Table statistics collection: beginning with a simplified `sql.Statistics` struct based on the types proposed in https://github.com/kwilteam/kwil-db/pull/603, the `pg` package provides the following new methods aimed at the (relatively expensive) collection of ground truth table statistics:
    * `RowCount` provides an exact row count
    * `colStats` computes column-wise statistics
    * `TableStats` uses the above functions to build a `*sql.Statistics` for a table.
    
    These methods are will not be used routinely. We will have incremental updates, but there are cases where a full scan may be needed to obtain the ground truth statistics.
- Use the `pgNumericToDecimal` helper to reuse the logic to convert from `pgtypes.Numeric` to either our `decimal.Decimal` or `types.Uint256` in the recent pgtype decoding added to the `query` helper for interpreting the values returned by `row.Values()` in `pgx.CollectRows`.

Note that this PR has three separate commits for easier review, but they can be squashed when merged.