### PR TITLE
added @block_timestamp

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -92,6 +92,9 @@ type TransactionData struct {
 
 	// Height is the block height of the incoming transaction.
 	Height int64
+
+	// BlockTimestamp is the unix timestamp of the block, set by the block proposer.
+	BlockTimestamp int64
 }
 
 // ExecutionOptions is contextual data that is passed to a procedure

--- a/common/context.go
+++ b/common/context.go
@@ -18,6 +18,11 @@ type BlockContext struct {
 	ChainContext *ChainContext
 	// Height gets the height of the current block.
 	Height int64
+	// BlockTimestamp is a timestamp of the current block.
+	// It is set by the block proposer, and therefore may not be accurate.
+	// It should not be used for time-sensitive operations where incorrect
+	// timestamps could result in security vulnerabilities.
+	BlockTimestamp int64
 	// Proposer gets the proposer public key of the current block.
 	Proposer []byte
 }

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -485,9 +485,10 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 	res := &abciTypes.ResponseFinalizeBlock{}
 
 	blockCtx := common.BlockContext{
-		ChainContext: a.chainContext,
-		Height:       req.Height,
-		Proposer:     proposerPubKey,
+		ChainContext:   a.chainContext,
+		Height:         req.Height,
+		BlockTimestamp: req.Time.Unix(),
+		Proposer:       proposerPubKey,
 	}
 
 	// since notifications are returned async from postgres, we will construct

