### PR TITLE
added better messages for testing

### DIFF
--- a/cmd/kwil-cli/cmds/utils/test.go
+++ b/cmd/kwil-cli/cmds/utils/test.go
@@ -178,7 +178,7 @@ func testCmd() *cobra.Command {
 
 	cmd.Flags().StringSliceVarP(&testCases, "file", "f", nil, "filepaths of tests to run")
 	cmd.Flags().BoolVar(&useTestContainer, "test-container", false, "runs the tests with a Docker testcontainer")
-	cmd.Flags().StringVar(&dbName, "database", "kwild", "name of the database to snapshot")
+	cmd.Flags().StringVar(&dbName, "database", "kwild", "name of the Postgres database to manually connect to")
 	cmd.Flags().StringVar(&user, "user", "postgres", "user with administrative privileges on the database")
 	cmd.Flags().StringVar(&pass, "password", "", "password for the database user")
 	cmd.Flags().StringVar(&host, "host", "localhost", "host of the database")

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -342,7 +342,8 @@ func (e *TestCase) runExecution(ctx context.Context, platform *Platform) error {
 
 		for j, col := range row {
 			if !assert.ObjectsAreEqualValues(e.Returns[i][j], col) {
-				return fmt.Errorf("incorrect value for expected result: row %d, column %d", i, j)
+				// add 1 to row and column index since they are 0 indexed.
+				return fmt.Errorf(`incorrect value for expected result: row %d, column %d. expected "%s", received "%s"`, i+1, j+1, e.Returns[i][j], col)
 			}
 		}
 	}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -343,7 +343,7 @@ func (e *TestCase) runExecution(ctx context.Context, platform *Platform) error {
 		for j, col := range row {
 			if !assert.ObjectsAreEqualValues(e.Returns[i][j], col) {
 				// add 1 to row and column index since they are 0 indexed.
-				return fmt.Errorf(`incorrect value for expected result: row %d, column %d. expected "%s", received "%s"`, i+1, j+1, e.Returns[i][j], col)
+				return fmt.Errorf(`incorrect value for expected result: row %d, column %d. expected "%v", received "%v"`, i+1, j+1, e.Returns[i][j], col)
 			}
 		}
 	}


### PR DESCRIPTION
While using the testing tool, I noticed two weird messages.

One of them was with the CLI. It had a flag description that I had copied over from snapshotting, and thus had an irrelevant description. The second of them was an error message for failed tests that could've been more helpful and accurate.
