### PR TITLE
Peer filtering based on the whitelisted peers

### DIFF
--- a/cmd/kwil-admin/cmds/peers/add.go
+++ b/cmd/kwil-admin/cmds/peers/add.go
@@ -12,7 +12,7 @@ import (
 func addCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "add <peerID>",
-		Short:   "Add a peer to the node's peer list",
+		Short:   "Add a peer to the node's whitelist peers to accept connections from",
 		Example: "kwil-admin peers add <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kwil-admin/cmds/peers/add.go
+++ b/cmd/kwil-admin/cmds/peers/add.go
@@ -1,0 +1,50 @@
+package peers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
+	"github.com/spf13/cobra"
+)
+
+func addCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "add <peerID>",
+		Short:   "Add a peer to the node's peer list",
+		Example: "kwil-admin peers add <peerID>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			client, err := common.GetAdminSvcClient(ctx, cmd)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			err = client.AddPeer(ctx, args[0])
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			return display.PrintCmd(cmd, &addMsg{peerID: args[0]})
+		},
+	}
+	common.BindRPCFlags(cmd)
+
+	return cmd
+}
+
+type addMsg struct {
+	peerID string
+}
+
+var _ display.MsgFormatter = (*addMsg)(nil)
+
+func (a *addMsg) MarshalText() ([]byte, error) {
+	return []byte("Added peer " + a.peerID), nil
+}
+
+func (a *addMsg) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.peerID)
+}

--- a/cmd/kwil-admin/cmds/peers/cmd.go
+++ b/cmd/kwil-admin/cmds/peers/cmd.go
@@ -12,7 +12,7 @@ func PeersCmd() *cobra.Command {
 	peersCmd.AddCommand(
 		addCmd(),
 		removeCmd(),
-		// listCmd(),
+		listCmd(),
 	)
 	return peersCmd
 }

--- a/cmd/kwil-admin/cmds/peers/cmd.go
+++ b/cmd/kwil-admin/cmds/peers/cmd.go
@@ -1,0 +1,18 @@
+package peers
+
+import "github.com/spf13/cobra"
+
+var peersCmd = &cobra.Command{
+	Use:     "peers",
+	Short:   "manages the node's peers",
+	Aliases: []string{"peer"},
+}
+
+func PeersCmd() *cobra.Command {
+	peersCmd.AddCommand(
+		addCmd(),
+		removeCmd(),
+		// listCmd(),
+	)
+	return peersCmd
+}

--- a/cmd/kwil-admin/cmds/peers/list.go
+++ b/cmd/kwil-admin/cmds/peers/list.go
@@ -1,0 +1,51 @@
+package peers
+
+import (
+	"context"
+	"encoding/json"
+	"strings"
+
+	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
+	"github.com/spf13/cobra"
+)
+
+func listCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "list",
+		Short:   "List all peers in the node's whitelist.",
+		Example: "kwil-admin peers list",
+		Args:    cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			client, err := common.GetAdminSvcClient(ctx, cmd)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			peers, err := client.ListPeers(ctx)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			return display.PrintCmd(cmd, &listPeersMsg{peers: peers})
+		},
+	}
+	common.BindRPCFlags(cmd)
+
+	return cmd
+}
+
+type listPeersMsg struct {
+	peers []string
+}
+
+var _ display.MsgFormatter = (*listPeersMsg)(nil)
+
+func (l *listPeersMsg) MarshalText() ([]byte, error) {
+	return []byte("Peers:  \n" + strings.Join(l.peers, "\n")), nil
+}
+
+func (l *listPeersMsg) MarshalJSON() ([]byte, error) {
+	return json.Marshal(l.peers)
+}

--- a/cmd/kwil-admin/cmds/peers/remove.go
+++ b/cmd/kwil-admin/cmds/peers/remove.go
@@ -1,0 +1,50 @@
+package peers
+
+import (
+	"context"
+	"encoding/json"
+
+	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
+	"github.com/spf13/cobra"
+)
+
+func removeCmd() *cobra.Command {
+	var cmd = &cobra.Command{
+		Use:     "remove <peerID>",
+		Short:   "Remove a peer from the node's peer list",
+		Example: "kwil-admin peers remove <peerID>",
+		Args:    cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := context.Background()
+			client, err := common.GetAdminSvcClient(ctx, cmd)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			err = client.RemovePeer(ctx, args[0])
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			return display.PrintCmd(cmd, &removeMsg{peerID: args[0]})
+		},
+	}
+	common.BindRPCFlags(cmd)
+
+	return cmd
+}
+
+type removeMsg struct {
+	peerID string
+}
+
+var _ display.MsgFormatter = (*addMsg)(nil)
+
+func (a *removeMsg) MarshalText() ([]byte, error) {
+	return []byte("Removed peer " + a.peerID), nil
+}
+
+func (a *removeMsg) MarshalJSON() ([]byte, error) {
+	return json.Marshal(a.peerID)
+}

--- a/cmd/kwil-admin/cmds/peers/remove.go
+++ b/cmd/kwil-admin/cmds/peers/remove.go
@@ -12,7 +12,7 @@ import (
 func removeCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "remove <peerID>",
-		Short:   "Remove a peer from the node's peer list",
+		Short:   "Remove a peer from the node's whitelist peers and disconnect the peer",
 		Example: "kwil-admin peers remove <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kwil-admin/cmds/root.go
+++ b/cmd/kwil-admin/cmds/root.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/common/version"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/key"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/node"
+	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/peers"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/setup"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/snapshot"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/utils"
@@ -21,6 +22,7 @@ func NewRootCmd() *cobra.Command {
 		validators.NewValidatorsCmd(),
 		utils.NewUtilsCmd(),
 		snapshot.NewSnapshotCmd(),
+		peers.PeersCmd(),
 	)
 
 	display.BindOutputFormatFlag(rootCmd)

--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -54,6 +54,9 @@ type TestnetGenerateConfig struct {
 	ChainID       string
 	BlockInterval time.Duration
 	// InitialHeight           int64
+	AdminAddress string
+	AdminNoTLS   bool
+
 	NValidators             int
 	NNonValidators          int
 	ConfigFile              string
@@ -76,6 +79,7 @@ type TestnetGenerateConfig struct {
 	MaxSnapshots            uint64
 	SnapshotHeights         uint64
 	Forks                   map[string]*uint64
+	PrivateMode             bool
 }
 
 // ConfigOpts is a struct to alter the generation of the node config.
@@ -255,6 +259,11 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 		}
 	}
 
+	if genCfg.AdminAddress != "" {
+		cfg.AppCfg.AdminListenAddress = genCfg.AdminAddress
+	}
+	cfg.AppCfg.NoTLS = genCfg.AdminNoTLS
+
 	privateKeys := make([]cmtEd.PrivKey, nNodes)
 	for i := range privateKeys {
 		privateKeys[i] = cmtEd.GenPrivKey()
@@ -320,6 +329,8 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 	}
 	cfg.ChainCfg.P2P.AddrBookStrict = false
 	cfg.ChainCfg.P2P.AllowDuplicateIP = true
