### PR TITLE
unified common structs used throughout codebase

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -60,20 +60,20 @@ type Engine interface {
 	SchemaGetter
 	// CreateDataset deploys a new dataset from a schema.
 	// The dataset will be owned by the caller.
-	CreateDataset(ctx context.Context, tx sql.DB, schema *types.Schema, txdata *TxContext) error
+	CreateDataset(ctx *TxContext, tx sql.DB, schema *types.Schema) error
 	// DeleteDataset deletes a dataset.
 	// The caller must be the owner of the dataset.
-	DeleteDataset(ctx context.Context, tx sql.DB, dbid string, txdata *TxContext) error
+	DeleteDataset(ctx *TxContext, tx sql.DB, dbid string) error
 	// Procedure executes a procedure in a dataset. It can be given
 	// either a readwrite or readonly database transaction. If it is
 	// given a read-only transaction, it will not be able to execute
 	// any procedures that are not `view`.
-	Procedure(ctx context.Context, tx sql.DB, options *ExecutionData) (*sql.ResultSet, error)
+	Procedure(ctx *TxContext, tx sql.DB, options *ExecutionData) (*sql.ResultSet, error)
 	// ListDatasets returns a list of all datasets on the network.
 	ListDatasets(caller []byte) ([]*types.DatasetIdentifier, error)
 	// Execute executes a SQL statement on a dataset.
 	// It uses Kwil's SQL dialect.
-	Execute(ctx context.Context, tx sql.DB, dbid, query string, values map[string]any) (*sql.ResultSet, error)
+	Execute(ctx *TxContext, tx sql.DB, dbid, query string, values map[string]any) (*sql.ResultSet, error)
 	// Reload reloads the engine with the latest db state
 	Reload(ctx context.Context, tx sql.Executor) error
 }
@@ -88,7 +88,7 @@ type SchemaGetter interface {
 // during call / execution. It is scoped to the lifetime of a single
 // execution.
 type ExecutionData struct {
-	TxCtx *TxContext
+	//TxCtx *TxContext
 	// Dataset is the DBID of the dataset that was called.
 	// Even if a procedure in another dataset is called, this will
 	// always be the original dataset.

--- a/common/common.go
+++ b/common/common.go
@@ -46,17 +46,24 @@ type TxContext struct {
 	// BlockContext is the context of the current block.
 	BlockContext *BlockContext
 	// TxID is the ID of the current transaction.
-	TxID []byte
+	TxID string
+	// Signer is the public key of the transaction signer.
+	Signer []byte
+	// Caller is the string identifier of the transaction signer.
+	// It is derived from the signer's registered authenticator.
+	Caller string
+	// Authenticator is the authenticator used to sign the transaction.
+	Authenticator string
 }
 
 type Engine interface {
 	SchemaGetter
 	// CreateDataset deploys a new dataset from a schema.
 	// The dataset will be owned by the caller.
-	CreateDataset(ctx context.Context, tx sql.DB, schema *types.Schema, txdata *TransactionData) error
+	CreateDataset(ctx context.Context, tx sql.DB, schema *types.Schema, txdata *TxContext) error
 	// DeleteDataset deletes a dataset.
 	// The caller must be the owner of the dataset.
-	DeleteDataset(ctx context.Context, tx sql.DB, dbid string, txdata *TransactionData) error
+	DeleteDataset(ctx context.Context, tx sql.DB, dbid string, txdata *TxContext) error
 	// Procedure executes a procedure in a dataset. It can be given
 	// either a readwrite or readonly database transaction. If it is
 	// given a read-only transaction, it will not be able to execute
@@ -77,37 +84,11 @@ type SchemaGetter interface {
 	GetSchema(dbid string) (*types.Schema, error)
 }
 
-// TransactionData holds contextual data about the transaction that
-// called the procedure.
-type TransactionData struct {
-	// Signer is the address of public key that signed the incoming
-	// transaction.
-	Signer []byte
-
-	// Caller is a string identifier for the signer.
-	// It is derived from the signer's registered authenticator.
-	// It is injected as a variable for usage in the query, under
-	// the variable name "@caller".
-	Caller string
-
-	// TxID is the transaction ID of the incoming transaction.
-	TxID string
-
-	// Height is the block height of the incoming transaction.
-	Height int64
-
-	// BlockTimestamp is the unix timestamp of the block, set by the block proposer.
-	BlockTimestamp int64
-
-	// Authenticator is the authenticator used to sign the transaction.
-	Authenticator string
-}
-
 // ExecutionOptions is contextual data that is passed to a procedure
 // during call / execution. It is scoped to the lifetime of a single
 // execution.
 type ExecutionData struct {
-	TransactionData
+	TxCtx *TxContext
 	// Dataset is the DBID of the dataset that was called.
 	// Even if a procedure in another dataset is called, this will
 	// always be the original dataset.

--- a/common/context.go
+++ b/common/context.go
@@ -23,11 +23,11 @@ type BlockContext struct {
 	ChainContext *ChainContext
 	// Height gets the height of the current block.
 	Height int64
-	// BlockTimestamp is a timestamp of the current block.
+	// Timestamp is a timestamp of the current block.
 	// It is set by the block proposer, and therefore may not be accurate.
 	// It should not be used for time-sensitive operations where incorrect
 	// timestamps could result in security vulnerabilities.
-	BlockTimestamp int64
+	Timestamp int64
 	// Proposer gets the proposer public key of the current block.
 	Proposer []byte
 }

--- a/extensions/consensus/payloads.go
+++ b/extensions/consensus/payloads.go
@@ -35,9 +35,9 @@ type Route interface {
 	// returned by the router in case of an error. A route may perform all
 	// actions with InTx, but others may use PreTx for initial validation prior
 	// to creating a nested transaction with the DB backend (expensive).
-	PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error)
+	PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error)
 	// InTx executes the transaction, which may include state changes via the DB
 	// or Engine. The TxCode is returned by the Router, and it should be CodeOk
 	// for a nil error.
-	InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error)
+	InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error)
 }

