### PR TITLE
fix: parse bug with string literals

### DIFF
--- a/parse/antlr.go
+++ b/parse/antlr.go
@@ -97,10 +97,16 @@ func unknownExpression(ctx antlr.ParserRuleContext) *ExpressionLiteral {
 }
 
 func (s *schemaVisitor) VisitString_literal(ctx *gen.String_literalContext) any {
-	str := ctx.STRING_()
+	str := ctx.STRING_().GetText()
+
+	if !strings.HasPrefix(str, "'") || !strings.HasSuffix(str, "'") || len(str) < 2 {
+		panic("invalid string literal")
+	}
+	str = str[1 : len(str)-1]
+
 	n := &ExpressionLiteral{
 		Type:  types.TextType,
-		Value: strings.Trim(str.GetText(), "'"),
+		Value: str,
 	}
 
 	n.Set(ctx)

--- a/parse/parse_test.go
+++ b/parse/parse_test.go
@@ -1979,6 +1979,24 @@ func Test_Procedure(t *testing.T) {
 				},
 			},
 		},
+		{
+			// regression test https://github.com/kwilteam/kwil-db/pull/947
+			name: "string literal",
+			proc: `
+			$a := '\'hello\'';
+			`,
+			want: &parse.ProcedureParseResult{
+				Variables: map[string]*types.DataType{
+					"$a": types.TextType,
+				},
+				AST: []parse.ProcedureStmt{
+					&parse.ProcedureStmtAssign{
+						Variable: exprVar("$a"),
+						Value:    exprLit("\\'hello\\'"),
+					},
+				},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
This PR fixes a bug I found where string literals that end in an escaped single quote (e.g. `'hello world \''`) incorrectly remove the escaped quote.