--- a/internal/engine/execution/queries.go
+++ b/internal/engine/execution/queries.go
@@ -351,6 +351,11 @@ func setContextualVars(ctx context.Context, db sql.DB, data *common.ExecutionDat
 		return err
 	}
 
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.BlockTimestamp, data.BlockTimestamp))
+	if err != nil {
+		return err
+	}
+
 	// we have to set the foreign caller to the empty string if it is nil.
 	// We can't leave it nil because once a config parameter is set, it cannot be unset.
 	// This means that we cannot properly handle scoping of the foreign caller in the outermost

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -267,9 +267,10 @@ func (d *deployDatasetRoute) PreTx(ctx common.TxContext, svc *common.Service, tx
 func (d *deployDatasetRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	err := app.Engine.CreateDataset(ctx.Ctx, app.DB, d.schema,
 		&common.TransactionData{
-			Signer: tx.Sender,
-			Caller: d.identifier,
-			TxID:   hex.EncodeToString(ctx.TxID),
+			Signer:         tx.Sender,
+			Caller:         d.identifier,
+			TxID:           hex.EncodeToString(ctx.TxID),
+			BlockTimestamp: ctx.BlockContext.BlockTimestamp,
 		})
 	if err != nil {
 		return transactions.CodeUnknownError, err
@@ -314,9 +315,10 @@ func (d *dropDatasetRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *
 
 func (d *dropDatasetRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	err := app.Engine.DeleteDataset(ctx.Ctx, app.DB, d.dbid, &common.TransactionData{
-		Signer: tx.Sender,
-		Caller: d.identifier,
-		TxID:   hex.EncodeToString(ctx.TxID),
+		Signer:         tx.Sender,
+		Caller:         d.identifier,
+		TxID:           hex.EncodeToString(ctx.TxID),
+		BlockTimestamp: ctx.BlockContext.BlockTimestamp,
 	})
 	if err != nil {
 		return transactions.CodeUnknownError, err
@@ -387,10 +389,11 @@ func (d *executeActionRoute) InTx(ctx common.TxContext, app *common.App, tx *tra
 			Procedure: d.action,
 			Args:      d.args[i],
 			TransactionData: common.TransactionData{
-				Signer: tx.Sender,
-				Caller: d.identifier,
-				TxID:   hex.EncodeToString(ctx.TxID),
-				Height: ctx.BlockContext.Height,
+				Signer:         tx.Sender,
+				Caller:         d.identifier,
+				TxID:           hex.EncodeToString(ctx.TxID),
+				Height:         ctx.BlockContext.Height,
+				BlockTimestamp: ctx.BlockContext.BlockTimestamp,
 			},
 		})
 		if err != nil {

--- a/parse/contextual.go
+++ b/parse/contextual.go
@@ -15,14 +15,17 @@ var (
 	HeightVar = "height"
 	// foreign_caller is the dbid of the schema that made a foreign call.
 	ForeignCaller = "foreign_caller"
+	// block_timestamp is the unix timestamp of the block, set by the block proposer.
+	BlockTimestamp = "block_timestamp"
 	// SessionVars are the session variables that are available in the engine.
 	// It maps the variable name to its type.
 	SessionVars = map[string]*types.DataType{
-		CallerVar:     types.TextType,
-		TxidVar:       types.TextType,
-		SignerVar:     types.BlobType,
-		HeightVar:     types.IntType,
-		ForeignCaller: types.TextType,
+		CallerVar:      types.TextType,
+		TxidVar:        types.TextType,
+		SignerVar:      types.BlobType,
+		HeightVar:      types.IntType,
+		ForeignCaller:  types.TextType,
+		BlockTimestamp: types.IntType,
 	}
 )
 

--- a/test/acceptance/test-data/contextual_vars.kf
+++ b/test/acceptance/test-data/contextual_vars.kf
@@ -5,37 +5,40 @@ table vars {
     caller text,
     signer blob,
     txid text,
-    height int
+    height int,
+    block_timestamp int
 }
 
 // act_store_vars checks that contextual variables work as expected
 // in actions
 action act_store_vars() public {
-    insert into vars (id, caller, signer, txid, height)
+    insert into vars (id, caller, signer, txid, height, block_timestamp)
     values (
         uuid_generate_v5('985b93a4-2045-44d6-bde4-442a4e498bc6'::uuid, @txid),
         @caller,
         @signer,
         @txid,
-        @height
+        @height,
+        @block_timestamp
     );
 }
 
 // proc_store_vars checks that contextual variables work as expected
 // in procedures
 procedure proc_store_vars() public {
-    insert into vars (id, caller, signer, txid, height)
+    insert into vars (id, caller, signer, txid, height, block_timestamp)
     values (
         uuid_generate_v5('985b93a4-2045-44d6-bde4-442a4e498bc6'::uuid, @txid),
         @caller,
         @signer,
         @txid,
-        @height
+        @height,
+        @block_timestamp
     );
 }
 
-procedure get_stored() public view returns table(caller text, signer blob, txid text, height int) {
-    return select caller, signer, txid, height from vars;
+procedure get_stored() public view returns table(caller text, signer blob, txid text, height int, block_timestamp int) {
+    return select caller, signer, txid, height, block_timestamp from vars;
 }
 
 procedure delete_all() public {

--- a/test/specifications/contextual_vars.go
+++ b/test/specifications/contextual_vars.go
@@ -5,6 +5,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -44,7 +45,7 @@ func testCtxVars(ctx context.Context, t *testing.T, execute ProcedureDSL, dbid, 
 		count++
 		rec := results.Records.Record()
 		require.NotNil(t, rec)
-		require.Len(t, rec, 4)
+		require.Len(t, rec, 5)
 
 		// check caller
 		ident, err := execute.Identifier()
@@ -64,6 +65,19 @@ func testCtxVars(ctx context.Context, t *testing.T, execute ProcedureDSL, dbid, 
 		height := rec["height"]
 		if height.(int64) <= 0 {
 			t.Errorf("height should be greater than 0")
+		}
+
+		// block_timestamp
+		// We don't know the exact timestamp, but it should be greater than 1722439321
+		// (the time I am writing this test), and less than the current time.
+		blockTimestamp := rec["block_timestamp"]
+		if blockTimestamp.(int64) <= 1722439321 {
+			t.Errorf("block_timestamp should be greater than 1722439321")
+		}
+
+		// since our test node is acting honestly
+		if blockTimestamp.(int64) >= time.Now().Unix()+100 {
+			t.Errorf("block_timestamp should be less than the current time")
 		}
 	}
 	require.Equal(t, 1, count)


### PR DESCRIPTION
I added an `@block_timestamp` variable. Both Truflation and idOS requested this in the last 2 weeks.

We should make sure to note that this can be spoofed, since it is just based off of block time. A less-spoofable version could be added using cometbft's vote extensions, but that is something we can add at a later date.