--- a/extensions/precompiles/actions.go
+++ b/extensions/precompiles/actions.go
@@ -45,10 +45,9 @@ type DeploymentContext struct {
 type ProcedureContext struct {
 	// Ctx is the context of the current execution.
 	Ctx context.Context
+	// TxCtx is the transaction context of the current execution.
+	TxCtx *common.TxContext
 	// Signer is the address or public key of the caller.
-	Signer []byte
-	// Caller is the string identifier of the signer.
-	Caller string
 
 	// values are the variables that are available to the execution.
 	values map[string]any // note: bind $args or @caller
@@ -58,18 +57,12 @@ type ProcedureContext struct {
 	// will be the last used DBID.
 	DBID string
 
-	// TxID is the hash of the transaction that the scope
-	// was called in.
-	TxID string
-
 	// Procedure is the Procedure identifier for the current scope.
 	// if calling a precompile instance instead of a Procedure, it
 	// will be the last used Procedure.
 	Procedure string
 	// Result is the result of the most recent SQL query.
 	Result *sql.ResultSet
-	// Height is the block height of the current execution.
-	Height int64
 
 	// StackDepth tracks the current depth of the procedure call stack. It is
 	// incremented each time a procedure calls another procedure.
@@ -103,10 +96,13 @@ func (p *ProcedureContext) Values() map[string]any {
 	}
 
 	// set environment variables
-	values["@caller"] = p.Caller
-	values["@txid"] = p.TxID
-	values["@signer"] = p.Signer
-	values["@height"] = p.Height
+	values["@caller"] = p.TxCtx.Caller
+	values["@txid"] = p.TxCtx.TxID
+	values["@signer"] = p.TxCtx.Signer
+	values["@height"] = p.TxCtx.BlockContext.Height
+	values["@foreign_caller"] = p.DBID
+	values["@block_timestamp"] = p.TxCtx.BlockContext.Timestamp
+	values["@authenticator"] = p.TxCtx.Authenticator
 
 	return values
 }
@@ -117,15 +113,12 @@ func (p *ProcedureContext) Values() map[string]any {
 func (p *ProcedureContext) NewScope() *ProcedureContext {
 	return &ProcedureContext{
 		Ctx:        p.Ctx,
-		Signer:     p.Signer,
-		Caller:     p.Caller,
+		TxCtx:      p.TxCtx,
 		values:     make(map[string]any),
 		DBID:       p.DBID,
-		TxID:       p.TxID,
 		Procedure:  p.Procedure,
 		StackDepth: p.StackDepth,
 		UsedGas:    p.UsedGas,
-		Height:     p.Height,
 	}
 }
 

--- a/extensions/precompiles/actions.go
+++ b/extensions/precompiles/actions.go
@@ -43,8 +43,6 @@ type DeploymentContext struct {
 
 // ProcedureContext is the context for a procedure and action execution.
 type ProcedureContext struct {
-	// Ctx is the context of the current execution.
-	Ctx context.Context
 	// TxCtx is the transaction context of the current execution.
 	TxCtx *common.TxContext
 	// Signer is the address or public key of the caller.
@@ -112,7 +110,6 @@ func (p *ProcedureContext) Values() map[string]any {
 // It will inherit the dbid, procedure, and stack depth from the parent.
 func (p *ProcedureContext) NewScope() *ProcedureContext {
 	return &ProcedureContext{
-		Ctx:        p.Ctx,
 		TxCtx:      p.TxCtx,
 		values:     make(map[string]any),
 		DBID:       p.DBID,

--- a/extensions/precompiles/adhoc.go
+++ b/extensions/precompiles/adhoc.go
@@ -63,7 +63,7 @@ func (adhocExtension) Call(scope *ProcedureContext, app *common.App, method stri
 		return nil, fmt.Errorf(`adhoc: unknown method "%s"`, method)
 	}
 
-	res, err := app.Engine.Execute(scope.Ctx, app.DB, scope.DBID, stmt, scope.Values())
+	res, err := app.Engine.Execute(scope.TxCtx, app.DB, scope.DBID, stmt, scope.Values())
 	if err != nil {
 		return nil, err
 	}

--- a/internal/abci/abci_test.go
+++ b/internal/abci/abci_test.go
@@ -406,7 +406,7 @@ func (m *mockTxApp) Begin(ctx context.Context, height int64) error {
 
 func (m *mockTxApp) Commit(ctx context.Context) {}
 
-func (m *mockTxApp) Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse {
+func (m *mockTxApp) Execute(ctx *common.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse {
 	return nil
 }
 

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -50,7 +50,7 @@ type TxApp interface {
 	ApplyMempool(ctx *common.TxContext, db sql.DB, tx *transactions.Transaction) error
 	Begin(ctx context.Context, height int64) error
 	Commit(ctx context.Context)
-	Execute(ctx txapp.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse
+	Execute(ctx *common.TxContext, db sql.DB, tx *transactions.Transaction) *txapp.TxResponse
 	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators []*types.Validator, approvedJoins, expiredJoins [][]byte, err error)
 	GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, genesisAccounts []*types.Account, initialHeight int64, chain *common.ChainContext) error
 	GetValidators(ctx context.Context, db sql.DB) ([]*types.Validator, error)

--- a/internal/engine/execution/dataset.go
+++ b/internal/engine/execution/dataset.go
@@ -48,7 +48,7 @@ func (d *baseDataset) Call(caller *precompiles.ProcedureContext, app *common.App
 		if !proc.public {
 			return nil, fmt.Errorf(`%w: "%s"`, ErrPrivate, method)
 		}
-		if proc.ownerOnly && !bytes.Equal(caller.Signer, d.schema.Owner) {
+		if proc.ownerOnly && !bytes.Equal(caller.TxCtx.Signer, d.schema.Owner) {
 			return nil, fmt.Errorf(`%w: "%s"`, ErrOwnerOnly, method)
 		}
 		if !proc.view && app.DB.(sql.AccessModer).AccessMode() == sql.ReadOnly {

--- a/internal/engine/execution/dataset.go
+++ b/internal/engine/execution/dataset.go
@@ -61,7 +61,7 @@ func (d *baseDataset) Call(caller *precompiles.ProcedureContext, app *common.App
 			return nil, fmt.Errorf(`procedure "%s" expects %d argument(s), got %d`, method, len(proc.parameters), len(inputs))
 		}
 
-		res, err := app.DB.Execute(caller.Ctx, proc.callString(d.schema.DBID()), append([]any{pg.QueryModeExec}, inputs...)...)
+		res, err := app.DB.Execute(caller.TxCtx.Ctx, proc.callString(d.schema.DBID()), append([]any{pg.QueryModeExec}, inputs...)...)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/engine/execution/execution_test.go
+++ b/internal/engine/execution/execution_test.go
@@ -30,10 +30,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -49,20 +50,22 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
 				_, ok := db.dbs[testdata.TestSchema.DBID()]
 				assert.True(t, ok)
 
-				err = eng.DeleteDataset(ctx, db, testdata.TestSchema.DBID(), &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid2",
+				err = eng.DeleteDataset(ctx, db, testdata.TestSchema.DBID(), &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
 				})
 				assert.NoError(t, err)
 
@@ -76,17 +79,19 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
-				err = eng.DeleteDataset(ctx, db, testdata.TestSchema.DBID(), &common.TransactionData{
-					Signer: []byte("not_owner"),
-					Caller: "not_owner",
-					TxID:   "txid1",
+				err = eng.DeleteDataset(ctx, db, testdata.TestSchema.DBID(), &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       []byte("not_owner"),
+					Caller:       "not_owner",
+					TxID:         "txid1",
 				})
 				assert.Error(t, err)
 			},
@@ -97,10 +102,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.DeleteDataset(ctx, db, "not_a_real_db", &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid2",
+				err := eng.DeleteDataset(ctx, db, "not_a_real_db", &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
 				})
 				assert.Error(t, err)
 			},
@@ -111,10 +117,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -122,10 +129,11 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "create_user",
 					Args:      []any{1, "brennan", 22},
-					TransactionData: common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
-						TxID:   "txid2",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
+						TxID:         "txid2",
 					},
 				})
 				assert.NoError(t, err)
@@ -137,10 +145,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -148,10 +157,11 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "create_user",
 					Args:      []any{1, "brennan"}, // missing age
-					TransactionData: common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
-						TxID:   "txid2",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
+						TxID:         "txid2",
 					},
 				})
 				assert.Error(t, err)
@@ -163,10 +173,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -174,10 +185,11 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionRecursive.Name,
 					Args:      []any{"id000000", "asdfasdfasdfasdf", "bigbigbigbigbigbigbigbigbigbig"},
-					TransactionData: common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
-						TxID:   "txid2",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
+						TxID:         "txid2",
 					},
 				})
 				assert.ErrorIs(t, err, ErrMaxStackDepth)
@@ -189,10 +201,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -200,10 +213,11 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionRecursiveSneakyA.Name,
 					Args:      []any{},
-					TransactionData: common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
-						TxID:   "txid2",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
+						TxID:         "txid2",
 					},
 				})
 				assert.ErrorIs(t, err, ErrMaxStackDepth)
@@ -215,10 +229,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -228,10 +243,11 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "create_user",
 					Args:      []any{1, "brennan", 22},
-					TransactionData: common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
-						TxID:   "txid2",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
+						TxID:         "txid2",
 					},
 				})
 				assert.Error(t, err)
@@ -241,10 +257,11 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "get_user_by_address",
 					Args:      []any{"address"},
-					TransactionData: common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
-						TxID:   "txid3",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
+						TxID:         "txid3",
 					},
 				})
 				assert.NoError(t, err)
@@ -256,10 +273,11 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testSchema, &common.TransactionData{
-					Signer: testSchema.Owner,
-					Caller: string(testSchema.Owner),
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testSchema.Owner,
+					Caller:       string(testSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -267,9 +285,10 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testSchema.DBID(),
 					Procedure: "use_math",
 					Args:      []any{1, 2},
-					TransactionData: common.TransactionData{
-						Signer: testSchema.Owner,
-						Caller: string(testSchema.Owner),
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testSchema.Owner,
+						Caller:       string(testSchema.Owner),
 						// no txid since it is non-mutative
 					},
 				})
@@ -281,10 +300,11 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testSchema.DBID(),
 					Procedure: "use_math",
 					Args:      []any{1, 2},
-					TransactionData: common.TransactionData{
-						Signer: testSchema.Owner,
-						Caller: string(testSchema.Owner),
-						TxID:   "txid3",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testSchema.Owner,
+						Caller:       string(testSchema.Owner),
+						TxID:         "txid3",
 					},
 				})
 				assert.NoError(t, err)
@@ -298,10 +318,11 @@ func Test_Execution(t *testing.T) {
 
 				owner := "owner"
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: []byte(owner),
-					Caller: owner,
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       []byte(owner),
+					Caller:       owner,
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -324,10 +345,11 @@ func Test_Execution(t *testing.T) {
 
 				owner := "owner"
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TransactionData{
-					Signer: []byte(owner),
-					Caller: owner,
-					TxID:   "txid1",
+				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       []byte(owner),
+					Caller:       owner,
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 
@@ -335,9 +357,10 @@ func Test_Execution(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ProcGetUsersByAge.Name,
 					Args:      []any{22},
-					TransactionData: common.TransactionData{
-						Signer: []byte(owner),
-						Caller: owner,
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte(owner),
+						Caller:       owner,
 					},
 				})
 				assert.NoError(t, err)

--- a/internal/engine/execution/execution_test.go
+++ b/internal/engine/execution/execution_test.go
@@ -30,12 +30,13 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
 				schema, err := eng.GetSchema(testdata.TestSchema.DBID())
@@ -50,23 +51,25 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
 				_, ok := db.dbs[testdata.TestSchema.DBID()]
 				assert.True(t, ok)
 
-				err = eng.DeleteDataset(ctx, db, testdata.TestSchema.DBID(), &common.TxContext{
+				err = eng.DeleteDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid2",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema.DBID())
 				assert.NoError(t, err)
 
 				_, ok = db.dbs[testdata.TestSchema.DBID()]
@@ -79,20 +82,22 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
-				err = eng.DeleteDataset(ctx, db, testdata.TestSchema.DBID(), &common.TxContext{
+				err = eng.DeleteDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       []byte("not_owner"),
 					Caller:       "not_owner",
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema.DBID())
 				assert.Error(t, err)
 			},
 		},
@@ -102,12 +107,13 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.DeleteDataset(ctx, db, "not_a_real_db", &common.TxContext{
+				err := eng.DeleteDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid2",
-				})
+					Ctx:          ctx,
+				}, db, "not_a_real_db")
 				assert.Error(t, err)
 			},
 		},
@@ -117,24 +123,25 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
-				_, err = eng.Procedure(ctx, db, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
+					Ctx:          ctx,
+				}, db, &common.ExecutionData{
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "create_user",
 					Args:      []any{1, "brennan", 22},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testdata.TestSchema.Owner,
-						Caller:       string(testdata.TestSchema.Owner),
-						TxID:         "txid2",
-					},
 				})
 				assert.NoError(t, err)
 			},
@@ -145,24 +152,26 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
-				_, err = eng.Procedure(ctx, db, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
+					Ctx:          ctx,
+				}, db, &common.ExecutionData{
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "create_user",
 					Args:      []any{1, "brennan"}, // missing age
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testdata.TestSchema.Owner,
-						Caller:       string(testdata.TestSchema.Owner),
-						TxID:         "txid2",
-					},
+
 				})
 				assert.Error(t, err)
 			},
@@ -173,24 +182,25 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
-				_, err = eng.Procedure(ctx, db, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
+					Ctx:          ctx,
+				}, db, &common.ExecutionData{
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionRecursive.Name,
 					Args:      []any{"id000000", "asdfasdfasdfasdf", "bigbigbigbigbigbigbigbigbigbig"},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testdata.TestSchema.Owner,
-						Caller:       string(testdata.TestSchema.Owner),
-						TxID:         "txid2",
-					},
 				})
 				assert.ErrorIs(t, err, ErrMaxStackDepth)
 			},
