### PR TITLE
removed unnecessary peer flag

### DIFF
--- a/cmd/kwil-admin/cmds/setup/peer.go
+++ b/cmd/kwil-admin/cmds/setup/peer.go
@@ -16,7 +16,7 @@ var (
 It will automatically generate required directories and keypairs, and can be given a genesis file and peer list for an existing network.`
 
 	peerExample = `# Initialize a node as a peer to an existing network
-kwil-admin setup peer --root-dir ./kwil-node --genesis /path/to/genesis.json`
+kwil-admin setup peer --root-dir ./kwil-node --genesis /path/to/genesis.json --chain.p2p.persistent-peers peer1@ip:26656,peer2@ip:26656`
 )
 
 func peerCmd() *cobra.Command {

--- a/cmd/kwil-admin/cmds/setup/peer.go
+++ b/cmd/kwil-admin/cmds/setup/peer.go
@@ -16,7 +16,7 @@ var (
 It will automatically generate required directories and keypairs, and can be given a genesis file and peer list for an existing network.`
 
 	peerExample = `# Initialize a node as a peer to an existing network
-kwil-admin setup peer --root-dir ./kwil-node --genesis /path/to/genesis.json --peers`
+kwil-admin setup peer --root-dir ./kwil-node --genesis /path/to/genesis.json`
 )
 
 func peerCmd() *cobra.Command {


### PR DESCRIPTION
Removes an incorrectly documented flag `--peers`, as noted [here](<https://github.com/truflation/tsn/issues/393#issuecomment-2283364060>)