+	// private mode
+	cfg.ChainCfg.P2P.PrivateMode = genCfg.PrivateMode
 
 	if genCfg.SnapshotsEnabled {
 		cfg.AppCfg.Snapshots.Enabled = true

--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -275,6 +275,10 @@ external_address = "{{ .ChainCfg.P2P.ExternalAddress }}"
 # Example: "d128266b8b9f64c313de466cf29e0a6182dba54d@172.10.100.2:26656,9440f4a8059cf7ff31454973c4f9c68de65fe526@172.10.100.3:26656"
 persistent_peers = "{{ .ChainCfg.P2P.PersistentPeers }}"
 
+# WhitelistPeers is a comma seperated list of nodeIDs that can connect to this node.
+# persistent peers, seeds and current validators are automatically whitelisted and need not be added here.
+whitelist_peers = "{{ .ChainCfg.P2P.WhitelistPeers }}"
+
 # Set true for strict address routability rules
 # Set false for private or local networks
 addr_book_strict = {{ .ChainCfg.P2P.AddrBookStrict }}

--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -275,7 +275,12 @@ external_address = "{{ .ChainCfg.P2P.ExternalAddress }}"
 # Example: "d128266b8b9f64c313de466cf29e0a6182dba54d@172.10.100.2:26656,9440f4a8059cf7ff31454973c4f9c68de65fe526@172.10.100.3:26656"
 persistent_peers = "{{ .ChainCfg.P2P.PersistentPeers }}"
 
-# WhitelistPeers is a comma seperated list of nodeIDs that can connect to this node.
+# PrivateMode prevents other nodes from connecting to the node unless the node is  
+# a current validator, or a seed node or a persistent peer or a whitelist peer.
+# If disabled, the node will accept connections from any peer.
+private_mode = {{ .ChainCfg.P2P.PrivateMode }}
+
+# WhitelistPeers is a comma separated list of nodeIDs that can connect to this node.
 # persistent peers, seeds and current validators are automatically whitelisted and need not be added here.
 whitelist_peers = "{{ .ChainCfg.P2P.WhitelistPeers }}"
 

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -119,7 +119,11 @@ type P2PConfig struct {
 	// PersistentPeers is a comma separated list of nodes to keep persistent
 	// connections to.
 	PersistentPeers string `mapstructure:"persistent_peers"`
-	// WhitelistPeers is a comma seperated list of nodeIDs that can connect to this node.
+	// PrivateMode prevents other nodes from connecting to the node unless
+	// they are the current validators or a part of the whitelistPeers.
+	// If disabled, the node by default operates in public mode, where any node can connect to it.
+	PrivateMode bool `mapstructure:"private_mode"`
+	// WhitelistPeers is a comma separated list of nodeIDs that can connect to this node.
 	// This is excluding any persistent peers or seeds or current validators.
 	WhitelistPeers string `mapstructure:"whitelist_peers"`
 	// AddrBookStrict enforces strict address routability rules. This must be
@@ -595,6 +599,7 @@ func DefaultConfig() *KwildConfig {
 			P2P: &P2PConfig{
 				ListenAddress:       "tcp://0.0.0.0:26656",
 				ExternalAddress:     "",
+				PrivateMode:         false,
 				AddrBookStrict:      false, // override comet
 				MaxNumInboundPeers:  40,
 				MaxNumOutboundPeers: 10,

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -119,6 +119,9 @@ type P2PConfig struct {
 	// PersistentPeers is a comma separated list of nodes to keep persistent
 	// connections to.
 	PersistentPeers string `mapstructure:"persistent_peers"`
+	// WhitelistPeers is a comma seperated list of nodeIDs that can connect to this node.
+	// This is excluding any persistent peers or seeds or current validators.
+	WhitelistPeers string `mapstructure:"whitelist_peers"`
 	// AddrBookStrict enforces strict address routability rules. This must be
 	// false for private or local networks.
 	AddrBookStrict bool `mapstructure:"addr_book_strict"`

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -70,6 +70,10 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *KwildConfig) {
 sharing them with incoming peers before immediately disconnecting. It is recommended
 to instead run a dedicated seeder like https://github.com/kwilteam/cometseed.`)
 
+	// Network flags
+	flagSet.BoolVarP(&cfg.ChainCfg.P2P.PrivateMode, "chain.p2p.private-mode", "p", cfg.ChainCfg.P2P.PrivateMode, "Run the node in private mode. In private mode, the connectivity to the node is restricted to the current validators and whitelist peers.")
+	flagSet.StringVar(&cfg.ChainCfg.P2P.WhitelistPeers, "chain.p2p.whitelist-peers", cfg.ChainCfg.P2P.WhitelistPeers, "List of allowed sentry nodes that can connect to the node. Whitelist peers can be updated dynamically using kwil-admin peer commands.")
+
 	// Chain Mempool flags
 	flagSet.IntVar(&cfg.ChainCfg.Mempool.Size, "chain.mempool.size", cfg.ChainCfg.Mempool.Size, "Chain mempool size")
 	flagSet.IntVar(&cfg.ChainCfg.Mempool.CacheSize, "chain.mempool.cache-size", cfg.ChainCfg.Mempool.CacheSize, "Chain mempool cache size")

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -171,6 +171,8 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	snapshotter := buildSnapshotter(d)
 	statesyncer := buildStatesyncer(d)
 
+	p2p := buildPeers(d, closers)
+
 	// this is a hack
 	// we need the cometbft client to broadcast txs.
 	// in order to get this, we need the comet node
@@ -178,8 +180,6 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	// to get the abci app, we need the tx router
 	// but the tx router needs the cometbft client
 	txApp := buildTxApp(d, db, e, ev)
-
-	p2p := buildPeers(d, closers)
 
 	abciApp := buildAbci(d, db, txApp, snapshotter, statesyncer, p2p, closers)
 
@@ -356,7 +356,7 @@ func buildPeers(d *coreDependencies, closers *closeFuncs) *cometbft.PeerWhiteLis
 	}
 	if len(vals) > 0 {
 		for _, v := range vals {
-			addr, err := abci.PubkeyToAddr(v.PubKey)
+			addr, err := cometbft.PubkeyToAddr(v.PubKey)
 			if err != nil {
 				failBuild(err, "failed to convert pubkey to address")
 			}
@@ -365,7 +365,7 @@ func buildPeers(d *coreDependencies, closers *closeFuncs) *cometbft.PeerWhiteLis
 	} else {
 		// Load the validators from the genesis file
 		for _, v := range d.genesisCfg.Validators {
-			addr, err := abci.PubkeyToAddr(v.PubKey)
+			addr, err := cometbft.PubkeyToAddr(v.PubKey)
 			if err != nil {
 				failBuild(err, "failed to convert pubkey to address")
 			}

--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -68,6 +68,7 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 		nodeCfg.Moniker = userChainCfg.Moniker
 	}
 
+	nodeCfg.FilterPeers = true
 	nodeCfg.RPC.ListenAddress = cleanListenAddr(userChainCfg.RPC.ListenAddress,
 		portFromURL(nodeCfg.RPC.ListenAddress))
 	nodeCfg.RPC.TLSCertFile = cfg.AppCfg.TLSCertFile

--- a/core/rpc/client/admin/admin.go
+++ b/core/rpc/client/admin/admin.go
@@ -25,4 +25,5 @@ type AdminClient interface {
 
 	AddPeer(ctx context.Context, peerID string) error
 	RemovePeer(ctx context.Context, peerID string) error
+	ListPeers(ctx context.Context) ([]string, error)
 }

--- a/core/rpc/client/admin/admin.go
+++ b/core/rpc/client/admin/admin.go
@@ -22,4 +22,7 @@ type AdminClient interface {
 	// GetConfig gets the current config from the node.
 	// It returns the config serialized as JSON.
 	GetConfig(ctx context.Context) ([]byte, error)
+
+	AddPeer(ctx context.Context, peerID string) error
+	RemovePeer(ctx context.Context, peerID string) error
 }

--- a/core/rpc/client/admin/jsonrpc/client.go
+++ b/core/rpc/client/admin/jsonrpc/client.go
@@ -217,3 +217,14 @@ func (cl *Client) RemovePeer(ctx context.Context, peerID string) error {
 	res := &adminjson.PeerResponse{}
 	return cl.CallMethod(ctx, string(adminjson.MethodRemovePeer), cmd, res)
 }
+
+// ListPeers lists all peers in the node's whitelist.
+func (cl *Client) ListPeers(ctx context.Context) ([]string, error) {
+	cmd := &adminjson.ListPeersRequest{}
+	res := &adminjson.ListPeersResponse{}
+	err := cl.CallMethod(ctx, string(adminjson.MethodListPeers), cmd, res)
+	if err != nil {
+		return nil, err
+	}
+	return res.Peers, err
+}

--- a/core/rpc/client/admin/jsonrpc/client.go
+++ b/core/rpc/client/admin/jsonrpc/client.go
@@ -199,3 +199,21 @@ func (cl *Client) Ping(ctx context.Context) (string, error) {
 	}
 	return res.Message, nil
 }
+
+// AddPeer adds a new peer to the node's peer list.
+func (cl *Client) AddPeer(ctx context.Context, peerID string) error {
+	cmd := &adminjson.PeerRequest{
+		PeerID: peerID,
+	}
+	res := &adminjson.PeerResponse{}
+	return cl.CallMethod(ctx, string(adminjson.MethodAddPeer), cmd, res)
+}
+
+// RemovePeer adds a new peer to the node's peer list.
+func (cl *Client) RemovePeer(ctx context.Context, peerID string) error {
+	cmd := &adminjson.PeerRequest{
+		PeerID: peerID,
+	}
+	res := &adminjson.PeerResponse{}
+	return cl.CallMethod(ctx, string(adminjson.MethodRemovePeer), cmd, res)
+}

--- a/core/rpc/json/admin/commands.go
+++ b/core/rpc/json/admin/commands.go
@@ -22,3 +22,5 @@ type ListJoinRequestsRequest struct{}
 type PeerRequest struct {
 	PeerID string `json:"peerid"`
 }
+
+type ListPeersRequest struct{}

--- a/core/rpc/json/admin/commands.go
+++ b/core/rpc/json/admin/commands.go
@@ -18,3 +18,7 @@ type JoinStatusRequest struct {
 }
 type ListValidatorsRequest struct{}
 type ListJoinRequestsRequest struct{}
+
+type PeerRequest struct {
+	PeerID string `json:"peerid"`
+}

--- a/core/rpc/json/admin/methods.go
+++ b/core/rpc/json/admin/methods.go
@@ -18,4 +18,5 @@ const (
 	MethodValListJoins  jsonrpc.Method = "admin.val_list_joins"
 	MethodAddPeer       jsonrpc.Method = "admin.add_peer"
 	MethodRemovePeer    jsonrpc.Method = "admin.remove_peer"
+	MethodListPeers     jsonrpc.Method = "admin.list_peers"
 )

--- a/core/rpc/json/admin/methods.go
+++ b/core/rpc/json/admin/methods.go
@@ -16,4 +16,6 @@ const (
 	MethodValJoinStatus jsonrpc.Method = "admin.val_join_status"
 	MethodValList       jsonrpc.Method = "admin.val_list"
 	MethodValListJoins  jsonrpc.Method = "admin.val_list_joins"
+	MethodAddPeer       jsonrpc.Method = "admin.add_peer"
+	MethodRemovePeer    jsonrpc.Method = "admin.remove_peer"
 )

--- a/core/rpc/json/admin/responses.go
+++ b/core/rpc/json/admin/responses.go
@@ -84,3 +84,9 @@ type GetConfigResponse struct {
 }
 
 type PeerResponse struct{}
+
+// List of peers in the node's whitelist.
+// These are the peers the node will accept connections from.
+type ListPeersResponse struct {
+	Peers []string `json:"peers,omitempty"`
+}

--- a/core/rpc/json/admin/responses.go
+++ b/core/rpc/json/admin/responses.go
@@ -82,3 +82,5 @@ type ListJoinRequestsResponse struct {
 type GetConfigResponse struct {
 	Config []byte `json:"config,omitempty"`
 }
+
+type PeerResponse struct{}

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -695,8 +695,8 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 	}
 
 	// Join requests approved by this node are added to the peer list.
-	for _, join := range approvedJoins {
-		addr, err := cometbft.PubkeyToAddr(join.PubKey)
+	for _, pubKey := range approvedJoins {
+		addr, err := cometbft.PubkeyToAddr(pubKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert pubkey to address: %w", err)
 		}
@@ -708,8 +708,8 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 	}
 
 	// peers whose join requests have expired are removed from the peer list
-	for _, join := range expiredJoins {
-		addr, err := cometbft.PubkeyToAddr(join.PubKey)
+	for _, pubKey := range expiredJoins {
+		addr, err := cometbft.PubkeyToAddr(pubKey)
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert pubkey to address: %w", err)
 		}
@@ -1500,6 +1500,7 @@ func (a *AbciApp) Query(ctx context.Context, req *abciTypes.RequestQuery) (*abci
 		switch paths[0] {
 		case "id":
 			if a.p2p.IsPeerWhitelisted(paths[1]) {
+				a.log.Info("Connection attempt accepted, peer is allowed to connect", zap.String("peerID", paths[1]))
 				return &abciTypes.ResponseQuery{Code: abciTypes.CodeTypeOK}, nil
 			}
 			// ID is not in the allowed list of peers, so reject the connection

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -411,7 +411,7 @@ func (m *mockTxApp) Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Tra
 	return nil
 }
 
-func (m *mockTxApp) Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (validatorUpgrades, approvedJoins, expiredJoins []*types.Validator, err error) {
+func (m *mockTxApp) Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (validatorUpgrades []*types.Validator, approvedJoins, expiredJoins [][]byte, err error) {
 	return nil, nil, nil, nil
 }
 

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -411,8 +411,8 @@ func (m *mockTxApp) Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Tra
 	return nil
 }
 
-func (m *mockTxApp) Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (validatorUpgrades []*types.Validator, err error) {
-	return nil, nil
+func (m *mockTxApp) Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (validatorUpgrades, approvedJoins, expiredJoins []*types.Validator, err error) {
+	return nil, nil, nil, nil
 }
 
 func (m *mockTxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, accounts []*types.Account,

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -232,8 +232,9 @@ func (n *CometBftNode) RemovePeer(nodeID string) error {
 	peerInfo := n.Node.Switch().Peers()
 	id := p2p.ID(nodeID)
 	peer := peerInfo.Get(id)
-	if peer == nil {
-		return fmt.Errorf("peer %s not found", nodeID)
+	if peer == nil { // peer is not connected to this node, so nothing to do
+		n.Node.Logger.Info("peer is not connected", "peerID", nodeID)
+		return nil
 	}
 
 	n.Node.Switch().StopPeerGracefully(peer)

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -227,3 +227,15 @@ func (n *CometBftNode) Stop() error {
 func (n *CometBftNode) IsCatchup() bool {
 	return n.Node.ConsensusReactor().WaitSync()
 }
+
+func (n *CometBftNode) RemovePeer(nodeID string) error {
+	peerInfo := n.Node.Switch().Peers()
+	id := p2p.ID(nodeID)
+	peer := peerInfo.Get(id)
+	if peer == nil {
+		return fmt.Errorf("peer %s not found", nodeID)
+	}
+
+	n.Node.Switch().StopPeerGracefully(peer)
+	return nil
+}

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -12,6 +12,7 @@ import (
 
 	abciTypes "github.com/cometbft/cometbft/abci/types"
 	cometConfig "github.com/cometbft/cometbft/config"
+	"github.com/cometbft/cometbft/crypto/ed25519"
 	cometEd25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	cometLog "github.com/cometbft/cometbft/libs/log"
 	cometNodes "github.com/cometbft/cometbft/node"
@@ -239,4 +240,17 @@ func (n *CometBftNode) RemovePeer(nodeID string) error {
 
 	n.Node.Switch().StopPeerGracefully(peer)
 	return nil
+}
+
+// PubkeyToAddr converts an Ed25519 public key as used to identify nodes in
+// CometBFT into an address, which for ed25519 in comet is an upper case
+// truncated sha256 hash of the pubkey. For secp256k1, they do like BTC with
+// RIPEMD160(SHA256(pubkey)).  If we support both (if either), we'll need a type
+// flag.
+func PubkeyToAddr(pubkey []byte) (string, error) {
+	if len(pubkey) != ed25519.PubKeySize {
+		return "", errors.New("invalid public key")
+	}
+	publicKey := ed25519.PubKey(pubkey)
+	return publicKey.Address().String(), nil
 }

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -12,7 +12,6 @@ import (
 
 	abciTypes "github.com/cometbft/cometbft/abci/types"
 	cometConfig "github.com/cometbft/cometbft/config"
-	"github.com/cometbft/cometbft/crypto/ed25519"
 	cometEd25519 "github.com/cometbft/cometbft/crypto/ed25519"
 	cometLog "github.com/cometbft/cometbft/libs/log"
 	cometNodes "github.com/cometbft/cometbft/node"
@@ -248,9 +247,9 @@ func (n *CometBftNode) RemovePeer(nodeID string) error {
 // RIPEMD160(SHA256(pubkey)).  If we support both (if either), we'll need a type
 // flag.
 func PubkeyToAddr(pubkey []byte) (string, error) {
-	if len(pubkey) != ed25519.PubKeySize {
+	if len(pubkey) != cometEd25519.PubKeySize {
 		return "", errors.New("invalid public key")
 	}
-	publicKey := ed25519.PubKey(pubkey)
+	publicKey := cometEd25519.PubKey(pubkey)
 	return publicKey.Address().String(), nil
 }

--- a/internal/abci/cometbft/peers.go
+++ b/internal/abci/cometbft/peers.go
@@ -12,7 +12,7 @@ import (
 )
 
 const (
-	p2pSchemaName = "peers" // TODO: Umm, should this be part of the chain metadata schema?
+	p2pSchemaName = "peers"
 
 	p2pStoreVersion = 0
 
@@ -20,24 +20,28 @@ const (
 		peer_id TEXT PRIMARY KEY
 	);`
 
-	addPeer = `INSERT INTO ` + p2pSchemaName + `.peers ` + `VALUES ($1) ` + `ON CONFLICT (peer_id) DO NOTHING;`
+	addPeer = `INSERT INTO ` + p2pSchemaName + `.peers ` + `VALUES ($1);`
 
 	removePeer = `DELETE FROM ` + p2pSchemaName + `.peers ` + `WHERE peer_id = $1;`
 )
 
-// Peers object is used to manage the set of peers that a node is allowed to connect to.
-// Static peers are those that are added in the genesis and are trusted by default. These
-// include the initial validators, persistent peers, and seed nodes.
-// Whitelist peers are the list of allowed sentry nodes that a node can connect to.
-// Whitelist peers can be updated dynamically using kwil-admin commands and are persisted
-// to disk.
+// PeerWhitelist object is used to manage the set of peers that a node is allowed to connect to.
+// Whitelist peers are the list of allowed nodes that the node can accept connections from.
+// Whitelist peers can be configured using the "chain.p2p.whitelist_peers" config in the config.toml file
+// and can be updated dynamically using kwil-admin commands.
+// The genesis validators are by default added to the whitelist peers during genesis. Any new validators
+// are automatically added to the whitelist peers and demoted validators are removed from the whitelist.
 // The Peers gossiped using PEX are not automatically trusted, and to be added manually if needed.
-// Any new validators are automatically added to the whitelist peers and demoted validators are removed from the whitelist.
-type Peers struct {
-	// whitelistPeers is a map of node IDs.
+type PeerWhiteList struct {
+	// privateMode is a flag to run the node in private mode. If disabled, the node will accept connections from any peer.
+	// If enabled, the node will only accept connections from the current validators and whitelist peers.
+	privateMode bool
+
+	// whitelistPeers is a map of node IDs that the node can accept connections from.
 	whitelistPeers map[string]bool
 	peerMtx        sync.RWMutex // protects peers
 
+	// removePeerFn is a function to gracefully stop and remove a peer connection.
 	removePeerFn func(peerID string) error
 
 	db sql.TxMaker
@@ -49,7 +53,7 @@ func initTables(ctx context.Context, tx sql.DB) error {
 }
 
 // NewPeers creates a new Peers object.
-func P2PInit(ctx context.Context, db sql.TxMaker, whitelistPeers []string) (*Peers, error) {
+func P2PInit(ctx context.Context, db sql.TxMaker, privateMode bool, whitelistPeers []string) (*PeerWhiteList, error) {
 	upgradeFns := map[int64]versioning.UpgradeFunc{
 		0: initTables,
 	}
@@ -58,14 +62,10 @@ func P2PInit(ctx context.Context, db sql.TxMaker, whitelistPeers []string) (*Pee
 		return nil, err
 	}
 
-	p := &Peers{
+	p := &PeerWhiteList{
 		whitelistPeers: make(map[string]bool),
 		db:             db,
-	}
-
-	// no need to persist them and these are added only once at startup
-	for _, peer := range whitelistPeers {
-		p.whitelistPeers[peer] = true
+		privateMode:    privateMode,
 	}
 
 	// Load peers from disk
@@ -73,22 +73,49 @@ func P2PInit(ctx context.Context, db sql.TxMaker, whitelistPeers []string) (*Pee
 		return nil, err
 	}
 
-	// load the whitelist peers from the config and persist if not already present
-	for _, peer := range whitelistPeers {
-		p.AddPeer(ctx, peer)
+	// add and persist peers from the whitelistPeers config if not already present
+	if err := p.AddPeers(ctx, whitelistPeers); err != nil {
+		return nil, err
 	}
 
 	return p, nil
 }
 
-// AddPeer adds a peer to the Peers object.
-func (p *Peers) AddPeer(ctx context.Context, peer string) error {
+func (p *PeerWhiteList) AddPeers(ctx context.Context, peers []string) error {
+	p.peerMtx.Lock()
+	defer p.peerMtx.Unlock()
+
+	tx, err := p.db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	for _, peer := range peers {
+		_, ok := p.whitelistPeers[peer]
+		if ok {
+			continue
+		}
+
+		p.whitelistPeers[peer] = true
+		// Persist peers to disk
+		_, err = tx.Execute(ctx, addPeer, peer)
+		if err != nil {
+			return err
+		}
+	}
+	return tx.Commit(ctx)
+}
+
+// AddPeer adds a peer to the whitelistPeers list. If the peer is already in the list,
+// it returns an error indicating that the peer is already whitelisted.
+func (p *PeerWhiteList) AddPeer(ctx context.Context, peer string) error {
 	p.peerMtx.Lock()
 	defer p.peerMtx.Unlock()
 
 	_, ok := p.whitelistPeers[peer]
 	if ok {
-		return nil
+		return fmt.Errorf("%s already a whitelisted peer", peer)
 	}
 
 	tx, err := p.db.BeginTx(ctx)
@@ -97,24 +124,25 @@ func (p *Peers) AddPeer(ctx context.Context, peer string) error {
 	}
 	defer tx.Rollback(ctx)
 
-	p.whitelistPeers[peer] = true
 	// Persist peers to disk
 	_, err = tx.Execute(ctx, addPeer, peer)
 	if err != nil {
 		return err
 	}
+	p.whitelistPeers[peer] = true
 
 	return tx.Commit(ctx)
 }
 
-// RemovePeer removes a peer from the Peers object.
-func (p *Peers) RemovePeer(ctx context.Context, peer string) error {
+// RemovePeer gracefully stops an existing peer connection and removes the peer from the whitelisted peers list.
+// If the peer is not found in the whitelistPeers list, it returns an error indicating that the peer is not found.
+func (p *PeerWhiteList) RemovePeer(ctx context.Context, peer string) error {
 	p.peerMtx.Lock()
 	defer p.peerMtx.Unlock()
 
 	_, ok := p.whitelistPeers[peer] // check if peer exists
 	if !ok {
-		return nil
+		return fmt.Errorf("%s not found in the whitelisted peers", peer)
 	}
 
 	tx, err := p.db.BeginTx(ctx)
@@ -123,34 +151,41 @@ func (p *Peers) RemovePeer(ctx context.Context, peer string) error {
 	}
 	defer tx.Rollback(ctx)
 
-	delete(p.whitelistPeers, peer)
-
-	if p.removePeerFn != nil {
-		if err := p.removePeerFn(peer); err != nil {
-			return err
-		}
-	}
-
-	// Persist peers to disk
+	// Remove peer from the whitelisted peers list and from the database
 	_, err = tx.Execute(ctx, removePeer, peer)
 	if err != nil {
 		return err
 	}
+	delete(p.whitelistPeers, peer)
 
+	// Call removePeerFn to gracefully stop and remove the peer connection
+	// if the node is already connected to the peer.
+	if p.removePeerFn != nil {
+		if err := p.removePeerFn(peer); err != nil {
+			return fmt.Errorf("failed to remove peer %s: %w", peer, err)
+		}
+	}
 	return tx.Commit(ctx)
 }
 
-// HasPeer checks if a peer is in the Peers object.
-func (p *Peers) HasPeer(ctx context.Context, peer string) bool {
+// IsPeerWhitelisted checks if a peer is in the list of whitelisted peers.
+// If the node is running with private mode disabled, it always returns true.
+func (p *PeerWhiteList) IsPeerWhitelisted(peer string) bool {
 	p.peerMtx.RLock()
 	defer p.peerMtx.RUnlock()
+
+	if !p.privateMode {
+		// In Public mode, accept connections from any peer
+		return true
+	}
 
 	// Check if peer is in the whitelistPeers
 	_, ok := p.whitelistPeers[peer]
 	return ok
 }
 
-func (p *Peers) loadPeers(ctx context.Context) error {
+// loadPeers loads the peers from the database into the whitelistPeers map.
+func (p *PeerWhiteList) loadPeers(ctx context.Context) error {
 	tx, err := p.db.BeginTx(ctx)
 	if err != nil {
 		return err
@@ -174,7 +209,7 @@ func (p *Peers) loadPeers(ctx context.Context) error {
 	return tx.Commit(ctx)
 }
 
-func (p *Peers) SetRemovePeerFn(fn func(peerID string) error) {
+func (p *PeerWhiteList) SetRemovePeerFn(fn func(peerID string) error) {
 	p.removePeerFn = fn
 }
 

--- a/internal/abci/cometbft/peers.go
+++ b/internal/abci/cometbft/peers.go
@@ -1,9 +1,182 @@
 package cometbft
 
 import (
+	"context"
+	"fmt"
+	"sync"
+
 	"github.com/cometbft/cometbft/crypto/ed25519"
 	"github.com/cometbft/cometbft/p2p"
+	"github.com/kwilteam/kwil-db/common/sql"
+	"github.com/kwilteam/kwil-db/internal/sql/versioning"
 )
+
+const (
+	p2pSchemaName = "peers" // TODO: Umm, should this be part of the chain metadata schema?
+
+	p2pStoreVersion = 0
+
+	initPeersTable = `CREATE TABLE IF NOT EXISTS ` + p2pSchemaName + `.peers (
+		peer_id TEXT PRIMARY KEY
+	);`
+
+	addPeer = `INSERT INTO ` + p2pSchemaName + `.peers ` + `VALUES ($1) ` + `ON CONFLICT (peer_id) DO NOTHING;`
+
+	removePeer = `DELETE FROM ` + p2pSchemaName + `.peers ` + `WHERE peer_id = $1;`
+)
+
+// Peers object is used to manage the set of peers that a node is allowed to connect to.
+// Static peers are those that are added in the genesis and are trusted by default. These
+// include the initial validators, persistent peers, and seed nodes.
+// Whitelist peers are the list of allowed sentry nodes that a node can connect to.
+// Whitelist peers can be updated dynamically using kwil-admin commands and are persisted
+// to disk.
+// The Peers gossiped using PEX are not automatically trusted, and to be added manually if needed.
+// Any new validators are automatically added to the whitelist peers and demoted validators are removed from the whitelist.
+type Peers struct {
+	// whitelistPeers is a map of node IDs.
+	whitelistPeers map[string]bool
+	peerMtx        sync.RWMutex // protects peers
+
+	removePeerFn func(peerID string) error
+
+	db sql.TxMaker
+}
+
+func initTables(ctx context.Context, tx sql.DB) error {
+	_, err := tx.Execute(ctx, initPeersTable)
+	return err
+}
+
+// NewPeers creates a new Peers object.
+func P2PInit(ctx context.Context, db sql.TxMaker, whitelistPeers []string) (*Peers, error) {
+	upgradeFns := map[int64]versioning.UpgradeFunc{
+		0: initTables,
+	}
+
+	if err := versioning.Upgrade(ctx, db, p2pSchemaName, upgradeFns, p2pStoreVersion); err != nil {
+		return nil, err
+	}
+
+	p := &Peers{
+		whitelistPeers: make(map[string]bool),
+		db:             db,
+	}
+
+	// no need to persist them and these are added only once at startup
+	for _, peer := range whitelistPeers {
+		p.whitelistPeers[peer] = true
+	}
+
+	// Load peers from disk
+	if err := p.loadPeers(ctx); err != nil {
+		return nil, err
+	}
+
+	// load the whitelist peers from the config and persist if not already present
+	for _, peer := range whitelistPeers {
+		p.AddPeer(ctx, peer)
+	}
+
+	return p, nil
+}
+
+// AddPeer adds a peer to the Peers object.
+func (p *Peers) AddPeer(ctx context.Context, peer string) error {
+	p.peerMtx.Lock()
+	defer p.peerMtx.Unlock()
+
+	_, ok := p.whitelistPeers[peer]
+	if ok {
+		return nil
+	}
+
+	tx, err := p.db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	p.whitelistPeers[peer] = true
+	// Persist peers to disk
+	_, err = tx.Execute(ctx, addPeer, peer)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// RemovePeer removes a peer from the Peers object.
+func (p *Peers) RemovePeer(ctx context.Context, peer string) error {
+	p.peerMtx.Lock()
+	defer p.peerMtx.Unlock()
+
+	_, ok := p.whitelistPeers[peer] // check if peer exists
+	if !ok {
+		return nil
+	}
+
+	tx, err := p.db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	delete(p.whitelistPeers, peer)
+
+	if p.removePeerFn != nil {
+		if err := p.removePeerFn(peer); err != nil {
+			return err
+		}
+	}
+
+	// Persist peers to disk
+	_, err = tx.Execute(ctx, removePeer, peer)
+	if err != nil {
+		return err
+	}
+
+	return tx.Commit(ctx)
+}
+
+// HasPeer checks if a peer is in the Peers object.
+func (p *Peers) HasPeer(ctx context.Context, peer string) bool {
+	p.peerMtx.RLock()
+	defer p.peerMtx.RUnlock()
+
+	// Check if peer is in the whitelistPeers
+	_, ok := p.whitelistPeers[peer]
+	return ok
+}
+
+func (p *Peers) loadPeers(ctx context.Context) error {
+	tx, err := p.db.BeginTx(ctx)
+	if err != nil {
+		return err
+	}
+	defer tx.Rollback(ctx)
+
+	res, err := tx.Execute(ctx, `SELECT peer_id FROM `+p2pSchemaName+`.peers;`)
+	if err != nil {
+		return err
+	}
+
+	for _, row := range res.Rows {
+		peer, ok := row[0].(string)
+		if !ok {
+			return fmt.Errorf("expected string for peer_id, got %T", row[0])
+		}
+
+		p.whitelistPeers[peer] = true
+	}
+
+	return tx.Commit(ctx)
+}
+
+func (p *Peers) SetRemovePeerFn(fn func(peerID string) error) {
+	p.removePeerFn = fn
+}
 
 // NodeIDAddressString makes a full CometBFT node ID address string in the
 // format <nodeID>@hostPort where nodeID is derived from the provided public

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -50,7 +50,7 @@ type TxApp interface {
 	Begin(ctx context.Context, height int64) error
 	Commit(ctx context.Context)
 	Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse
-	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators, approvedJoins, expiredJoins []*types.Validator, err error)
+	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators []*types.Validator, approvedJoins, expiredJoins [][]byte, err error)
 	GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, genesisAccounts []*types.Account, initialHeight int64, chain *common.ChainContext) error
 	GetValidators(ctx context.Context, db sql.DB) ([]*types.Validator, error)
 	ProposerTxs(ctx context.Context, db sql.DB, txNonce uint64, maxTxsSize int64, block *common.BlockContext) ([][]byte, error)

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -78,3 +78,13 @@ type DB interface {
 	sql.ReadTxMaker
 	sql.SnapshotTxMaker
 }
+
+// PeerModule is an interface that manages network peers.
+type PeerModule interface {
+	// AddPeer adds a peer to the Peers object.
+	AddPeer(ctx context.Context, peer string) error
+	// RemovePeer removes a peer from the Peers object.
+	RemovePeer(ctx context.Context, peer string) error
+	// HasPeer checks if a peer is in the Peers object.
+	HasPeer(ctx context.Context, peer string) bool
+}

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -85,6 +85,7 @@ type PeerModule interface {
 	AddPeer(ctx context.Context, peer string) error
 	// RemovePeer removes a peer from the Peers object.
 	RemovePeer(ctx context.Context, peer string) error
-	// HasPeer checks if a peer is in the Peers object.
-	HasPeer(ctx context.Context, peer string) bool
+	// IsPeerWhitelisted checks if a peer is in the PeerWhitelist object.
+	// If private mode is distabled, it always returns true.
+	IsPeerWhitelisted(peer string) bool
 }

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -50,7 +50,7 @@ type TxApp interface {
 	Begin(ctx context.Context, height int64) error
 	Commit(ctx context.Context)
 	Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse
-	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators []*types.Validator, err error)
+	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators, approvedJoins, expiredJoins []*types.Validator, err error)
 	GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, genesisAccounts []*types.Account, initialHeight int64, chain *common.ChainContext) error
 	GetValidators(ctx context.Context, db sql.DB) ([]*types.Validator, error)
 	ProposerTxs(ctx context.Context, db sql.DB, txNonce uint64, maxTxsSize int64, block *common.BlockContext) ([][]byte, error)
@@ -80,7 +80,7 @@ type DB interface {
 }
 
 // PeerModule is an interface that manages network peers.
-type PeerModule interface {
+type WhitelistPeersModule interface {
 	// AddPeer adds a peer to the Peers object.
 	AddPeer(ctx context.Context, peer string) error
 	// RemovePeer removes a peer from the Peers object.

--- a/internal/services/jsonrpc/adminsvc/service.go
+++ b/internal/services/jsonrpc/adminsvc/service.go
@@ -45,10 +45,10 @@ type Pricer interface {
 }
 
 type P2P interface {
-	// AddPeer adds a peer to the node's peer list.
-	AddPeer(ctx context.Context, nodeID string) error
-	// RemovePeer removes a peer from the node's peer list.
-	RemovePeer(ctx context.Context, nodeID string) error
+	// AddPeer adds a peer to the node's peer list and persists it.
+	AddAndPersistPeer(ctx context.Context, nodeID string) error
+	// RemovePeer removes a peer from the node's peer list permanently.
+	RemovePersistedPeer(ctx context.Context, nodeID string) error
 	// ListPeers returns the list of peers in the node's whitelist.
 	ListPeers(ctx context.Context) []string
 }
@@ -418,7 +418,7 @@ func (svc *Service) GetConfig(ctx context.Context, req *adminjson.GetConfigReque
 }
 
 func (svc *Service) AddPeer(ctx context.Context, req *adminjson.PeerRequest) (*adminjson.PeerResponse, *jsonrpc.Error) {
-	err := svc.p2p.AddPeer(ctx, req.PeerID)
+	err := svc.p2p.AddAndPersistPeer(ctx, req.PeerID)
 	if err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to add a peer. Reason: "+err.Error(), nil)
 	}
@@ -427,7 +427,7 @@ func (svc *Service) AddPeer(ctx context.Context, req *adminjson.PeerRequest) (*a
 
 func (svc *Service) RemovePeer(ctx context.Context, req *adminjson.PeerRequest) (*adminjson.PeerResponse, *jsonrpc.Error) {
 	fmt.Println("RemovePeer : ", req.PeerID)
-	err := svc.p2p.RemovePeer(ctx, req.PeerID)
+	err := svc.p2p.RemovePersistedPeer(ctx, req.PeerID)
 	if err != nil {
 		svc.log.Error("failed to remove peer", zap.Error(err))
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, "failed to remove peer : "+err.Error(), nil)

--- a/test/driver/operator/cli_driver.go
+++ b/test/driver/operator/cli_driver.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/core/types"
+	admintypes "github.com/kwilteam/kwil-db/core/types/admin"
 	"github.com/kwilteam/kwil-db/test/driver"
 )
 
@@ -132,6 +133,39 @@ func (o *OperatorCLIDriver) ValidatorsList(ctx context.Context) ([]*types.Valida
 	}
 
 	return res, nil
+}
+
+func (o *OperatorCLIDriver) AddPeer(ctx context.Context, peerID string) error {
+	var peer string
+	return o.runCommand(ctx, &peer, "peers", "add", peerID)
+}
+
+func (o *OperatorCLIDriver) RemovePeer(ctx context.Context, peerID string) error {
+	var peer string
+	return o.runCommand(ctx, &peer, "peers", "remove", peerID)
+}
+
+func (o *OperatorCLIDriver) ListPeers(ctx context.Context) ([]string, error) {
+	var res []string
+	err := o.runCommand(ctx, &res, "peers", "list")
+	if err != nil {
+		return nil, err
+	}
+	return res, nil
+}
+
+func (o *OperatorCLIDriver) ConnectedPeers(ctx context.Context) ([]string, error) {
+	var res []*admintypes.PeerInfo
+	err := o.runCommand(ctx, &res, "node", "peers")
+	if err != nil {
+		return nil, err
+	}
+
+	var peers []string
+	for _, p := range res {
+		peers = append(peers, p.RemoteAddr)
+	}
+	return peers, nil
 }
 
 type cliResponse struct {

--- a/test/driver/operator/client_driver.go
+++ b/test/driver/operator/client_driver.go
@@ -57,3 +57,29 @@ func (a *AdminClientDriver) ValidatorNodeRemove(ctx context.Context, target []by
 func (a *AdminClientDriver) ValidatorsList(ctx context.Context) ([]*types.Validator, error) {
 	return a.Client.ListValidators(ctx)
 }
+
+func (a *AdminClientDriver) AddPeer(ctx context.Context, peerID string) error {
+	return a.Client.AddPeer(ctx, peerID)
+}
+
+func (a *AdminClientDriver) ListPeers(ctx context.Context) ([]string, error) {
+	return a.Client.ListPeers(ctx)
+}
+
+func (a *AdminClientDriver) RemovePeer(ctx context.Context, peerID string) error {
+	return a.Client.RemovePeer(ctx, peerID)
+}
+
+func (a *AdminClientDriver) ConnectedPeers(ctx context.Context) ([]string, error) {
+	peersInfo, err := a.Client.Peers(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	peers := make([]string, 0, len(peersInfo))
+	for _, peer := range peersInfo {
+		peers = append(peers, peer.RemoteAddr)
+	}
+
+	return peers, nil
+}

--- a/test/driver/operator/operator.go
+++ b/test/driver/operator/operator.go
@@ -6,4 +6,5 @@ import "github.com/kwilteam/kwil-db/test/specifications"
 type KwilOperatorDriver interface {
 	specifications.ValidatorOpsDsl // TODO: split into ValidatorJoinDsl, ValidatorApproveDsl, ValidatorLeaveDsl
 	specifications.ValidatorRemoveDsl
+	specifications.PeersDsl
 }

--- a/test/integration/docker-compose.yml.template
+++ b/test/integration/docker-compose.yml.template
@@ -6,6 +6,7 @@ services:
     image: {{ .DockerImage }}
     ports:
       - "{{with .ExposedRPCPorts}}{{index . 0}}:{{end}}8484"
+      - "{{with .ExposedRPCPorts}}{{index . 0}}:{{end}}8485"
       - "26656"
       - "26657"
     #env_file:
@@ -29,7 +30,6 @@ services:
       --log.time-format=rfc3339milli
       --log.level=${LOG_LEVEL:-info}
       --app.extension-endpoints=ext1:50051
-      --app.admin-listen-addr=/tmp/admin.socket
       --chain.p2p.listen-addr=tcp://0.0.0.0:26656
       --chain.rpc.listen-addr=tcp://0.0.0.0:26657
       --app.pg-db-host=pg0
@@ -72,6 +72,7 @@ services:
     image: {{ .DockerImage }}
     ports:
       - "{{with .ExposedRPCPorts}}{{index . 1}}:{{end}}8484"
+      - "{{with .ExposedRPCPorts}}{{index . 1}}:{{end}}8485"
       - "26656"
       - "26657"
     environment:
@@ -93,7 +94,6 @@ services:
       --log.time-format=rfc3339milli
       --log.level=${LOG_LEVEL:-info}
       --app.extension-endpoints=ext1:50051
-      --app.admin-listen-addr=/tmp/admin.socket
       --chain.p2p.listen-addr=tcp://0.0.0.0:26656
       --chain.rpc.listen-addr=tcp://0.0.0.0:26657
       --app.pg-db-host=pg1
@@ -136,6 +136,7 @@ services:
     image: {{ .DockerImage }}
     ports:
       - "{{with .ExposedRPCPorts}}{{index . 2}}:{{end}}8484"
+      - "{{with .ExposedRPCPorts}}{{index . 2}}:{{end}}8485"
       - "26656"
       - "26657"
     environment:
@@ -157,7 +158,6 @@ services:
       --log.format=plain
       --log.time-format=rfc3339milli
       --app.extension-endpoints=ext1:50051
-      --app.admin-listen-addr=/tmp/admin.socket
       --chain.p2p.listen-addr=tcp://0.0.0.0:26656
       --chain.rpc.listen-addr=tcp://0.0.0.0:26657
       --app.pg-db-host=pg2
@@ -203,6 +203,7 @@ services:
     image: {{ .DockerImage }}
     ports:
       - "{{with .ExposedRPCPorts}}{{index . 3}}:{{end}}8484"
+      - "{{with .ExposedRPCPorts}}{{index . 3}}:{{end}}8485"
       - "26656"
       - "26657"
     environment:
@@ -225,7 +226,6 @@ services:
       --log.level=${LOG_LEVEL:-info}
       --app.extension-endpoints=ext3:50051
       --chain.p2p.listen-addr=tcp://0.0.0.0:26656
-      --app.admin-listen-addr=/tmp/admin.socket
       --chain.rpc.listen-addr=tcp://0.0.0.0:26657
       --app.pg-db-host=pg3
       --app.pg-db-port=5432
@@ -267,6 +267,7 @@ services:
     image: {{ .DockerImage }}
     ports:
       - "{{with .ExposedRPCPorts}}{{index . 4}}:{{end}}8484"
+      - "{{with .ExposedRPCPorts}}{{index . 4}}:{{end}}8485"
       - "26656"
       - "26657"
     environment:
@@ -288,7 +289,6 @@ services:
       --log.time-format=rfc3339milli
       --log.level=${LOG_LEVEL:-info}
       --app.extension-endpoints=ext1:50051
-      --app.admin-listen-addr=/tmp/admin.socket
       --chain.p2p.listen-addr=tcp://0.0.0.0:26656
       --chain.rpc.listen-addr=tcp://0.0.0.0:26657
       --app.pg-db-host=pg4
@@ -331,6 +331,7 @@ services:
     image: {{ .DockerImage }}
     ports:
       - "{{with .ExposedRPCPorts}}{{index . 5}}:{{end}}8484"
+      - "{{with .ExposedRPCPorts}}{{index . 5}}:{{end}}8485"
       - "26656"
       - "26657"
     environment:
@@ -352,7 +353,6 @@ services:
       --log.time-format=rfc3339milli
       --log.level=${LOG_LEVEL:-info}
       --app.extension-endpoints=ext1:50051
-      --app.admin-listen-addr=/tmp/admin.socket
       --chain.p2p.listen-addr=tcp://0.0.0.0:26656
       --chain.rpc.listen-addr=tcp://0.0.0.0:26657
       --app.pg-db-host=pg5

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -757,9 +757,9 @@ func TestKwildPrivateNetworks(t *testing.T) {
 		specifications.RemovePeerSpecification(ctx, t, node2Driver, node1)
 
 		// List whitelisted peers
-		specifications.ListPeersSpecification(ctx, t, node0Driver, []string{node0})
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node1})
-		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node2})
+		specifications.ListPeersSpecification(ctx, t, node0Driver, []string{})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{})
+		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{})
 
 		// Deploy a database on node0 and verify that the database does not exist on node1 and node2
 		specifications.DatabaseDeploySpecification(ctx, t, userNode0Driver)
@@ -773,9 +773,9 @@ func TestKwildPrivateNetworks(t *testing.T) {
 		specifications.AddPeerSpecification(ctx, t, node0Driver, node1)
 		specifications.AddPeerSpecification(ctx, t, node1Driver, node0)
 
-		specifications.ListPeersSpecification(ctx, t, node0Driver, []string{node0, node1})
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node1, node0})
-		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node2})
+		specifications.ListPeersSpecification(ctx, t, node0Driver, []string{node1})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node0})
+		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{})
 
 		// Verify that the database exists on node1 but not on node2
 		time.Sleep(30 * time.Second) // TODO: node eventually connects and syncs // figure out the time interval
@@ -789,9 +789,9 @@ func TestKwildPrivateNetworks(t *testing.T) {
 		specifications.AddPeerSpecification(ctx, t, node0Driver, node2)
 		specifications.AddPeerSpecification(ctx, t, node2Driver, node0)
 
-		specifications.ListPeersSpecification(ctx, t, node0Driver, []string{node0, node1, node2})
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node1, node0})
-		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node2, node0})
+		specifications.ListPeersSpecification(ctx, t, node0Driver, []string{node1, node2})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node0})
+		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node0})
 
 		// ensure that the database exists on all nodes
 		time.Sleep(30 * time.Second)
@@ -806,8 +806,8 @@ func TestKwildPrivateNetworks(t *testing.T) {
 		// n1: [n1, n0, n2]
 		// n2: [n2, n0]
 		specifications.AddPeerSpecification(ctx, t, node1Driver, node2)
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node1, node0, node2})
-		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node2, node0})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node0, node2})
+		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node0})
 
 		// so both the nodes are still not connected
 		specifications.PeerConnectivitySpecification(ctx, t, node1Driver, nodeIDs["node2"], false)
@@ -826,8 +826,8 @@ func TestKwildPrivateNetworks(t *testing.T) {
 		// node2 automatocally adds node1 as a peer as it is a validator
 		// time.Sleep(30 * time.Second)
 		// n0, n1, n3: [n0, n1, n2]
-		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node1, node0, node2})
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node2, node0, node1})
+		specifications.ListPeersSpecification(ctx, t, node2Driver, []string{node1, node0})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node2, node0})
 
 		// node1 removes node2 from its peer list
 		specifications.RemovePeerSpecification(ctx, t, node1Driver, node2)
@@ -839,12 +839,12 @@ func TestKwildPrivateNetworks(t *testing.T) {
 		node2PrivKey := helper.NodePrivateKey("node2")
 		node2PubKey := node2PrivKey.PubKey().Bytes()
 		specifications.ValidatorNodeJoinSpecification(ctx, t, node2Driver, node2PubKey, 2)
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node1, node0})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node0})
 		specifications.ValidatorNodeApproveSpecification(ctx, t, node1Driver, node2PubKey, 2, 2, false)
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node1, node0, node2})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node0, node2})
 
 		time.Sleep(expiryWait)
 		// as join request expires, node1 removes node2 from its peer list
-		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node1, node0})
+		specifications.ListPeersSpecification(ctx, t, node1Driver, []string{node0})
 	})
 }

--- a/test/specifications/dsl.go
+++ b/test/specifications/dsl.go
@@ -141,3 +141,11 @@ type DeployerDsl interface {
 type TxInfoer interface {
 	TxInfo(ctx context.Context, hash []byte) (*transactions.TcTxQueryResponse, error)
 }
+
+type PeersDsl interface {
+	ListPeers(ctx context.Context) ([]string, error)
+	AddPeer(ctx context.Context, peerID string) error
+	RemovePeer(ctx context.Context, peerID string) error
+
+	ConnectedPeers(ctx context.Context) ([]string, error)
+}

--- a/test/specifications/peers.go
+++ b/test/specifications/peers.go
@@ -1,0 +1,103 @@
+package specifications
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func AddPeerSpecification(ctx context.Context, t *testing.T, netops PeersDsl, peerID string) {
+	t.Log("Executing add peer specification")
+
+	peers, err := netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.False(t, hasPeer(peers, peerID))
+
+	err = netops.AddPeer(ctx, peerID)
+	require.NoError(t, err)
+
+	peers, err = netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.True(t, hasPeer(peers, peerID))
+
+	t.Logf("Added peer %s", peerID)
+}
+
+func AddExistingPeerSpecification(ctx context.Context, t *testing.T, netops PeersDsl, peerID string) {
+	t.Log("Executing add existing peer specification")
+
+	peers, err := netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.True(t, hasPeer(peers, peerID))
+
+	err = netops.AddPeer(ctx, peerID)
+	require.Error(t, err)
+
+	peers, err = netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.True(t, hasPeer(peers, peerID))
+}
+
+func RemovePeerSpecification(ctx context.Context, t *testing.T, netops PeersDsl, peerID string) {
+	t.Log("Executing remove peer specification")
+
+	peers, err := netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.True(t, hasPeer(peers, peerID))
+
+	err = netops.RemovePeer(ctx, peerID)
+	require.NoError(t, err)
+
+	peers, err = netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.False(t, hasPeer(peers, peerID))
+
+	t.Logf("Removed peer %s", peerID)
+}
+
+func RemoveNonExistingPeerSpecification(ctx context.Context, t *testing.T, netops PeersDsl, peerID string) {
+	t.Log("Executing remove non-existing peer specification")
+
+	peers, err := netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.False(t, hasPeer(peers, peerID))
+
+	err = netops.RemovePeer(ctx, peerID)
+	require.Error(t, err)
+
+	peers, err = netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.False(t, hasPeer(peers, peerID))
+}
+
+func ListPeersSpecification(ctx context.Context, t *testing.T, netops PeersDsl, peers []string) {
+	t.Log("Executing list peers specification")
+
+	peersList, err := netops.ListPeers(ctx)
+	require.NoError(t, err)
+	require.ElementsMatch(t, peers, peersList)
+}
+
+func hasPeer(peers []string, peerID string) bool {
+	for _, peer := range peers {
+		if peer == peerID {
+			return true
+		}
+	}
+	return false
+}
+
+func PeerConnectivitySpecification(ctx context.Context, t *testing.T, netops PeersDsl, peerID string, connected bool) {
+	t.Log("Executing peer connectivity specification")
+
+	connectedPeers, err := netops.ConnectedPeers(ctx)
+	require.NoError(t, err)
+
+	isConnected := hasPeer(connectedPeers, peerID)
+	if connected {
+		require.True(t, isConnected)
+	} else {
+		require.False(t, isConnected)
+	}
+}


### PR DESCRIPTION
Each node can now run in private mode which accepts connections from:
- the current validator set 
- persistent peers (`chain.p2p.persistent-peers`)
- seeds (`chain.p2p.seeds`)
- whitelisted peers  (`chain.p2p.whitelist-peers`)
Connections from  other sentry nodes can be allowed, either updating whitelist peers config and restart the node or by using `kwil-admin peers add/remove` commands.

When private mode is disabled, the node can accept the connections from any nodes. 