@@ -201,24 +211,25 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
-				_, err = eng.Procedure(ctx, db, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
+					Ctx:          ctx,
+				}, db, &common.ExecutionData{
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionRecursiveSneakyA.Name,
 					Args:      []any{},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testdata.TestSchema.Owner,
-						Caller:       string(testdata.TestSchema.Owner),
-						TxID:         "txid2",
-					},
 				})
 				assert.ErrorIs(t, err, ErrMaxStackDepth)
 			},
@@ -229,40 +240,41 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testdata.TestSchema.Owner,
 					Caller:       string(testdata.TestSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
 				db2 := newDB(true)
 
-				_, err = eng.Procedure(ctx, db2, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
+					Ctx:          ctx,
+				}, db2, &common.ExecutionData{
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "create_user",
 					Args:      []any{1, "brennan", 22},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testdata.TestSchema.Owner,
-						Caller:       string(testdata.TestSchema.Owner),
-						TxID:         "txid2",
-					},
 				})
 				assert.Error(t, err)
 				assert.ErrorIs(t, err, ErrMutativeProcedure)
 
-				_, err = eng.Procedure(ctx, db2, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid3",
+					Ctx:          ctx,
+				}, db2, &common.ExecutionData{
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: "get_user_by_address",
 					Args:      []any{"address"},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testdata.TestSchema.Owner,
-						Caller:       string(testdata.TestSchema.Owner),
-						TxID:         "txid3",
-					},
 				})
 				assert.NoError(t, err)
 			},
@@ -273,39 +285,40 @@ func Test_Execution(t *testing.T) {
 				ctx := context.Background()
 				db := newDB(false)
 
-				err := eng.CreateDataset(ctx, db, testSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       testSchema.Owner,
 					Caller:       string(testSchema.Owner),
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testSchema)
 				assert.NoError(t, err)
 
-				_, err = eng.Procedure(ctx, db, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testSchema.Owner,
+					Caller:       string(testSchema.Owner),
+					// no txid since it is non-mutative
+					Ctx: ctx,
+				}, db, &common.ExecutionData{
 					Dataset:   testSchema.DBID(),
 					Procedure: "use_math",
 					Args:      []any{1, 2},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testSchema.Owner,
-						Caller:       string(testSchema.Owner),
-						// no txid since it is non-mutative
-					},
 				})
 				assert.NoError(t, err)
 
 				// call non-mutative
 				// since we do not have a sql connection, we cannot evaluate the result
-				_, err = eng.Procedure(ctx, db, &common.ExecutionData{
+				_, err = eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testSchema.Owner,
+					Caller:       string(testSchema.Owner),
+					TxID:         "txid3",
+					Ctx:          ctx,
+				}, db, &common.ExecutionData{
 					Dataset:   testSchema.DBID(),
 					Procedure: "use_math",
 					Args:      []any{1, 2},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       testSchema.Owner,
-						Caller:       string(testSchema.Owner),
-						TxID:         "txid3",
-					},
 				})
 				assert.NoError(t, err)
 			},
@@ -318,12 +331,13 @@ func Test_Execution(t *testing.T) {
 
 				owner := "owner"
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       []byte(owner),
 					Caller:       owner,
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
 				datasets, err := eng.ListDatasets([]byte(owner))
@@ -345,23 +359,25 @@ func Test_Execution(t *testing.T) {
 
 				owner := "owner"
 
-				err := eng.CreateDataset(ctx, db, testdata.TestSchema, &common.TxContext{
+				err := eng.CreateDataset(&common.TxContext{
 					BlockContext: &common.BlockContext{},
 					Signer:       []byte(owner),
 					Caller:       owner,
 					TxID:         "txid1",
-				})
+					Ctx:          ctx,
+				}, db, testdata.TestSchema)
 				assert.NoError(t, err)
 
-				res, err := eng.Procedure(ctx, db, &common.ExecutionData{
+				res, err := eng.Procedure(&common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       []byte(owner),
+					Caller:       owner,
+					TxID:         "txid2",
+					Ctx:          ctx,
+				}, db, &common.ExecutionData{
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ProcGetUsersByAge.Name,
 					Args:      []any{22},
-					TxCtx: &common.TxContext{
-						BlockContext: &common.BlockContext{},
-						Signer:       []byte(owner),
-						Caller:       owner,
-					},
 				})
 				assert.NoError(t, err)
 

--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -240,7 +240,7 @@ func (e *callMethod) execute(scope *precompiles.ProcedureContext, global *Global
 	var inputs []any
 	vals := scope.Values() // declare here since scope.Values() is expensive
 	for _, arg := range e.Args {
-		val, err := arg(scope.Ctx, db.Execute, vals)
+		val, err := arg(scope.TxCtx.Ctx, db.Execute, vals)
 		if err != nil {
 			return err
 		}
@@ -335,7 +335,7 @@ func (e *dmlStmt) execute(scope *precompiles.ProcedureContext, _ *GlobalContext,
 	// Expend the arguments based on the ordered parameters for the DML statement.
 	params := orderAndCleanValueMap(scope.Values(), e.OrderedParameters)
 	// args := append([]any{pg.QueryModeExec}, params...)
-	results, err := db.Execute(scope.Ctx, e.SQLStatement, append([]any{pg.QueryModeExec}, params...)...)
+	results, err := db.Execute(scope.TxCtx.Ctx, e.SQLStatement, append([]any{pg.QueryModeExec}, params...)...)
 	if err != nil {
 		return decorateExecuteErr(err, e.SQLStatement)
 	}

--- a/internal/engine/execution/procedure.go
+++ b/internal/engine/execution/procedure.go
@@ -93,7 +93,7 @@ func prepareActions(schema *types.Schema) ([]*preparedAction, error) {
 		// add instructions for both owner only and view procedures
 		if action.IsOwnerOnly() {
 			instructions = append(instructions, instructionFunc(func(scope *precompiles.ProcedureContext, global *GlobalContext, db sql.DB) error {
-				if !bytes.Equal(scope.Signer, owner) {
+				if !bytes.Equal(scope.TxCtx.Signer, owner) {
 					return fmt.Errorf("cannot call owner action, not owner")
 				}
 

--- a/internal/engine/execution/queries.go
+++ b/internal/engine/execution/queries.go
@@ -326,37 +326,37 @@ func deleteSchema(ctx context.Context, tx sql.TxMaker, dbid string) error {
 }
 
 // setContextualVars sets the contextual variables for the given postgres session.
-func setContextualVars(ctx context.Context, db sql.DB, data *common.ExecutionData) error {
+func setContextualVars(ctx *common.TxContext, db sql.DB, data *common.ExecutionData) error {
 	// for contextual parameters, we use postgres's current_setting()
 	// feature for setting session variables. For example, @caller
 	// is accessed via current_setting('ctx.caller')
 
-	_, err := db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.CallerVar, data.TxCtx.Caller))
+	_, err := db.Execute(ctx.Ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.CallerVar, ctx.Caller))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.TxidVar, data.TxCtx.TxID))
+	_, err = db.Execute(ctx.Ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.TxidVar, ctx.TxID))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.SignerVar, base64.StdEncoding.EncodeToString(data.TxCtx.Signer)))
+	_, err = db.Execute(ctx.Ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.SignerVar, base64.StdEncoding.EncodeToString(ctx.Signer)))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.HeightVar, data.TxCtx.BlockContext.Height))
+	_, err = db.Execute(ctx.Ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.HeightVar, ctx.BlockContext.Height))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.BlockTimestamp, data.TxCtx.BlockContext.Timestamp))
+	_, err = db.Execute(ctx.Ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.BlockTimestamp, ctx.BlockContext.Timestamp))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.Authenticator, data.TxCtx.Authenticator))
+	_, err = db.Execute(ctx.Ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.Authenticator, ctx.Authenticator))
 	if err != nil {
 		return err
 	}
@@ -365,7 +365,7 @@ func setContextualVars(ctx context.Context, db sql.DB, data *common.ExecutionDat
 	// We can't leave it nil because once a config parameter is set, it cannot be unset.
 	// This means that we cannot properly handle scoping of the foreign caller in the outermost
 	// function call.
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '';`, generate.PgSessionPrefix, parse.ForeignCaller))
+	_, err = db.Execute(ctx.Ctx, fmt.Sprintf(`SET LOCAL %s.%s = '';`, generate.PgSessionPrefix, parse.ForeignCaller))
 	if err != nil {
 		return err
 	}

--- a/internal/engine/execution/queries.go
+++ b/internal/engine/execution/queries.go
@@ -331,32 +331,32 @@ func setContextualVars(ctx context.Context, db sql.DB, data *common.ExecutionDat
 	// feature for setting session variables. For example, @caller
 	// is accessed via current_setting('ctx.caller')
 
-	_, err := db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.CallerVar, data.Caller))
+	_, err := db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.CallerVar, data.TxCtx.Caller))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.TxidVar, data.TxID))
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.TxidVar, data.TxCtx.TxID))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.SignerVar, base64.StdEncoding.EncodeToString(data.Signer)))
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.SignerVar, base64.StdEncoding.EncodeToString(data.TxCtx.Signer)))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.HeightVar, data.Height))
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.HeightVar, data.TxCtx.BlockContext.Height))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.BlockTimestamp, data.BlockTimestamp))
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = %d;`, generate.PgSessionPrefix, parse.BlockTimestamp, data.TxCtx.BlockContext.Timestamp))
 	if err != nil {
 		return err
 	}
 
-	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.Authenticator, data.Authenticator))
+	_, err = db.Execute(ctx, fmt.Sprintf(`SET LOCAL %s.%s = '%s';`, generate.PgSessionPrefix, parse.Authenticator, data.TxCtx.Authenticator))
 	if err != nil {
 		return err
 	}

