### PR TITLE
fix: generate_dbid() generates syntax error

### DIFF
--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -256,6 +256,12 @@ func Test_Procedures(t *testing.T) {
 				if generate_dbid('aa', decode('B7E2d6DABaf3B0038cFAaf09688Fa104f4409697', 'hex')) != 'xacfa19c2d4af530c6225ea139d611f91e7a55222a362dfd5eb70a826' {
 					error('generate_dbid failed');
 				}
+
+				// regression test for invalid generated sql
+				$dbid := generate_dbid('aa', decode('B7E2d6DABaf3B0038cFAaf09688Fa104f4409697', 'hex'));
+				if $dbid != 'xacfa19c2d4af530c6225ea139d611f91e7a55222a362dfd5eb70a826' {
+					error('generate_dbid regression test failed');
+				}
 			}`,
 		},
 		{

--- a/parse/functions.go
+++ b/parse/functions.go
@@ -207,7 +207,7 @@ var (
 					return "", errDistinct("generate_dbid")
 				}
 
-				return fmt.Sprintf(`('x' || encode(sha224(lower(%s)::bytea || %s), 'hex'))`, inputs[0], inputs[1]), nil
+				return fmt.Sprintf(`(select 'x' || encode(sha224(lower(%s)::bytea || %s), 'hex'))`, inputs[0], inputs[1]), nil
 			},
 		},
 		// array functions


### PR DESCRIPTION
The new `generate_dbid` function generates a syntax error if it is used with assignment (`:=`). I fixed this and added a test for it.
