### PR TITLE
kwild,jsonrpc: add app.rpc-req-limit / cfg.AppCfg.RPCMaxReqSize

### DIFF
--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -116,6 +116,9 @@ rpc_timeout = "{{ .AppCfg.RPCTimeout }}"
 # Timeout on database reads initiated by the user RPC service
 db_read_timeout = "{{ .AppCfg.ReadTxTimeout }}"
 
+# RPC request size limit in bytes
+rpc_req_limit = {{ .AppCfg.RPCMaxReqSize }}
+
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = {{arrayFormatter .AppCfg.ExtensionEndpoints}}
 

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -76,6 +76,7 @@ type AppConfig struct {
 	DBName string `mapstructure:"pg_db_name"`
 
 	RPCTimeout         Duration                     `mapstructure:"rpc_timeout"`
+	RPCMaxReqSize      int                          `mapstructure:"rpc_req_limit"`
 	ReadTxTimeout      Duration                     `mapstructure:"db_read_timeout"`
 	ExtensionEndpoints []string                     `mapstructure:"extension_endpoints"`
 	AdminRPCPass       string                       `mapstructure:"admin_pass"`
@@ -580,6 +581,7 @@ func DefaultConfig() *KwildConfig {
 			DBUser:               "kwild",
 			DBName:               "kwild",
 			RPCTimeout:           Duration(45 * time.Second),
+			RPCMaxReqSize:        4_200_000,
 			ReadTxTimeout:        Duration(5 * time.Second),
 			Extensions:           make(map[string]map[string]string),
 			Snapshots: SnapshotConfig{

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -40,6 +40,9 @@ rpc_timeout = "45s"
 # Timeout on database reads initiated by the user RPC service
 db_read_timeout = "5s"
 
+# RPC request size limit in bytes
+rpc_req_limit = 4200000
+
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = []
 

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -35,6 +35,7 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *KwildConfig) {
 	flagSet.StringVar(&cfg.AppCfg.ProfileFile, "app.profile-file", cfg.AppCfg.ProfileFile, "kwild profile output file path (e.g. cpu.pprof)")
 
 	flagSet.Var(&cfg.AppCfg.RPCTimeout, "app.rpc-timeout", "timeout for RPC requests (through reading the request, handling the request, and sending the response)")
+	flagSet.IntVar(&cfg.AppCfg.RPCMaxReqSize, "app.rpc-req-limit", cfg.AppCfg.RPCMaxReqSize, "RPC request size limit")
 	flagSet.Var(&cfg.AppCfg.ReadTxTimeout, "app.db-read-timeout", "timeout for database reads initiated by RPC requests")
 
 	// Extension endpoints flags

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -43,6 +43,9 @@ rpc_timeout = "45s"
 # Timeout on database reads initiated by the user RPC service
 db_read_timeout = "5s"
 
+# RPC request size limit in bytes
+rpc_req_limit = 4200000
+
 # List of Extension endpoints to be enabled ex: ["localhost:50052", "169.198.102.34:50053"]
 extension_endpoints = ["localhost:50052", "localhost:50053", "localhost:50054"]
 

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -212,10 +212,16 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	rpcSvcLogger := increaseLogLevel("user-json-svc", &d.log, d.cfg.Logging.RPCLevel)
 	rpcServerLogger := increaseLogLevel("user-jsonrpc-server", &d.log, d.cfg.Logging.RPCLevel)
 
+	if d.cfg.AppCfg.RPCMaxReqSize < d.cfg.ChainCfg.Mempool.MaxTxBytes {
+		d.log.Warnf("RPC request size limit (%d) is less than maximium transaction size (%d)",
+			d.cfg.AppCfg.RPCMaxReqSize, d.cfg.ChainCfg.Mempool.MaxTxBytes)
+	}
+
 	jsonRPCTxSvc := usersvc.NewService(db, e, wrappedCmtClient, txApp, abciApp, migrator,
 		*rpcSvcLogger, usersvc.WithReadTxTimeout(time.Duration(d.cfg.AppCfg.ReadTxTimeout)))
 	jsonRPCServer, err := rpcserver.NewServer(d.cfg.AppCfg.JSONRPCListenAddress,
 		*rpcServerLogger, rpcserver.WithTimeout(time.Duration(d.cfg.AppCfg.RPCTimeout)),
+		rpcserver.WithReqSizeLimit(d.cfg.AppCfg.RPCMaxReqSize),
 		rpcserver.WithCORS(), rpcserver.WithServerInfo(&usersvc.SpecInfo))
 	if err != nil {
 		failBuild(err, "unable to create json-rpc server")


### PR DESCRIPTION
This adds a configurable request size limit to kwild.

In toml: `app.rpc_req_limit`
With cli flag: `--app.rpc-req-limit`

The default is somewhat arbitrarily 4,200,000 bytes.

If the network's genesis config sets max transaction size larger than this limit, kwild warns on startup.