--- a/internal/engine/integration/deployment_test.go
+++ b/internal/engine/integration/deployment_test.go
@@ -239,12 +239,13 @@ func Test_Deployment(t *testing.T) {
 			require.NoError(t, err)
 			parsed.Schema.Owner = owner
 
-			err = global.CreateDataset(ctx, tx, parsed.Schema, &common.TxContext{
+			err = global.CreateDataset(&common.TxContext{
 				BlockContext: &common.BlockContext{},
 				Signer:       owner,
 				Caller:       string(owner),
 				TxID:         "test",
-			})
+				Ctx:          ctx,
+			}, tx, parsed.Schema)
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)
 			} else {

--- a/internal/engine/integration/deployment_test.go
+++ b/internal/engine/integration/deployment_test.go
@@ -239,10 +239,11 @@ func Test_Deployment(t *testing.T) {
 			require.NoError(t, err)
 			parsed.Schema.Owner = owner
 
-			err = global.CreateDataset(ctx, tx, parsed.Schema, &common.TransactionData{
-				Signer: owner,
-				Caller: string(owner),
-				TxID:   "test",
+			err = global.CreateDataset(ctx, tx, parsed.Schema, &common.TxContext{
+				BlockContext: &common.BlockContext{},
+				Signer:       owner,
+				Caller:       string(owner),
+				TxID:         "test",
 			})
 			if tc.err != nil {
 				require.ErrorIs(t, err, tc.err)

--- a/internal/engine/integration/execution_test.go
+++ b/internal/engine/integration/execution_test.go
@@ -36,10 +36,11 @@ func Test_Engine(t *testing.T) {
 			name: "create database",
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 			},
@@ -60,20 +61,22 @@ func Test_Engine(t *testing.T) {
 			name: "drop database",
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
 			},
 			ses2: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
-				err := global.DeleteDataset(ctx, tx, testdata.TestSchema.DBID(), &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid2",
+				err := global.DeleteDataset(ctx, tx, testdata.TestSchema.DBID(), &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid2",
 				})
 				require.NoError(t, err)
 			},
@@ -88,10 +91,11 @@ func Test_Engine(t *testing.T) {
 			name: "execute procedures",
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 			},
@@ -103,9 +107,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionCreateUser.Name,
 					Args:      []any{1, "satoshi", 42},
-					TransactionData: common.TransactionData{
-						Signer: []byte(signer),
-						Caller: signer,
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte(signer),
+						Caller:       signer,
 					},
 				})
 				require.NoError(t, err)
@@ -114,9 +119,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionCreatePost.Name,
 					Args:      []any{1, "Bitcoin!", "The Bitcoin Whitepaper", "9/31/2008"},
-					TransactionData: common.TransactionData{
-						Signer: []byte(signer),
-						Caller: signer,
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte(signer),
+						Caller:       signer,
 					},
 				})
 				require.NoError(t, err)
@@ -128,9 +134,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionGetPosts.Name,
 					Args:      []any{"satoshi"},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -160,10 +167,11 @@ func Test_Engine(t *testing.T) {
 			name: "executing outside of a commit",
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 			},
@@ -174,9 +182,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionCreatePost.Name,
 					Args:      []any{1, "Bitcoin!", "The Bitcoin Whitepaper", "9/31/2008"},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NotNil(t, err)
@@ -186,10 +195,11 @@ func Test_Engine(t *testing.T) {
 			name: "calling outside of a commit",
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
@@ -197,9 +207,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionCreateUser.Name,
 					Args:      []any{1, "satoshi", 42},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -211,9 +222,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionGetUserByAddress.Name,
 					Args:      []any{"signer"},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -227,10 +239,11 @@ func Test_Engine(t *testing.T) {
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
 
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
@@ -238,9 +251,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionCreateUser.Name,
 					Args:      []any{1, "satoshi", 42},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -252,9 +266,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionGetUserByAddress.Name,
 					Args:      []any{"signer"},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -284,19 +299,21 @@ func Test_Engine(t *testing.T) {
 					},
 				)
 
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.Error(t, err)
 
 				testdata.TestSchema.Extensions = oldExtensions
 
-				err = global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err = global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				assert.NoError(t, err)
 			},
@@ -306,10 +323,11 @@ func Test_Engine(t *testing.T) {
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
 
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
@@ -317,9 +335,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionAdminDeleteUser.Name,
 					Args:      []any{1},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.Error(t, err)
@@ -328,9 +347,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionAdminDeleteUser.Name,
 					Args:      []any{1},
-					TransactionData: common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
 					},
 				})
 				require.NoError(t, err)
@@ -341,10 +361,11 @@ func Test_Engine(t *testing.T) {
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
 
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
@@ -353,9 +374,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionPrivate.Name,
 					Args:      []any{},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.Error(t, err)
@@ -365,9 +387,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionCallsPrivate.Name,
 					Args:      []any{},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -382,10 +405,11 @@ func Test_Engine(t *testing.T) {
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
 
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
@@ -393,9 +417,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionCreateUser.Name,
 					Args:      []any{1, "satoshi", 42},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -404,9 +429,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ActionGetUserByAddress.Name,
 					Args:      []any{"signer"},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -421,10 +447,11 @@ func Test_Engine(t *testing.T) {
 					newSchema := *testdata.TestSchema
 					newSchema.Name = testdata.TestSchema.Name + fmt.Sprint(i)
 
-					err := global.CreateDataset(ctx, tx, &newSchema, &common.TransactionData{
-						Signer: testdata.TestSchema.Owner,
-						Caller: string(testdata.TestSchema.Owner),
-						TxID:   "txid" + fmt.Sprint(i),
+					err := global.CreateDataset(ctx, tx, &newSchema, &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       testdata.TestSchema.Owner,
+						Caller:       string(testdata.TestSchema.Owner),
+						TxID:         "txid" + fmt.Sprint(i),
 					})
 					require.NoError(t, err)
 				}
@@ -435,17 +462,19 @@ func Test_Engine(t *testing.T) {
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
 
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
-				err = global.DeleteDataset(ctx, tx, testdata.TestSchema.DBID(), &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid3",
+				err = global.DeleteDataset(ctx, tx, testdata.TestSchema.DBID(), &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid3",
 				})
 				require.NoError(t, err)
 			},
@@ -457,10 +486,11 @@ func Test_Engine(t *testing.T) {
 
 				schema := *caseSchema
 
-				err := global.CreateDataset(ctx, tx, &schema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, &schema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 
@@ -471,9 +501,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   schema.DBID(),
 					Procedure: "CREATE_USER",
 					Args:      []any{1, "satoshi"},
-					TransactionData: common.TransactionData{
-						Signer: []byte(caller),
-						Caller: string(signer),
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte(caller),
+						Caller:       string(signer),
 					},
 				})
 				require.NoError(t, err)
@@ -482,9 +513,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   schema.DBID(),
 					Procedure: "CREATE_USER",
 					Args:      []any{"2", "vitalik"},
-					TransactionData: common.TransactionData{
-						Signer: []byte(caller),
-						Caller: string(signer),
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte(caller),
+						Caller:       string(signer),
 					},
 				})
 				require.NoError(t, err)
@@ -493,9 +525,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   schema.DBID(),
 					Procedure: "CREATE_FOLLOWER",
 					Args:      []any{"satoshi", "vitalik"},
-					TransactionData: common.TransactionData{
-						Signer: []byte(caller),
-						Caller: string(signer),
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte(caller),
+						Caller:       string(signer),
 					},
 				})
 				require.NoError(t, err)
@@ -504,9 +537,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   schema.DBID(),
 					Procedure: "USE_EXTENSION",
 					Args:      []any{1, "2"}, // math_ext.add($arg1 + $arg2, 1)
-					TransactionData: common.TransactionData{
-						Signer: []byte(caller),
-						Caller: string(signer),
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte(caller),
+						Caller:       string(signer),
 					},
 				})
 				require.NoError(t, err)
