### PR TITLE
pg: elide unchanged tup vals in UPDATE changeset

### DIFF
--- a/internal/sql/pg/repl_changeset_test.go
+++ b/internal/sql/pg/repl_changeset_test.go
@@ -1,0 +1,125 @@
+package pg
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangesetEntry_Serialize(t *testing.T) {
+	tests := []struct {
+		name string
+		ce   *ChangesetEntry
+	}{
+		{
+			name: "valid changeset entry",
+			ce: &ChangesetEntry{
+				RelationIdx: 1,
+				OldTuple: []*TupleColumn{
+					{
+						ValueType: SerializedValue,
+						Data:      []byte{2, 3, 4, 5},
+					},
+				},
+				NewTuple: []*TupleColumn{
+					{
+						ValueType: SerializedValue,
+						Data:      []byte{4, 5, 6, 7},
+					},
+				},
+			},
+		},
+		{
+			name: "changeset entry with empty old",
+			ce: &ChangesetEntry{
+				RelationIdx: 1,
+				OldTuple:    []*TupleColumn{}, // nil does not round trip in RLP!
+				NewTuple: []*TupleColumn{
+					{
+						ValueType: SerializedValue,
+						Data:      []byte{4, 5, 6, 7},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// First test round trip with MarshalBinary and UnmarshalBinary
+			bts, err := tt.ce.MarshalBinary()
+			require.NoError(t, err)
+
+			// Deserialize and compare
+			newCE := &ChangesetEntry{}
+			err = newCE.UnmarshalBinary(bts)
+			require.NoError(t, err)
+			assert.Equal(t, tt.ce, newCE)
+
+			// Now as a prefixed element in a stream
+			var buf bytes.Buffer
+			err = StreamElement(&buf, tt.ce)
+			require.NoError(t, err)
+
+			csStream := buf.Bytes()
+			csType, csSize := DecodeStreamPrefix([5]byte(csStream[:5]))
+			assert.Equal(t, ChangesetEntryType, csType)
+			assert.Equal(t, int(csSize), len(bts))
+		})
+	}
+}
+
+func TestRelation_Serialize(t *testing.T) {
+	tests := []struct {
+		name string
+		r    *Relation
+	}{
+		{
+			name: "valid relation",
+			r: &Relation{
+				Schema: "ns",
+				Table:  "table",
+				Columns: []*Column{
+					{Name: "a", Type: types.IntType},
+					{Name: "b", Type: types.TextType},
+				},
+			},
+		},
+		{
+			name: "changeset entry with no schema",
+			r: &Relation{
+				Table: "tablex",
+				Columns: []*Column{
+					{Name: "a", Type: types.BlobType},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// First test round trip with MarshalBinary and UnmarshalBinary
+			bts, err := tt.r.MarshalBinary()
+			require.NoError(t, err)
+
+			// Deserialize and compare
+			rel := &Relation{}
+			err = rel.UnmarshalBinary(bts)
+			require.NoError(t, err)
+			assert.Equal(t, tt.r, rel)
+
+			// Now as a prefixed element in a stream
+			var buf bytes.Buffer
+			err = StreamElement(&buf, tt.r)
+			require.NoError(t, err)
+
+			csStream := buf.Bytes()
+			csType, csSize := DecodeStreamPrefix([5]byte(csStream[:5]))
+			assert.Equal(t, RelationType, csType)
+			assert.Equal(t, int(csSize), len(bts))
+		})
+	}
+}


### PR DESCRIPTION
This PR has two closely related commits:

1. https://github.com/kwilteam/kwil-db/pull/942/commits/b1f9c903f69f9f92628ad705131ebed51ebd097d In changesets, the `ChangesetElentry` for an UPDATE includes both old and new values.  All of the old values are required, to be used with a fully-specified `WHERE` clause.  However, only the changed *new* values need to be included in the `SET` clause.  This commit deduplicates this unchanged data from the changesets.  This can drastically reduce the size of the serialized changesets (imagine only modifying an integer column and other large bytea/text columns unchanged), which must be stored and trasmitted cross-chain and then recorded permanently in governance transactions on the new chain.   The second reason it is helpful to flag these values as unchanged is that it makes statistics maintenance simpler when handling updates.
2. https://github.com/kwilteam/kwil-db/pull/942/commits/baaceb99e9cba683c2f180a12a71e9598a047a90 formalizes the changeset streaming format. Previously a special 5 byte prefixing convention and code was duplicated in several methods.  Plus the Serialize/Deserialize methods were not complementary, meaning they did not match and could not round trip data.  The `ChangeStreamer` interface and the `StreamElement` and `DecodeStreamPrefix` functions are now used to encasulate these details and conventions.  Each of the concrete types that are encoded/decoded to/from a stream of changeset elements implement the `ChangeStreamer`.  It is still awkward there is a single enum of prefix bytes but that both `internal/migrations` and `internal/sql/pg`, although this is still much clearer than before.