### PR TITLE
types: uint256 and uuid marshaling fixes

### DIFF
--- a/core/types/uint256_test.go
+++ b/core/types/uint256_test.go
@@ -1,0 +1,97 @@
+package types
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// func intHex(v int64) []byte
+
+const hugeIntStrP1 = "18446744073709551616"   // 1 + math.MaxUint64
+const hugeIntStrX10 = "184467440737095516150" // 10 * math.MaxUint64
+
+func TestUint256BinaryMarshaling(t *testing.T) {
+	tests := []struct {
+		name     string
+		val      string
+		expected []byte
+	}{
+		{
+			name:     "small int",
+			val:      "123",
+			expected: []byte{0x7b},
+		},
+		{
+			name:     "zero",
+			val:      "0",
+			expected: []byte{}, // optimized to empty slice
+		},
+		{
+			name:     "null",
+			val:      "", // special case
+			expected: nil,
+		},
+		{
+			name:     "just bigger than uint64",
+			val:      hugeIntStrP1,
+			expected: []byte{0x01, 0, 0, 0, 0, 0, 0, 0, 0},
+		},
+		{
+			name:     "much than uint64",
+			val:      hugeIntStrX10,
+			expected: []byte{0x09, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xf6},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var u *Uint256
+			if tt.val == "" {
+				u = &Uint256{Null: true}
+			} else {
+				var err error
+				u, err = Uint256FromString(tt.val)
+				require.NoError(t, err)
+			}
+
+			marshaled, err := u.MarshalBinary()
+			require.NoError(t, err)
+			assert.Equal(t, tt.expected, marshaled)
+
+			var unmarshaled Uint256
+			err = unmarshaled.UnmarshalBinary(marshaled)
+			require.NoError(t, err)
+
+			assert.Equal(t, u.String(), unmarshaled.String())
+		})
+	}
+}
+
+func TestUint256JSONRoundTrip(t *testing.T) {
+	for _, str := range []string{"12345", "0", "", hugeIntStrX10} {
+		var original *Uint256
+		if str == "" {
+			original = &Uint256{Null: true}
+		} else {
+			var err error
+			original, err = Uint256FromString(str)
+			require.NoError(t, err)
+		}
+
+		marshaled, err := original.MarshalJSON()
+		require.NoError(t, err)
+		if len(str) > 0 {
+			require.Equal(t, `"`+str+`"`, string(marshaled))
+		} else {
+			require.Equal(t, string(marshaled), "null")
+		}
+
+		var unmarshaled Uint256
+		err = unmarshaled.UnmarshalJSON(marshaled)
+		require.NoError(t, err)
+
+		assert.Equal(t, original.String(), unmarshaled.String())
+	}
+}

--- a/core/types/uuid.go
+++ b/core/types/uuid.go
@@ -51,10 +51,15 @@ func (u *UUID) Bytes() []byte {
 	return u[:]
 }
 
-// Over json, we want to send uuids as strings
+var _ json.Marshaler = UUID{}
+var _ json.Marshaler = (*UUID)(nil)
+
+// MarshalJSON implements json.Marshaler.
 func (u UUID) MarshalJSON() ([]byte, error) {
-	return json.Marshal(u.String())
+	return []byte(`"` + u.String() + `"`), nil
 }
+
+var _ json.Unmarshaler = (*UUID)(nil)
 
 func (u *UUID) UnmarshalJSON(b []byte) error {
 	var s string

--- a/core/types/uuid_test.go
+++ b/core/types/uuid_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+
 	"github.com/kwilteam/kwil-db/core/types"
 )
 
@@ -17,7 +19,7 @@ func Test_UUID(t *testing.T) {
 	}
 }
 
-func Test_UUIDJSON(t *testing.T) {
+func Test_UUIDJSONRoundTrip(t *testing.T) {
 	seed := []byte("test")
 
 	uuid := types.NewUUIDV5(seed)
@@ -27,12 +29,13 @@ func Test_UUIDJSON(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	t.Log(uuid)
+	assert.Equal(t, `"24aa70cf-0e18-57c9-b449-da8c9db37821"`, string(b))
 
-	var uuid3 types.UUID
-	err = json.Unmarshal(b, &uuid3)
+	var uuidBack types.UUID
+	err = json.Unmarshal(b, &uuidBack)
 	if err != nil {
 		t.Fatal(err)
 	}
-	t.Log(uuid3) // 00000000-0000-0000-0000-000000000000
+
+	assert.Equal(t, *uuid, uuidBack)
 }


### PR DESCRIPTION
This is some more small fixes coming out of my statistics work branch.  This fixes and tests round trip json marshaling for both `types.Uint256` and `types.UUID`, and adds binary marshalling for `Uint256`.

The standard libarary's `encoding.BinaryMarshaler` and `encoding.BinaryUnmarshaler` interfaces have special significance for several packages in the standard library, most notably `encoding/gob`, which is a simple and convenient way to encode Go structs containing interfaces and custom types.