@@ -525,10 +559,11 @@ func Test_Engine(t *testing.T) {
 			ses1: func(t *testing.T, global *execution.GlobalContext, tx sql.DB) {
 				ctx := context.Background()
 
-				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TransactionData{
-					Signer: testdata.TestSchema.Owner,
-					Caller: string(testdata.TestSchema.Owner),
-					TxID:   "txid1",
+				err := global.CreateDataset(ctx, tx, testdata.TestSchema, &common.TxContext{
+					BlockContext: &common.BlockContext{},
+					Signer:       testdata.TestSchema.Owner,
+					Caller:       string(testdata.TestSchema.Owner),
+					TxID:         "txid1",
 				})
 				require.NoError(t, err)
 			},
@@ -539,9 +574,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ProcCreateUser.Name,
 					Args:      []any{1, "satoshi", 42},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)
@@ -550,9 +586,10 @@ func Test_Engine(t *testing.T) {
 					Dataset:   testdata.TestSchema.DBID(),
 					Procedure: testdata.ProcGetUserByAddress.Name,
 					Args:      []any{"signer"},
-					TransactionData: common.TransactionData{
-						Signer: []byte("signer"),
-						Caller: "signer",
+					TxCtx: &common.TxContext{
+						BlockContext: &common.BlockContext{},
+						Signer:       []byte("signer"),
+						Caller:       "signer",
 					},
 				})
 				require.NoError(t, err)

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -436,8 +436,7 @@ func Test_Procedures(t *testing.T) {
 			}()
 
 			// execute test procedure
-			res, err := global.Procedure(ctx, execTx, &common.ExecutionData{
-				TxCtx:     d,
+			res, err := global.Procedure(d, execTx, &common.ExecutionData{
 				Dataset:   dbid,
 				Procedure: procedureName,
 				Args:      test.inputs,
@@ -688,8 +687,7 @@ func Test_ForeignProcedures(t *testing.T) {
 			}
 
 			// execute test procedure
-			res, err := global.Procedure(ctx, tx, &common.ExecutionData{
-				TxCtx:     d,
+			res, err := global.Procedure(d, tx, &common.ExecutionData{
 				Dataset:   mainDBID,
 				Procedure: procedureName,
 				Args:      test.inputs,
@@ -813,14 +811,12 @@ var satoshisUUID = &types.UUID{0x38, 0xeb, 0x77, 0xcb, 0x1e, 0x5a, 0x56, 0xc0, 0
 // deploy deploys a schema.
 // if deployer is not "", it will set the deployer as the owner.
 func deploy(t *testing.T, global *execution.GlobalContext, db sql.DB, schema string) (dbid string) {
-	ctx := context.Background()
-
 	parsed, err := parse.Parse([]byte(schema))
 	require.NoError(t, err)
 
 	d := txData()
 
-	err = global.CreateDataset(ctx, db, parsed, d)
+	err = global.CreateDataset(d, db, parsed)
 	require.NoError(t, err)
 
 	// get dbid
@@ -839,8 +835,6 @@ func deploy(t *testing.T, global *execution.GlobalContext, db sql.DB, schema str
 
 // deployAndSeed deploys the test schema and seeds it with data
 func deployAndSeed(t *testing.T, global *execution.GlobalContext, db sql.DB, extraProcedures ...string) (dbid string) {
-	ctx := context.Background()
-
 	schema := testSchema
 	for _, proc := range extraProcedures {
 		schema += proc + "\n"
@@ -851,8 +845,7 @@ func deployAndSeed(t *testing.T, global *execution.GlobalContext, db sql.DB, ext
 
 	// create initial data
 	for _, kv := range order.OrderMap(initialData) {
-		_, err := global.Procedure(ctx, db, &common.ExecutionData{
-			TxCtx:     txData(),
+		_, err := global.Procedure(txData(), db, &common.ExecutionData{
 			Dataset:   dbid,
 			Procedure: "create_user",
 			Args:      []any{kv.Key},
@@ -860,8 +853,7 @@ func deployAndSeed(t *testing.T, global *execution.GlobalContext, db sql.DB, ext
 		require.NoError(t, err)
 
 		for _, post := range kv.Value {
-			_, err = global.Procedure(ctx, db, &common.ExecutionData{
-				TxCtx:     txData(),
+			_, err = global.Procedure(txData(), db, &common.ExecutionData{
 				Dataset:   dbid,
 				Procedure: "create_post",
 				Args:      []any{kv.Key, post},

--- a/internal/engine/integration/procedure_test.go
+++ b/internal/engine/integration/procedure_test.go
@@ -437,10 +437,10 @@ func Test_Procedures(t *testing.T) {
 
 			// execute test procedure
 			res, err := global.Procedure(ctx, execTx, &common.ExecutionData{
-				TransactionData: d,
-				Dataset:         dbid,
-				Procedure:       procedureName,
-				Args:            test.inputs,
+				TxCtx:     d,
+				Dataset:   dbid,
+				Procedure: procedureName,
+				Args:      test.inputs,
 			})
 			if test.err != nil {
 				require.Error(t, err)
@@ -689,10 +689,10 @@ func Test_ForeignProcedures(t *testing.T) {
 
 			// execute test procedure
 			res, err := global.Procedure(ctx, tx, &common.ExecutionData{
-				TransactionData: d,
-				Dataset:         mainDBID,
-				Procedure:       procedureName,
-				Args:            test.inputs,
+				TxCtx:     d,
+				Dataset:   mainDBID,
+				Procedure: procedureName,
+				Args:      test.inputs,
 			})
 			if test.wantErr != "" {
 				require.Error(t, err)
@@ -820,7 +820,7 @@ func deploy(t *testing.T, global *execution.GlobalContext, db sql.DB, schema str
 
 	d := txData()
 
-	err = global.CreateDataset(ctx, db, parsed, &d)
+	err = global.CreateDataset(ctx, db, parsed, d)
 	require.NoError(t, err)
 
 	// get dbid
@@ -852,19 +852,19 @@ func deployAndSeed(t *testing.T, global *execution.GlobalContext, db sql.DB, ext
 	// create initial data
 	for _, kv := range order.OrderMap(initialData) {
 		_, err := global.Procedure(ctx, db, &common.ExecutionData{
-			TransactionData: txData(),
-			Dataset:         dbid,
-			Procedure:       "create_user",
-			Args:            []any{kv.Key},
+			TxCtx:     txData(),
+			Dataset:   dbid,
+			Procedure: "create_user",
+			Args:      []any{kv.Key},
 		})
 		require.NoError(t, err)
 
 		for _, post := range kv.Value {
 			_, err = global.Procedure(ctx, db, &common.ExecutionData{
-				TransactionData: txData(),
-				Dataset:         dbid,
-				Procedure:       "create_post",
-				Args:            []any{kv.Key, post},
+				TxCtx:     txData(),
+				Dataset:   dbid,
+				Procedure: "create_post",
+				Args:      []any{kv.Key, post},
 			})
 			require.NoError(t, err)
 		}

--- a/internal/engine/integration/schema_test.go
+++ b/internal/engine/integration/schema_test.go
@@ -47,46 +47,46 @@ func Test_Schemas(t *testing.T) {
 
 				// create user
 				_, err := global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         usersDBID,
-					Procedure:       "create_user",
-					Args:            []any{"satoshi"},
-					TransactionData: txData(),
+					Dataset:   usersDBID,
+					Procedure: "create_user",
+					Args:      []any{"satoshi"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
 				// make a post
 				_, err = global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         socialDBID,
-					Procedure:       "create_post",
-					Args:            []any{"hello world"},
-					TransactionData: txData(),
+					Dataset:   socialDBID,
+					Procedure: "create_post",
+					Args:      []any{"hello world"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
 				// make another post
 				_, err = global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         socialDBID,
-					Procedure:       "create_post",
-					Args:            []any{"goodbye world"},
-					TransactionData: txData(),
+					Dataset:   socialDBID,
+					Procedure: "create_post",
+					Args:      []any{"goodbye world"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
 				// make one more large post
 				_, err = global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         socialDBID,
-					Procedure:       "create_post",
-					Args:            []any{"this is a longer post than the others`"},
-					TransactionData: txData(),
+					Dataset:   socialDBID,
+					Procedure: "create_post",
+					Args:      []any{"this is a longer post than the others`"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
 				// get posts using get_recent_posts
 				res, err := global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         socialDBID,
-					Procedure:       "get_recent_posts",
-					Args:            []any{"satoshi"},
-					TransactionData: txData(),
+					Dataset:   socialDBID,
+					Procedure: "get_recent_posts",
+					Args:      []any{"satoshi"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
@@ -104,10 +104,10 @@ func Test_Schemas(t *testing.T) {
 
 				// use get_recent_posts_by_size to only get posts larger than 20 characters
 				res, err = global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         socialDBID,
-					Procedure:       "get_recent_posts_by_size",
-					Args:            []any{"satoshi", 20, 10}, // takes username, size, limit
-					TransactionData: txData(),
+					Dataset:   socialDBID,
+					Procedure: "get_recent_posts_by_size",
+					Args:      []any{"satoshi", 20, 10}, // takes username, size, limit
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
@@ -133,28 +133,28 @@ func Test_Schemas(t *testing.T) {
 
 				// create user
 				_, err := global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         usersDBID,
-					Procedure:       "create_user",
-					Args:            []any{"satoshi"},
-					TransactionData: txData(),
+					Dataset:   usersDBID,
+					Procedure: "create_user",
+					Args:      []any{"satoshi"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
 				// set the user's high score
 				_, err = global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         gameDBID,
-					Procedure:       "set_high_score",
-					Args:            []any{100},
-					TransactionData: txData(),
+					Dataset:   gameDBID,
+					Procedure: "set_high_score",
+					Args:      []any{100},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
 				// get the user's high score
 				res, err := global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         gameDBID,
-					Procedure:       "get_high_score",
-					Args:            []any{"satoshi"},
-					TransactionData: txData(),
+					Dataset:   gameDBID,
+					Procedure: "get_high_score",
+					Args:      []any{"satoshi"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
@@ -177,19 +177,19 @@ func Test_Schemas(t *testing.T) {
 				// create user. we do this in the social_media db to ensure the
 				// procedure can write to a foreign dataset
 				_, err := global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         social_media,
-					Procedure:       "create_user",
-					Args:            []any{"satoshi"},
-					TransactionData: txData(),
+					Dataset:   social_media,
+					Procedure: "create_user",
+					Args:      []any{"satoshi"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
 				// get the user by name
 				res, err := global.Procedure(ctx, db, &common.ExecutionData{
-					Dataset:         usersDBID,
-					Procedure:       "get_user_by_name",
-					Args:            []any{"satoshi"},
-					TransactionData: txData(),
+					Dataset:   usersDBID,
+					Procedure: "get_user_by_name",
+					Args:      []any{"satoshi"},
+					TxCtx:     txData(),
 				})
 				require.NoError(t, err)
 
@@ -248,7 +248,7 @@ func deployAllSchemas(t *testing.T, global *execution.GlobalContext, db sql.DB) 
 		require.NoError(t, err)
 
 		transactionData := txData()
-		err = global.CreateDataset(ctx, db, schema, &transactionData)
+		err = global.CreateDataset(ctx, db, schema, transactionData)
 		require.NoError(t, err)
 	}
 
@@ -278,26 +278,26 @@ func deployAllSchemas(t *testing.T, global *execution.GlobalContext, db sql.DB) 
 	// - userbyowner: the procedure to get a user by owner
 	for _, dbid := range []string{socialMedia, videoGame} {
 		_, err := global.Procedure(ctx, db, &common.ExecutionData{
-			Dataset:         dbid,
-			Procedure:       "admin_set",
-			Args:            []any{"dbid", users},
-			TransactionData: txData(),
+			Dataset:   dbid,
+			Procedure: "admin_set",
+			Args:      []any{"dbid", users},
+			TxCtx:     txData(),
 		})
 		require.NoError(t, err)
 
 		_, err = global.Procedure(ctx, db, &common.ExecutionData{
-			Dataset:         dbid,
-			Procedure:       "admin_set",
-			Args:            []any{"userbyname", "get_user_by_name"},
-			TransactionData: txData(),
+			Dataset:   dbid,
+			Procedure: "admin_set",
+			Args:      []any{"userbyname", "get_user_by_name"},
+			TxCtx:     txData(),
 		})
 		require.NoError(t, err)
 
 		_, err = global.Procedure(ctx, db, &common.ExecutionData{
-			Dataset:         dbid,
-			Procedure:       "admin_set",
-			Args:            []any{"userbyowner", "get_user_by_owner"},
-			TransactionData: txData(),
+			Dataset:   dbid,
+			Procedure: "admin_set",
+			Args:      []any{"userbyowner", "get_user_by_owner"},
+			TxCtx:     txData(),
 		})
 		require.NoError(t, err)
 	}
@@ -313,11 +313,12 @@ func nextTxID() string {
 	return fmt.Sprintf("tx_%d", txCounter)
 }
 
-// txData returns a common.TransactionData with the owner as the signer and caller.
-func txData() common.TransactionData {
-	return common.TransactionData{
-		Signer: owner,
-		Caller: string(owner),
-		TxID:   nextTxID(),
+// txData returns a common.TxContext with the owner as the signer and caller.
+func txData() *common.TxContext {
+	return &common.TxContext{
+		BlockContext: &common.BlockContext{},
+		Signer:       owner,
+		Caller:       string(owner),
+		TxID:         nextTxID(),
 	}
 }

--- a/internal/engine/integration/sql_test.go
+++ b/internal/engine/integration/sql_test.go
@@ -238,12 +238,12 @@ func Test_SQL(t *testing.T) {
 
 			// if there is a pre statement, execute it
 			if tt.pre != "" {
-				_, err := global.Execute(ctx, tx, dbid, tt.pre, nil)
+				_, err := global.Execute(txData(), tx, dbid, tt.pre, nil)
 				require.NoError(t, err)
 			}
 
 			// execute sql
-			res, err := global.Execute(ctx, tx, dbid, tt.sql, tt.values)
+			res, err := global.Execute(txData(), tx, dbid, tt.sql, tt.values)
 			if tt.err != nil {
 				require.Error(t, err)
 				require.ErrorIs(t, err, tt.err)

--- a/internal/extensions/extensions_test.go
+++ b/internal/extensions/extensions_test.go
@@ -8,6 +8,7 @@ import (
 	"math/big"
 	"testing"
 
+	"github.com/kwilteam/kwil-db/common"
 	actions "github.com/kwilteam/kwil-db/extensions/precompiles"
 	extensions "github.com/kwilteam/kwil-db/internal/extensions"
 	"github.com/kwilteam/kwil-extensions/client"
@@ -56,7 +57,9 @@ func (m *mockClient) Initialize(ctx context.Context, metadata map[string]string)
 func Test_LocalExtension(t *testing.T) {
 	ctx := context.Background()
 	callCtx := &actions.ProcedureContext{
-		Ctx: ctx,
+		TxCtx: &common.TxContext{
+			Ctx: ctx,
+		},
 	}
 
 	metadata := map[string]string{
@@ -133,7 +136,9 @@ func Test_RemoteExtension(t *testing.T) {
 	ctx := context.Background()
 	ext := extensions.New("local:8080")
 	callCtx := &actions.ProcedureContext{
-		Ctx: ctx,
+		TxCtx: &common.TxContext{
+			Ctx: ctx,
+		},
 	}
 
 	err := ext.Connect(ctx)

--- a/internal/extensions/remote_extensions.go
+++ b/internal/extensions/remote_extensions.go
@@ -47,7 +47,7 @@ func (e *RemoteExtension) Execute(ctx *precompiles.ProcedureContext, metadata ma
 	}
 
 	return e.client.CallMethod(&types.ExecutionContext{
-		Ctx:      ctx.Ctx,
+		Ctx:      ctx.TxCtx.Ctx,
 		Metadata: metadata,
 	}, method, args...)
 }

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -583,10 +583,12 @@ func (svc *Service) Call(ctx context.Context, req *userjson.CallRequest) (*userj
 		Dataset:   body.DBID,
 		Procedure: body.Action,
 		Args:      args,
-		TransactionData: common.TransactionData{
-			Signer:        signer,
-			Caller:        caller,
-			Height:        -1, // not available
+		TxCtx: &common.TxContext{
+			Signer: signer,
+			Caller: caller,
+			BlockContext: &common.BlockContext{
+				Height: -1, // cannot know the height here.
+			},
 			Authenticator: msg.AuthType,
 		},
 	})

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -207,10 +207,10 @@ func (svc *Service) Handlers() map[jsonrpc.Method]rpcserver.MethodHandler {
 }
 
 type EngineReader interface {
-	Procedure(ctx context.Context, tx sql.DB, options *common.ExecutionData) (*sql.ResultSet, error)
+	Procedure(ctx *common.TxContext, tx sql.DB, options *common.ExecutionData) (*sql.ResultSet, error)
 	GetSchema(dbid string) (*types.Schema, error)
 	ListDatasets(owner []byte) ([]*types.DatasetIdentifier, error)
-	Execute(ctx context.Context, tx sql.DB, dbid string, query string, values map[string]any) (*sql.ResultSet, error)
+	Execute(ctx *common.TxContext, tx sql.DB, dbid string, query string, values map[string]any) (*sql.ResultSet, error)
 }
 
 // NOTE:
@@ -363,7 +363,12 @@ func (svc *Service) Query(ctx context.Context, req *userjson.QueryRequest) (*use
 	readTx := svc.db.BeginDelayedReadTx()
 	defer readTx.Rollback(ctx)
 
-	result, err := svc.engine.Execute(ctxExec, readTx, req.DBID, req.Query, nil)
+	result, err := svc.engine.Execute(&common.TxContext{
+		Ctx: ctxExec,
+		BlockContext: &common.BlockContext{
+			Height: -1, // cannot know the height here.
+		},
+	}, readTx, req.DBID, req.Query, nil)
 	if err != nil {
 		// We don't know for sure that it's an invalid argument, but an invalid
 		// user-provided query isn't an internal server error.
@@ -579,18 +584,18 @@ func (svc *Service) Call(ctx context.Context, req *userjson.CallRequest) (*userj
 		}
 	}()
 
-	executeResult, err := svc.engine.Procedure(ctxExec, readTx, &common.ExecutionData{
+	executeResult, err := svc.engine.Procedure(&common.TxContext{
+		Ctx:    ctxExec,
+		Signer: signer,
+		Caller: caller,
+		BlockContext: &common.BlockContext{
+			Height: -1, // cannot know the height here.
+		},
+		Authenticator: msg.AuthType,
+	}, readTx, &common.ExecutionData{
 		Dataset:   body.DBID,
 		Procedure: body.Action,
 		Args:      args,
-		TxCtx: &common.TxContext{
-			Signer: signer,
-			Caller: caller,
-			BlockContext: &common.BlockContext{
-				Height: -1, // cannot know the height here.
-			},
-			Authenticator: msg.AuthType,
-		},
 	})
 	if err != nil {
 		return nil, engineError(err)

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -266,7 +266,7 @@ func (d *deployDatasetRoute) PreTx(ctx *common.TxContext, svc *common.Service, t
 }
 
 func (d *deployDatasetRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
-	err := app.Engine.CreateDataset(ctx.Ctx, app.DB, d.schema, ctx)
+	err := app.Engine.CreateDataset(ctx, app.DB, d.schema)
 	if err != nil {
 		return transactions.CodeUnknownError, err
 	}
@@ -303,7 +303,7 @@ func (d *dropDatasetRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx 
 }
 
 func (d *dropDatasetRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
-	err := app.Engine.DeleteDataset(ctx.Ctx, app.DB, d.dbid, ctx)
+	err := app.Engine.DeleteDataset(ctx, app.DB, d.dbid)
 	if err != nil {
 		return transactions.CodeUnknownError, err
 	}
@@ -362,11 +362,10 @@ func (d *executeActionRoute) PreTx(ctx *common.TxContext, svc *common.Service, t
 
 func (d *executeActionRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	for i := range d.args {
-		_, err := app.Engine.Procedure(ctx.Ctx, app.DB, &common.ExecutionData{
+		_, err := app.Engine.Procedure(ctx, app.DB, &common.ExecutionData{
 			Dataset:   d.dbid,
 			Procedure: d.action,
 			Args:      d.args[i],
-			TxCtx:     ctx,
 		})
 		if err != nil {
 			return codeForEngineError(err), err

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -3,7 +3,6 @@ package txapp
 import (
 	"bytes"
 	"context"
-	"encoding/hex"
 	"errors"
 	"fmt"
 	"math/big"
@@ -49,7 +48,7 @@ type Route interface {
 	// All transactions should spend, regardless of success or failure.
 	// Therefore, a nested transaction should be used for all database
 	// operations after the initial checkAndSpend.
-	Execute(ctx TxContext, router *TxApp, db sql.DB, tx *transactions.Transaction) *TxResponse
+	Execute(ctx *common.TxContext, router *TxApp, db sql.DB, tx *transactions.Transaction) *TxResponse
 }
 
 // NewRoute creates a complete Route for the TxApp from a consensus.Route.
@@ -62,10 +61,6 @@ func NewRoute(impl consensus.Route) Route {
 func RegisterRouteImpl(payloadType transactions.PayloadType, route consensus.Route) error {
 	return RegisterRoute(payloadType, NewRoute(route))
 }
-
-// TxContext is the context for transaction execution. It is a type alias for
-// common.TxContext (same type) for convenience.
-type TxContext = common.TxContext
 
 // ConsensusParams holds network level parameters that may evolve over time.
 type ConsensusParams struct {
@@ -158,7 +153,7 @@ func (d *baseRoute) Price(ctx context.Context, router *TxApp, db sql.DB, tx *tra
 	}, tx)
 }
 
-func (d *baseRoute) Execute(ctx TxContext, router *TxApp, db sql.DB, tx *transactions.Transaction) *TxResponse {
+func (d *baseRoute) Execute(ctx *common.TxContext, router *TxApp, db sql.DB, tx *transactions.Transaction) *TxResponse {
 	dbTx, err := db.BeginTx(ctx.Ctx)
 	if err != nil {
 		return txRes(nil, transactions.CodeUnknownError, err)
@@ -244,7 +239,7 @@ func (d *deployDatasetRoute) Price(ctx context.Context, app *common.App, tx *tra
 	return big.NewInt(1000000000000000000), nil
 }
 
-func (d *deployDatasetRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *deployDatasetRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot deploy dataset during migration")
 	}
@@ -270,16 +265,8 @@ func (d *deployDatasetRoute) PreTx(ctx common.TxContext, svc *common.Service, tx
 	return 0, nil
 }
 
-func (d *deployDatasetRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
-	err := app.Engine.CreateDataset(ctx.Ctx, app.DB, d.schema,
-		&common.TransactionData{
-			Signer:         tx.Sender,
-			Caller:         d.identifier,
-			TxID:           hex.EncodeToString(ctx.TxID),
-			Height:         ctx.BlockContext.Height,
-			BlockTimestamp: ctx.BlockContext.BlockTimestamp,
-			Authenticator:  d.authType,
-		})
+func (d *deployDatasetRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+	err := app.Engine.CreateDataset(ctx.Ctx, app.DB, d.schema, ctx)
 	if err != nil {
 		return transactions.CodeUnknownError, err
 	}
@@ -287,9 +274,7 @@ func (d *deployDatasetRoute) InTx(ctx common.TxContext, app *common.App, tx *tra
 }
 
 type dropDatasetRoute struct {
-	dbid       string
-	identifier string
-	authType   string
+	dbid string
 }
 
 var _ consensus.Route = (*dropDatasetRoute)(nil)
@@ -302,7 +287,7 @@ func (d *dropDatasetRoute) Price(ctx context.Context, app *common.App, tx *trans
 	return big.NewInt(10000000000000), nil
 }
 
-func (d *dropDatasetRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *dropDatasetRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot drop dataset during migration")
 	}
@@ -313,26 +298,12 @@ func (d *dropDatasetRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *
 		return transactions.CodeEncodingError, err
 	}
 
-	d.identifier, err = ident.Identifier(tx.Signature.Type, tx.Sender)
-	if err != nil {
-		return transactions.CodeUnknownError, err
-	}
-
-	d.authType = tx.Signature.Type
-
 	d.dbid = drop.DBID
 	return 0, nil
 }
 
-func (d *dropDatasetRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
-	err := app.Engine.DeleteDataset(ctx.Ctx, app.DB, d.dbid, &common.TransactionData{
-		Signer:         tx.Sender,
-		Caller:         d.identifier,
-		TxID:           hex.EncodeToString(ctx.TxID),
-		Height:         ctx.BlockContext.Height,
-		BlockTimestamp: ctx.BlockContext.BlockTimestamp,
-		Authenticator:  d.authType,
-	})
+func (d *dropDatasetRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+	err := app.Engine.DeleteDataset(ctx.Ctx, app.DB, d.dbid, ctx)
 	if err != nil {
 		return transactions.CodeUnknownError, err
 	}
@@ -340,11 +311,9 @@ func (d *dropDatasetRoute) InTx(ctx common.TxContext, app *common.App, tx *trans
 }
 
 type executeActionRoute struct {
-	identifier string
-	authType   string
-	dbid       string
-	action     string
-	args       [][]any
+	dbid   string
+	action string
+	args   [][]any
 }
 
 var _ consensus.Route = (*executeActionRoute)(nil)
@@ -357,7 +326,7 @@ func (d *executeActionRoute) Price(ctx context.Context, app *common.App, tx *tra
 	return big.NewInt(2000000000000000), nil
 }
 
-func (d *executeActionRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *executeActionRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	action := &transactions.ActionExecution{}
 	err := action.UnmarshalBinary(tx.Body.Payload)
 	if err != nil {
@@ -366,12 +335,6 @@ func (d *executeActionRoute) PreTx(ctx common.TxContext, svc *common.Service, tx
 
 	d.action = action.Action
 	d.dbid = action.DBID
-	d.authType = tx.Signature.Type
-
-	d.identifier, err = ident.Identifier(tx.Signature.Type, tx.Sender)
-	if err != nil {
-		return transactions.CodeUnknownError, err
-	}
 
 	// here, we decode the [][]transactions.EncodedTypes into [][]any
 	args := make([][]any, len(action.Arguments))
@@ -397,20 +360,13 @@ func (d *executeActionRoute) PreTx(ctx common.TxContext, svc *common.Service, tx
 	return 0, nil
 }
 
-func (d *executeActionRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *executeActionRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	for i := range d.args {
 		_, err := app.Engine.Procedure(ctx.Ctx, app.DB, &common.ExecutionData{
 			Dataset:   d.dbid,
 			Procedure: d.action,
 			Args:      d.args[i],
-			TransactionData: common.TransactionData{
-				Signer:         tx.Sender,
-				Caller:         d.identifier,
-				TxID:           hex.EncodeToString(ctx.TxID),
-				Height:         ctx.BlockContext.Height,
-				BlockTimestamp: ctx.BlockContext.BlockTimestamp,
-				Authenticator:  d.authType,
-			},
+			TxCtx:     ctx,
 		})
 		if err != nil {
 			return codeForEngineError(err), err
@@ -434,7 +390,7 @@ func (d *transferRoute) Price(ctx context.Context, app *common.App, tx *transact
 	return big.NewInt(210_000), nil
 }
 
-func (d *transferRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *transferRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot transfer during migration")
 	}
@@ -461,7 +417,7 @@ func (d *transferRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *tra
 	return 0, nil
 }
 
-func (d *transferRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *transferRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	err := transfer(ctx.Ctx, app.DB, tx.Sender, d.to, d.amt)
 	if err != nil {
 		if errors.Is(err, accounts.ErrInsufficientFunds) {
@@ -489,7 +445,7 @@ func (d *validatorJoinRoute) Price(ctx context.Context, app *common.App, tx *tra
 	return big.NewInt(10000000000000), nil
 }
 
-func (d *validatorJoinRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorJoinRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot join validator during migration")
 	}
@@ -504,7 +460,7 @@ func (d *validatorJoinRoute) PreTx(ctx common.TxContext, svc *common.Service, tx
 	return 0, nil
 }
 
-func (d *validatorJoinRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorJoinRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	// ensure this candidate is not already a validator
 	power, err := getVoterPower(ctx.Ctx, app.DB, tx.Sender)
 	if err != nil {
@@ -561,7 +517,7 @@ func (d *validatorApproveRoute) Price(ctx context.Context, app *common.App, tx *
 	return big.NewInt(10000000000000), nil
 }
 
-func (d *validatorApproveRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorApproveRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot approve validator join during migration")
 	}
@@ -580,7 +536,7 @@ func (d *validatorApproveRoute) PreTx(ctx common.TxContext, svc *common.Service,
 	return 0, nil
 }
 
-func (d *validatorApproveRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorApproveRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	// each pending validator can only have one active join request at a time
 	// we need to retrieve the join request and ensure that it is still pending
 	pending, err := getResolutionsByTypeAndProposer(ctx.Ctx, app.DB, voting.ValidatorJoinEventType, d.candidate)
@@ -626,7 +582,7 @@ func (d *validatorRemoveRoute) Price(ctx context.Context, app *common.App, tx *t
 	return big.NewInt(100_000), nil
 }
 
-func (d *validatorRemoveRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorRemoveRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot remove validator during migration")
 	}
@@ -641,7 +597,7 @@ func (d *validatorRemoveRoute) PreTx(ctx common.TxContext, svc *common.Service, 
 	return 0, nil
 }
 
-func (d *validatorRemoveRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorRemoveRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	removeReq := &voting.UpdatePowerRequest{
 		PubKey: d.target,
 		Power:  0,
@@ -697,14 +653,14 @@ func (d *validatorLeaveRoute) Price(ctx context.Context, app *common.App, tx *tr
 	return big.NewInt(10000000000000), nil
 }
 
-func (d *validatorLeaveRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorLeaveRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot leave validator during migration")
 	}
 	return 0, nil // no payload to decode or validate for this route
 }
 
-func (d *validatorLeaveRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorLeaveRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	power, err := getVoterPower(ctx.Ctx, app.DB, tx.Sender)
 	if err != nil {
 		return transactions.CodeUnknownError, err
@@ -741,14 +697,14 @@ func (d *validatorVoteIDsRoute) Price(ctx context.Context, app *common.App, tx *
 	return big.NewInt(int64(len(ids.ResolutionIDs)) * ValidatorVoteIDPrice.Int64()), nil
 }
 
-func (d *validatorVoteIDsRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorVoteIDsRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot vote during migration")
 	}
 	return 0, nil
 }
 
-func (d *validatorVoteIDsRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorVoteIDsRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	// if the caller has 0 power, they are not a validator, and should not be able to vote
 	power, err := getVoterPower(ctx.Ctx, app.DB, tx.Sender)
 	if err != nil {
@@ -821,7 +777,7 @@ func (d *validatorVoteBodiesRoute) Price(ctx context.Context, _ *common.App, tx 
 	return big.NewInt(totalSize * ValidatorVoteBodyBytePrice), nil
 }
 
-func (d *validatorVoteBodiesRoute) PreTx(ctx common.TxContext, _ *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorVoteBodiesRoute) PreTx(ctx *common.TxContext, _ *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot vote during migration")
 
@@ -843,7 +799,7 @@ func (d *validatorVoteBodiesRoute) PreTx(ctx common.TxContext, _ *common.Service
 	return 0, nil
 }
 
-func (d *validatorVoteBodiesRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *validatorVoteBodiesRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	fromLocalValidator := bytes.Equal(tx.Sender, app.Service.Identity)
 
 	// Expectation:
@@ -911,7 +867,7 @@ func (d *createResolutionRoute) Price(ctx context.Context, app *common.App, tx *
 	return big.NewInt(int64(len(res.Resolution.Body)) * ValidatorVoteBodyBytePrice), nil
 }
 
-func (d *createResolutionRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *createResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, errors.New("cannot create resolution during migration")
 	}
@@ -934,7 +890,7 @@ func (d *createResolutionRoute) PreTx(ctx common.TxContext, svc *common.Service,
 	return 0, nil
 }
 
-func (d *createResolutionRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *createResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	// ensure the sender is a validator
 	// only validators can create resolutions
 	power, err := getVoterPower(ctx.Ctx, app.DB, tx.Sender)
@@ -974,7 +930,7 @@ func (d *approveResolutionRoute) Price(ctx context.Context, app *common.App, tx 
 	return ValidatorVoteIDPrice, nil
 }
 
-func (d *approveResolutionRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *approveResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, errors.New("cannot approve a resolution during migration")
 	}
@@ -989,7 +945,7 @@ func (d *approveResolutionRoute) PreTx(ctx common.TxContext, svc *common.Service
 	return 0, nil
 }
 
-func (d *approveResolutionRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *approveResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	// ensure the sender is a validator
 	power, err := getVoterPower(ctx.Ctx, app.DB, tx.Sender)
 	if err != nil {
@@ -1032,7 +988,7 @@ func (d *deleteResolutionRoute) Price(ctx context.Context, app *common.App, tx *
 	return ValidatorVoteIDPrice, nil
 }
 
-func (d *deleteResolutionRoute) PreTx(ctx common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *deleteResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		return transactions.CodeNetworkInMigration, errors.New("cannot vote during migration")
 	}
@@ -1048,7 +1004,7 @@ func (d *deleteResolutionRoute) PreTx(ctx common.TxContext, svc *common.Service,
 }
 
 // deleteResolutionRoute is a route for deleting a resolution.
-func (d *deleteResolutionRoute) InTx(ctx common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *deleteResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx *transactions.Transaction) (transactions.TxCode, error) {
 	// ensure the sender is a validator
 	power, err := getVoterPower(ctx.Ctx, app.DB, tx.Sender)
 	if err != nil {

--- a/internal/txapp/routes_test.go
+++ b/internal/txapp/routes_test.go
@@ -59,7 +59,7 @@ func Test_Routes(t *testing.T) {
 		fn      func(t *testing.T, callback func()) // required, uses callback to control when the test is run
 		payload transactions.Payload                // required
 		fee     int64                               // optional, if nil, will automatically use 0
-		ctx     TxContext                           // optional, if nil, will automatically create a mock
+		ctx     *common.TxContext                   // optional, if nil, will automatically create a mock
 		from    auth.Signer                         // optional, if nil, will automatically use default validatorSigner1
 		err     error                               // if not nil, expect this error
 	}
@@ -191,7 +191,7 @@ func Test_Routes(t *testing.T) {
 					},
 				},
 			},
-			ctx: TxContext{
+			ctx: &common.TxContext{
 				BlockContext: &common.BlockContext{
 					Proposer: validatorSigner1().Identity(),
 				},
@@ -227,7 +227,7 @@ func Test_Routes(t *testing.T) {
 					},
 				},
 			},
-			ctx: TxContext{
+			ctx: &common.TxContext{
 				BlockContext: &common.BlockContext{
 					Proposer: validatorSigner1().Identity(),
 				},
@@ -282,6 +282,10 @@ func Test_Routes(t *testing.T) {
 				}
 				if app.signer == nil {
 					app.signer = validatorSigner1()
+				}
+
+				if tc.ctx == nil {
+					tc.ctx = &common.TxContext{}
 				}
 
 				if tc.ctx.BlockContext == nil {

--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -242,7 +242,7 @@ func (r *TxApp) validatorSetPower(ctx context.Context, tx sql.Executor) (int64, 
 // appropriate module(s) and return the response. This method must only be
 // called from the consensus engine, sequentially, when executing transactions
 // in a block.
-func (r *TxApp) Execute(ctx TxContext, db sql.DB, tx *transactions.Transaction) *TxResponse {
+func (r *TxApp) Execute(ctx *common.TxContext, db sql.DB, tx *transactions.Transaction) *TxResponse {
 	route, ok := routes[tx.Body.PayloadType.String()] // and RegisterRoute call is not concurrent
 	if !ok {
 		return txRes(nil, transactions.CodeInvalidTxType, fmt.Errorf("unknown payload type: %s", tx.Body.PayloadType.String()))
@@ -805,7 +805,7 @@ func (s *Spend) ApplySpend(ctx context.Context, db sql.DB) error {
 
 // recordSpend records a spend occurred during the block execution.
 // This only records spends during migrations.
-func (r *TxApp) recordSpend(ctx TxContext, spend *Spend) {
+func (r *TxApp) recordSpend(ctx *common.TxContext, spend *Spend) {
 	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
 		r.spends = append(r.spends, spend)
 	}
@@ -828,7 +828,7 @@ func (r *TxApp) GetBlockSpends() []*Spend {
 // It also returns an error code.
 // if we allow users to implement their own routes, this function will need to
 // be exported.
-func (r *TxApp) checkAndSpend(ctx TxContext, tx *transactions.Transaction, pricer Pricer, dbTx sql.DB) (*big.Int, transactions.TxCode, error) {
+func (r *TxApp) checkAndSpend(ctx *common.TxContext, tx *transactions.Transaction, pricer Pricer, dbTx sql.DB) (*big.Int, transactions.TxCode, error) {
 	amt := big.NewInt(0)
 	var err error
 

--- a/test/nodes/fork/gremlin.go
+++ b/test/nodes/fork/gremlin.go
@@ -101,7 +101,7 @@ func (d *gremlinNoopRoute) Price(context.Context, *common.App, *transactions.Tra
 	return big.NewInt(42000), nil
 }
 
-func (d *gremlinNoopRoute) PreTx(_ common.TxContext, _ *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
+func (d *gremlinNoopRoute) PreTx(_ *common.TxContext, _ *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
 	if len(tx.Body.Payload) != 1 {
 		return transactions.CodeEncodingError, errors.New("incorrect payload length")
 	}
@@ -112,6 +112,6 @@ func (d *gremlinNoopRoute) PreTx(_ common.TxContext, _ *common.Service, tx *tran
 	return 0, nil
 }
 
-func (d *gremlinNoopRoute) InTx(common.TxContext, *common.App, *transactions.Transaction) (transactions.TxCode, error) {
+func (d *gremlinNoopRoute) InTx(*common.TxContext, *common.App, *transactions.Transaction) (transactions.TxCode, error) {
 	return transactions.CodeOk, nil // no-op, no app state mods
 }

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -196,11 +196,13 @@ func (tc SchemaTest) Run(ctx context.Context, opts *Options) error {
 
 				// deploy schemas
 				for _, schema := range parsedSchemas {
-					err := engine.CreateDataset(ctx, outerTx, schema, &common.TransactionData{
+					err := engine.CreateDataset(ctx, outerTx, schema, &common.TxContext{
 						Signer: deployer,
 						Caller: string(deployer),
 						TxID:   platform.Txid(),
-						Height: 0,
+						BlockContext: &common.BlockContext{
+							Height: 0,
+						},
 					})
 					if err != nil {
 						return err
@@ -297,11 +299,17 @@ func (e *TestCase) runExecution(ctx context.Context, platform *Platform) error {
 	platform.Logger.Logf(`executing action/procedure "%s" against schema "%s" (DBID: %s)`, e.Target, e.Database, dbid)
 
 	res, err := platform.Engine.Procedure(ctx, platform.DB, &common.ExecutionData{
-		TransactionData: common.TransactionData{
+		TxCtx: &common.TxContext{
 			Signer: []byte(caller),
 			Caller: caller,
-			Height: e.Height,
 			TxID:   platform.Txid(),
+			BlockContext: &common.BlockContext{
+				Height: e.Height,
+				ChainContext: &common.ChainContext{
+					MigrationParams:   &common.MigrationContext{},
+					NetworkParameters: &common.NetworkParameters{},
+				},
+			},
 		},
 		Dataset:   dbid,
 		Procedure: e.Target,

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -196,14 +196,15 @@ func (tc SchemaTest) Run(ctx context.Context, opts *Options) error {
 
 				// deploy schemas
 				for _, schema := range parsedSchemas {
-					err := engine.CreateDataset(ctx, outerTx, schema, &common.TxContext{
+					err := engine.CreateDataset(&common.TxContext{
+						Ctx:    ctx,
 						Signer: deployer,
 						Caller: string(deployer),
 						TxID:   platform.Txid(),
 						BlockContext: &common.BlockContext{
 							Height: 0,
 						},
-					})
+					}, outerTx, schema)
 					if err != nil {
 						return err
 					}
@@ -219,7 +220,14 @@ func (tc SchemaTest) Run(ctx context.Context, opts *Options) error {
 
 					for _, sql := range seed {
 						dbid := utils.GenerateDBID(dbName, deployer)
-						_, err = engine.Execute(ctx, outerTx, dbid, sql, nil)
+						_, err = engine.Execute(&common.TxContext{
+							Signer: deployer,
+							Caller: string(deployer),
+							TxID:   platform.Txid(),
+							BlockContext: &common.BlockContext{
+								Height: 0,
+							},
+						}, outerTx, dbid, sql, nil)
 						if err != nil {
 							return fmt.Errorf(`error executing seed query "%s" on schema "%s": %s`, sql, dbName, err)
 						}
@@ -298,19 +306,19 @@ func (e *TestCase) runExecution(ctx context.Context, platform *Platform) error {
 	// log to help users debug failed tests
 	platform.Logger.Logf(`executing action/procedure "%s" against schema "%s" (DBID: %s)`, e.Target, e.Database, dbid)
 
-	res, err := platform.Engine.Procedure(ctx, platform.DB, &common.ExecutionData{
-		TxCtx: &common.TxContext{
-			Signer: []byte(caller),
-			Caller: caller,
-			TxID:   platform.Txid(),
-			BlockContext: &common.BlockContext{
-				Height: e.Height,
-				ChainContext: &common.ChainContext{
-					MigrationParams:   &common.MigrationContext{},
-					NetworkParameters: &common.NetworkParameters{},
-				},
+	res, err := platform.Engine.Procedure(&common.TxContext{
+		Ctx:    ctx,
+		Signer: []byte(caller),
+		Caller: caller,
+		TxID:   platform.Txid(),
+		BlockContext: &common.BlockContext{
+			Height: e.Height,
+			ChainContext: &common.ChainContext{
+				MigrationParams:   &common.MigrationContext{},
+				NetworkParameters: &common.NetworkParameters{},
 			},
 		},
+	}, platform.DB, &common.ExecutionData{
 		Dataset:   dbid,
 		Procedure: e.Target,
 		Args:      e.Args,


### PR DESCRIPTION
Ok this was the last major change I wanted to make before we have another release.

This change removes/refactors some unnecessary structs in `common`, and unifies them. In particular, we had essentially two structs that do the same thing, and we often switch between them. The reason I felt this change was necessary is because there are currently some very awkward patterns used in extensions (resolutions in particular) that are the result of not properly duplicating fields/information in these structs.

Therefore, this is a breaking change, however it is trivially easy to port over old extensions, and extensions already received a breaking interface change in this release.