### PR TITLE
simplify expressions in the planner

### DIFF
--- a/parse/planner/logical/mappings.go
+++ b/parse/planner/logical/mappings.go
@@ -11,15 +11,6 @@ import (
 // but decided to have clean separation so that other parts of the
 // planner don't have to rely on the parse package.
 
-var comparisonOps = map[parse.ComparisonOperator]ComparisonOperator{
-	parse.ComparisonOperatorEqual:              Equal,
-	parse.ComparisonOperatorNotEqual:           NotEqual,
-	parse.ComparisonOperatorLessThan:           LessThan,
-	parse.ComparisonOperatorLessThanOrEqual:    LessThanOrEqual,
-	parse.ComparisonOperatorGreaterThan:        GreaterThan,
-	parse.ComparisonOperatorGreaterThanOrEqual: GreaterThanOrEqual,
-}
-
 var stringComparisonOps = map[parse.StringComparisonOperator]ComparisonOperator{
 	parse.StringComparisonOperatorLike:  Like,
 	parse.StringComparisonOperatorILike: ILike,

--- a/parse/planner/logical/nodes.go
+++ b/parse/planner/logical/nodes.go
@@ -1563,12 +1563,9 @@ const (
 	// https://en.wikipedia.org/wiki/Sargable
 	// for the purposes of our planner, we will treat rarely
 	// sargable as not sargable
-	Equal              ComparisonOperator = iota // sargable
-	NotEqual                                     // rarely sargable
-	LessThan                                     // sargable
-	LessThanOrEqual                              // sargable
-	GreaterThan                                  // sargable
-	GreaterThanOrEqual                           // sargable
+	Equal       ComparisonOperator = iota // sargable
+	LessThan                              // sargable
+	GreaterThan                           // sargable
 	// IS and IS NOT are rarely sargable because they can only be used
 	// with NULL values or BOOLEAN values
 	Is             // rarely sargable
@@ -1581,16 +1578,10 @@ func (c ComparisonOperator) String() string {
 	switch c {
 	case Equal:
 		return "="
-	case NotEqual:
-		return "!="
 	case LessThan:
 		return "<"
-	case LessThanOrEqual:
-		return "<="
 	case GreaterThan:
 		return ">"
-	case GreaterThanOrEqual:
-		return ">="
 	case Is:
 		return "IS"
 	case IsDistinctFrom:


### PR DESCRIPTION
This PR simplifies comparisons in logical plans by limiting the number of operators. I felt this change was good b/c of how I am managing them within procedures.
