### PR TITLE
admin: set/use optional admin service password

### DIFF
--- a/core/adminclient/client.go
+++ b/core/adminclient/client.go
@@ -30,6 +30,8 @@ type AdminClient struct {
 
 	log log.Logger
 
+	pass string
+
 	// optional TLS files
 	kwildCertFile  string
 	clientKeyFile  string
@@ -178,6 +180,7 @@ func NewClient(ctx context.Context, target string, opts ...Opt) (*AdminClient, e
 			Transport: trans,
 		}),
 		rpcclient.WithLogger(c.log),
+		rpcclient.WithPass(c.pass),
 	)
 	c.adminSvcClient = cl
 

--- a/core/adminclient/opts.go
+++ b/core/adminclient/opts.go
@@ -13,6 +13,14 @@ func WithLogger(logger log.Logger) Opt {
 	}
 }
 
+// WithPass specifies a password to use, if password authentication is enable on
+// the server.
+func WithPass(pass string) Opt {
+	return func(c *AdminClient) {
+		c.pass = pass
+	}
+}
+
 // WithTLS provides the required files for the admin client to use TLS, and
 // possibly client authenticated TLS. kwildCertFile may be omitted if the
 // service is issued a TLS certificate by a root CA. The client files may be

--- a/internal/services/jsonrpc/server.go
+++ b/internal/services/jsonrpc/server.go
@@ -400,8 +400,7 @@ func (s *Server) handlerV1(w http.ResponseWriter, r *http.Request) {
 	r.Close = true
 
 	if s.authSHA != nil {
-		// r.SetBasicAuth("", "passwords")
-		_, pass, haveAuth := r.Response.Request.BasicAuth() // r.Header.Get("Authorization")
+		_, pass, haveAuth := r.BasicAuth() // r.Header.Get("Authorization")
 		if !haveAuth {
 			http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
 			return


### PR DESCRIPTION
```
core/{rpc,adminclient},kwil-admin: set/use optional admin service password

This updates the admin RPC client with the ability to set the admin
RPC password, which was introduced when the server was converted to
JSON-RPC.

This also updates kwil-admin with a "--pass" flag to specify it.
With security implications in mind, an optional file at
~/.kwil-admin/rpc-admin-pass will be loaded if the --pass flag is
omitted and the file exists.

Finally, this fixes a nil ptr bug in the JSON-RPC admin server.

NOTE: if using curl, use the "-u" flag with "user:pass", where "pass"
is the intended password.  The "user" part is ignored but required
for HTTP Basic authentication to work properly.
```

As a reminder, back when we only had gRPC for the admin server, there were limited solutions for authentication, so we went with transport layer authentication (mTLS).  With JSON-RPC and the http.Server and its routes under our fully control, it is minimally invasive to add http basic auth, which was why I added it initially.  For some reason I simply neglected to add client support, only having tried it with `curl -u`