### PR TITLE
types,migrations,admin,rpc: cleanup and migrations type fix

### DIFF
--- a/cmd/kwil-admin/cmds/migration/approve.go
+++ b/cmd/kwil-admin/cmds/migration/approve.go
@@ -1,12 +1,11 @@
 package migration
 
 import (
-	"context"
+	"github.com/spf13/cobra"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/spf13/cobra"
 )
 
 func approveCmd() *cobra.Command {
@@ -16,8 +15,7 @@ func approveCmd() *cobra.Command {
 		Example: "kwil-admin migrate approve <proposal-id>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-
+			ctx := cmd.Context()
 			clt, err := common.GetAdminSvcClient(ctx, cmd)
 			if err != nil {
 				return display.PrintErr(cmd, err)

--- a/cmd/kwil-admin/cmds/migration/cmd.go
+++ b/cmd/kwil-admin/cmds/migration/cmd.go
@@ -1,8 +1,9 @@
 package migration
 
 import (
-	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/spf13/cobra"
+
+	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 )
 
 var migrationCmd = &cobra.Command{

--- a/cmd/kwil-admin/cmds/migration/genesis.go
+++ b/cmd/kwil-admin/cmds/migration/genesis.go
@@ -1,41 +1,42 @@
 package migration
 
 import (
-	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
 
+	"github.com/spf13/cobra"
+
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/common/chain"
 	"github.com/kwilteam/kwil-db/internal/statesync"
-	"github.com/spf13/cobra"
 )
 
 var (
 	genesisFileName  = "genesis.json"
 	snapshotFileName = "snapshot.sql.gz"
 
-	genesisStateLong = "Download the genesis state for the new network from a trusted node on the source network. The genesis state includes the genesis config file (genesis.json) , genesis snapshot (snapshot.sql.gz) , and the migration info such as the start and end heights. The genesis state is saved in the root directory specified by the `--root-dir` flag. If there is no approved migration or if the migration has not started yet, the command will return a message indicating that there is no genesis state to download."
+	genesisStateLong = "Download the genesis state for the new network from a trusted node on the source network. The genesis state includes the genesis config file (genesis.json), genesis snapshot (snapshot.sql.gz), and the migration info such as the start and end heights. The genesis state is saved in the root directory specified by the `--root-dir` flag. If there is no approved migration or if the migration has not started yet, the command will return a message indicating that there is no genesis state to download."
 
 	genesisStateExample = `# Download the genesis state to the default root directory (~/.kwild)
-kwil-admin migration genesis-state
+kwil-admin migrate genesis-state
 
 # Download the genesis state to a custom root directory
-kwil-admin migration genesis-state --root-dir /path/to/root/dir.`
+kwil-admin migrate genesis-state --root-dir /path/to/root/dir`
 )
 
 func genesisStateCmd() *cobra.Command {
 	var rootDir string
 	cmd := &cobra.Command{
 		Use:     "genesis-state",
-		Short:   "Download the genesis state corresponding to the on-going migration.",
+		Short:   "Download the genesis state corresponding to the ongoing migration.",
 		Long:    genesisStateLong,
 		Example: genesisStateExample,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
+			ctx := cmd.Context()
 			clt, err := common.GetAdminSvcClient(ctx, cmd)
 			if err != nil {
 				return display.PrintErr(cmd, err)
@@ -116,7 +117,7 @@ func genesisStateCmd() *cobra.Command {
 	}
 
 	common.BindRPCFlags(cmd)
-	cmd.Flags().StringVar(&rootDir, "root-dir", "~/.kwild", "Root directory for the genesis state files")
+	cmd.Flags().StringVarP(&rootDir, "root-dir", "r", "~/.kwild", "Root directory for the genesis state files")
 	return cmd
 }
 

--- a/cmd/kwil-admin/cmds/migration/list.go
+++ b/cmd/kwil-admin/cmds/migration/list.go
@@ -2,14 +2,14 @@ package migration
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
+
+	"github.com/spf13/cobra"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/spf13/cobra"
 )
 
 func listCmd() *cobra.Command {
@@ -21,8 +21,7 @@ func listCmd() *cobra.Command {
 kwil-admin migrate list`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-
+			ctx := cmd.Context()
 			clt, err := common.GetAdminSvcClient(ctx, cmd)
 			if err != nil {
 				return display.PrintErr(cmd, err)

--- a/cmd/kwil-admin/cmds/migration/propose.go
+++ b/cmd/kwil-admin/cmds/migration/propose.go
@@ -1,17 +1,17 @@
 package migration
 
 import (
-	"context"
 	"errors"
+
+	"github.com/spf13/cobra"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/internal/migrations"
-	"github.com/spf13/cobra"
 )
 
 var (
-	proposeLong = "A Validator operator can submit a migration proposal using the `propose` subcommand. The migration proposal includes the new `chain-id`, `activation-period` and `duration`. This action will generate a migration resolution for the other validators to vote on. If a supermajority of validators approve the migration proposal, the migration will commence after the specified activation-period blocks from approval and will continue for the duration defined by duration blocks."
+	proposeLong = "A Validator operator can submit a migration proposal using the `propose` subcommand. The migration proposal includes the new `chain-id`, `activation-period` and `duration`. This action will generate a migration resolution for the other validators to vote on. If a super-majority of validators approve the migration proposal, the migration will commence after the specified activation-period blocks from approval and will continue for the duration defined by duration blocks."
 
 	proposeExample = `# Submit a migration proposal to migrate to a new chain "kwil-chain-new" with activation period 1000 and migration duration of 14400 blocks.
 kwil-admin migrate propose --activation-period 1000 --duration 14400 --chain-id kwil-chain-new
@@ -30,8 +30,7 @@ func proposeCmd() *cobra.Command {
 		Example: proposeExample,
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-
+			ctx := cmd.Context()
 			clt, err := common.GetAdminSvcClient(ctx, cmd)
 			if err != nil {
 				return display.PrintErr(cmd, err)

--- a/cmd/kwil-admin/cmds/migration/status.go
+++ b/cmd/kwil-admin/cmds/migration/status.go
@@ -2,7 +2,6 @@ package migration
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"fmt"
 	"math"
@@ -26,8 +25,7 @@ func statusCmd() *cobra.Command {
 		Example: statusExample,
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			ctx := context.Background()
-
+			ctx := cmd.Context()
 			clt, err := common.GetAdminSvcClient(ctx, cmd)
 			if err != nil {
 				return display.PrintErr(cmd, err)

--- a/cmd/kwil-admin/cmds/snapshot/create.go
+++ b/cmd/kwil-admin/cmds/snapshot/create.go
@@ -58,6 +58,7 @@ func createCmd() *cobra.Command {
 		Short:   "Creates a snapshot of the database.",
 		Long:    createLongExplain,
 		Example: createExample,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			snapshotDir, err := common.ExpandPath(snapshotDir)
 			if err != nil {

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"encoding/json"
 	"fmt"
 	"math/big"
 )
@@ -94,9 +95,9 @@ type Migration struct {
 // consumers of what information the current node has available
 // for the migration.
 type MigrationMetadata struct {
-	InMigration      bool   `json:"in_migration"`      // InMigration is true if the node is in migration state i.e current height is between StartHeight and EndHeight
-	StartHeight      int64  `json:"start_height"`      // StartHeight is the block height at which the migration starts
-	EndHeight        int64  `json:"end_height"`        // EndHeight is the block height at which the migration ends
-	GenesisConfig    []byte `json:"genesis_config"`    // GenesisConfig is the genesis file data
-	SnapshotMetadata []byte `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
+	InMigration      bool            `json:"in_migration"`      // InMigration is true if the node is in migration state i.e current height is between StartHeight and EndHeight
+	StartHeight      int64           `json:"start_height"`      // StartHeight is the block height at which the migration starts
+	EndHeight        int64           `json:"end_height"`        // EndHeight is the block height at which the migration ends
+	GenesisConfig    json.RawMessage `json:"genesis_config"`    // GenesisConfig is the genesis file data
+	SnapshotMetadata json.RawMessage `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
 }

--- a/internal/migrations/migrator.go
+++ b/internal/migrations/migrator.go
@@ -375,7 +375,7 @@ func (m *Migrator) GetGenesisSnapshotChunk(height int64, format uint32, chunkIdx
 }
 
 // GetChangesetMetadata gets the metadata for the changeset at the given height.
-func (m *Migrator) GetChangesetMetadata(height int64) (*ChangesetMetdata, error) {
+func (m *Migrator) GetChangesetMetadata(height int64) (*ChangesetMetadata, error) {
 	m.mu.RLock()
 	defer m.mu.RUnlock()
 
@@ -426,14 +426,14 @@ func (m *Migrator) GetChangeset(height int64, index int64) ([]byte, error) {
 //		genesis.json
 //		snapshot data.....
 
-type ChangesetMetdata struct {
+type ChangesetMetadata struct {
 	Height     int64
 	Chunks     int64
 	ChunkSizes []int64
 }
 
 // Serialize serializes the metadata to a file.
-func (m *ChangesetMetdata) saveAs(file string) error {
+func (m *ChangesetMetadata) saveAs(file string) error {
 	bts, err := json.MarshalIndent(m, "", "  ")
 	if err != nil {
 		return err
@@ -443,13 +443,13 @@ func (m *ChangesetMetdata) saveAs(file string) error {
 
 // LoadChangesetMetadata loads the metadata associated with a changeset.s
 // It reads the changeset metadata file and returns the metadata.
-func loadChangesetMetadata(metadatafile string) (*ChangesetMetdata, error) {
+func loadChangesetMetadata(metadatafile string) (*ChangesetMetadata, error) {
 	bts, err := os.ReadFile(metadatafile)
 	if err != nil {
 		return nil, fmt.Errorf("metadata file not found %s", err.Error())
 	}
 
-	var metadata ChangesetMetdata
+	var metadata ChangesetMetadata
 	if err := json.Unmarshal(bts, &metadata); err != nil {
 		return nil, err
 	}
@@ -567,7 +567,7 @@ func (cw *chunkWriter) Close() error {
 
 func (cw *chunkWriter) SaveMetadata() error {
 	filename := formatChangesetMetadataFilename(cw.dir, cw.height)
-	metadata := &ChangesetMetdata{
+	metadata := &ChangesetMetadata{
 		Height:     cw.height,
 		Chunks:     cw.chunkIdx + 1,
 		ChunkSizes: cw.chunkSizes,

--- a/internal/services/jsonrpc/adminsvc/service.go
+++ b/internal/services/jsonrpc/adminsvc/service.go
@@ -56,7 +56,7 @@ type P2P interface {
 }
 
 type Migrator interface {
-	GetChangesetMetadata(height int64) (*migrations.ChangesetMetdata, error)
+	GetChangesetMetadata(height int64) (*migrations.ChangesetMetadata, error)
 	GetChangeset(height int64, index int64) ([]byte, error)
 	GetMigrationMetadata() (*coretypes.MigrationMetadata, error)
 	GetGenesisSnapshotChunk(height int64, format uint32, chunkIdx uint32) ([]byte, error)

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -232,7 +232,7 @@ type Pricer interface {
 }
 
 type Migrator interface {
-	GetChangesetMetadata(height int64) (*migrations.ChangesetMetdata, error)
+	GetChangesetMetadata(height int64) (*migrations.ChangesetMetadata, error)
 	GetChangeset(height int64, index int64) ([]byte, error)
 	GetMigrationMetadata() (*types.MigrationMetadata, error)
 	GetGenesisSnapshotChunk(height int64, format uint32, chunkIdx uint32) ([]byte, error)

--- a/test/specifications/migration.go
+++ b/test/specifications/migration.go
@@ -80,8 +80,8 @@ func InstallGenesisState(ctx context.Context, t *testing.T, netops MigrationOpsD
 	}, 6*time.Second, 500*time.Millisecond)
 
 	// Verify genesis state
-	require.NotNil(t, metadata.GenesisConfig)
-	require.NotNil(t, metadata.SnapshotMetadata)
+	require.NotEmpty(t, metadata.GenesisConfig)
+	require.NotEmpty(t, metadata.SnapshotMetadata)
 
 	// Ensure the root directory exists
 	err = os.MkdirAll(rootDir, 0755)


### PR DESCRIPTION
This PR does a few minor things pertaining to recent migrations code in various packages:

- In `core/types/MigrationMetadata` change the `GenesisConfig` and `SnapshotMetadata` fields from `[]byte` to `json.RawMessage`. This is the preferred type when delaying the unmarshal of raw JSON, which is exactly the case as we unmarshal these into internal types.  This avoids the RPC service/client from having to needlessly round trip the content, which is already text (JSON), to base64 and back.  This is very similar to changing the field to a `string`.  There are no visible changes unless using `curl` to see the raw response.
- In each of the `cmd/kwil-admin/cmds/...`, cleanup various typo, use the `cmd.Context()`, set arg counts, docs tweaks, etc.
- Rename `internal/migrations.ChangesetMetdata` to `ChangesetMetadata` (spelling)
