### PR TITLE
Migration fixes

### DIFF
--- a/cmd/kwil-admin/cmds/migration/list.go
+++ b/cmd/kwil-admin/cmds/migration/list.go
@@ -60,6 +60,7 @@ func (m *MigrationsList) MarshalText() ([]byte, error) {
 		msg.WriteString(fmt.Sprintf("\tactivationPeriod: %d\n", migration.ActivationPeriod))
 		msg.WriteString(fmt.Sprintf("\tmigrationDuration: %d\n", migration.Duration))
 		msg.WriteString(fmt.Sprintf("\tchainID: %s\n", migration.ChainID))
+		msg.WriteString(fmt.Sprintf("\ttimestamp: %s\n", migration.Timestamp))
 	}
 	return msg.Bytes(), nil
 }

--- a/cmd/kwil-admin/cmds/migration/propose.go
+++ b/cmd/kwil-admin/cmds/migration/propose.go
@@ -2,12 +2,14 @@ package migration
 
 import (
 	"errors"
+	"time"
 
 	"github.com/spf13/cobra"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/internal/migrations"
+	"github.com/kwilteam/kwil-db/internal/voting"
 )
 
 var (
@@ -48,6 +50,7 @@ func proposeCmd() *cobra.Command {
 				ActivationPeriod: activationPeriod,
 				Duration:         migrationDuration,
 				ChainID:          chainID,
+				Timestamp:        time.Now().String(),
 			}
 			proposalBts, err := proposal.MarshalBinary()
 			if err != nil {
@@ -55,7 +58,7 @@ func proposeCmd() *cobra.Command {
 			}
 
 			// Submit a migration proposal
-			txHash, err := clt.CreateResolution(ctx, proposalBts, migrations.StartMigrationEventType)
+			txHash, err := clt.CreateResolution(ctx, proposalBts, voting.StartMigrationEventType)
 			if err != nil {
 				return display.PrintErr(cmd, err)
 			}

--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -202,9 +202,16 @@ func (genCfg *NodeGenerateConfig) ApplyGenesisParams(genesisCfg *chain.GenesisCo
 	if genCfg.ChainID != "" {
 		genesisCfg.ChainID = genCfg.ChainID
 	}
-	genesisCfg.ConsensusParams.Validator.JoinExpiry = genCfg.JoinExpiry
+
+	if genCfg.JoinExpiry > 0 {
+		genesisCfg.ConsensusParams.Validator.JoinExpiry = genCfg.JoinExpiry
+	}
+
 	genesisCfg.ConsensusParams.WithoutGasCosts = genCfg.WithoutGasCosts
-	genesisCfg.ConsensusParams.Votes.VoteExpiry = genCfg.VoteExpiry
+
+	if genCfg.VoteExpiry > 0 {
+		genesisCfg.ConsensusParams.Votes.VoteExpiry = genCfg.VoteExpiry
+	}
 
 	numAllocs := len(genCfg.Allocs)
 	if !genCfg.WithoutGasCosts { // when gas is enabled, give genesis validators some funds

--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -90,6 +90,10 @@ func RootCmd() *cobra.Command {
 				return fmt.Errorf("failed to initialize private key and genesis: %w", err)
 			}
 
+			if err := genesisConfig.SanityChecks(); err != nil {
+				return fmt.Errorf("genesis configuration failed sanity checks: %w", err)
+			}
+
 			if err := kwildCfg.ConfigureExtensions(genesisConfig); err != nil {
 				return err
 			}

--- a/common/chain/chaincfg.go
+++ b/common/chain/chaincfg.go
@@ -7,6 +7,7 @@ import (
 	"crypto/sha256"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"math/big"
 	"os"
 	"sort"
@@ -163,10 +164,6 @@ func defaultConsensusParams() *ConsensusParams {
 			ABCI: ABCIParams{
 				VoteExtensionsEnableHeight: 0, // disabled, needs coordinated upgrade to enable
 			},
-			Migration: MigrationParams{
-				StartHeight: -1, // not a zero-downtime migration
-				EndHeight:   -1,
-			},
 		},
 		WithoutGasCosts: true,
 	}
@@ -287,4 +284,28 @@ func NewGenesisWithValidator(pubKey []byte) *GenesisConfig {
 		Name:   "validator-0",
 	})
 	return genesisCfg
+}
+
+func (gc *GenesisConfig) SanityChecks() error {
+	// Vote expiry shouldn't be 0
+	if gc.ConsensusParams.Votes.VoteExpiry == 0 {
+		return errors.New("vote expiry should be greater than 0")
+	}
+
+	// MaxVotesPerTx shouldn't be 0
+	if gc.ConsensusParams.Votes.MaxVotesPerTx == 0 {
+		return errors.New("max votes per tx should be greater than 0")
+	}
+
+	// join expiry shouldn't be 0
+	if gc.ConsensusParams.Validator.JoinExpiry == 0 {
+		return errors.New("join expiry should be greater than 0")
+	}
+
+	// Block params
+	if gc.ConsensusParams.Block.MaxBytes == 0 {
+		return errors.New("max bytes should be greater than 0")
+	}
+
+	return nil
 }

--- a/common/common.go
+++ b/common/common.go
@@ -139,12 +139,15 @@ type NetworkParameters struct {
 	VoteExpiry int64
 	// DisabledGasCosts dictates whether gas costs are disabled.
 	DisabledGasCosts bool
-	// InMigration is true if the network is being migrated to a new network.
-	// Once this is set to true, it can never be set to false. If true,
-	// new databases cannot be created, old databases cannot be deleted,
-	// balances cannot be transferred
-	// and the vote store is paused.
-	InMigration bool
+
+	// MigrationStatus determines the status of the migration.
+	// It can be one of the following:
+	// - NoActiveMigration: No active migration is in progress.
+	// - MigrationNotStarted: A migration has been approved but not yet activated.
+	// - MigrationInProgress: A migration is in progress.
+	// - MigrationCompleted: A migration has been completed.
+	MigrationStatus types.MigrationStatus
+
 	// MaxVotesPerTx is the maximum number of votes that can be included in a
 	// single transaction.
 	MaxVotesPerTx int64

--- a/core/rpc/client/admin/jsonrpc/client.go
+++ b/core/rpc/client/admin/jsonrpc/client.go
@@ -150,6 +150,11 @@ func (cl *Client) Status(ctx context.Context) (*adminTypes.Status, error) {
 			PubKey: res.Validator.PubKey,
 			Power:  res.Validator.Power,
 		},
+		Migration: adminTypes.MigrationInfo{
+			Status:      res.Migration.Status.String(),
+			StartHeight: res.Migration.StartHeight,
+			EndHeight:   res.Migration.EndHeight,
+		},
 	}, nil
 }
 

--- a/core/rpc/json/admin/responses.go
+++ b/core/rpc/json/admin/responses.go
@@ -8,9 +8,10 @@ import (
 // type StatusResponse = adminTypes.Status
 
 type StatusResponse struct {
-	Node      *NodeInfo  `json:"node,omitempty"`
-	Sync      *SyncInfo  `json:"sync,omitempty"`
-	Validator *Validator `json:"validator,omitempty"`
+	Node      *NodeInfo             `json:"node,omitempty"`
+	Sync      *SyncInfo             `json:"sync,omitempty"`
+	Validator *Validator            `json:"validator,omitempty"`
+	Migration *types.MigrationState `json:"migration,omitempty"`
 }
 
 type NodeInfo = adminTypes.NodeInfo

--- a/core/types/admin/types.go
+++ b/core/types/admin/types.go
@@ -49,6 +49,7 @@ type Status struct {
 	Node      *NodeInfo      `json:"node"`
 	Sync      *SyncInfo      `json:"sync"`
 	Validator *ValidatorInfo `json:"validator"`
+	Migration MigrationInfo  `json:"migration"`
 }
 
 // PeerInfo describes a connected peer node.
@@ -56,4 +57,10 @@ type PeerInfo struct {
 	NodeInfo   *NodeInfo `json:"node"`
 	Inbound    bool      `json:"inbound"`
 	RemoteAddr string    `json:"remote_addr"`
+}
+
+type MigrationInfo struct {
+	Status      string `json:"status"`
+	StartHeight int64  `json:"start_height"`
+	EndHeight   int64  `json:"end_height"`
 }

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -1,7 +1,6 @@
 package types
 
 import (
-	"encoding/json"
 	"fmt"
 	"math/big"
 )
@@ -89,15 +88,44 @@ type Migration struct {
 	ActivationPeriod int64  `json:"activation_height"`  // ActivationPeriod is the amount of blocks before the migration is activated.
 	Duration         int64  `json:"migration_duration"` // MigrationDuration is the duration of the migration process starting from the ActivationHeight
 	ChainID          string `json:"chain_id"`           // ChainID of the new network
+	Timestamp        string `json:"timestamp"`          // Timestamp when the migration was proposed
+}
+
+type MigrationStatus int
+
+const (
+	NoActiveMigration MigrationStatus = iota
+	MigrationNotStarted
+	MigrationInProgress
+	MigrationCompleted
+)
+
+func (status *MigrationStatus) String() string {
+	switch *status {
+	case NoActiveMigration:
+		return "NoActiveMigration"
+	case MigrationNotStarted:
+		return "MigrationNotStarted"
+	case MigrationInProgress:
+		return "MigrationInProgress"
+	case MigrationCompleted:
+		return "MigrationCompleted"
+	default:
+		return "Unknown"
+	}
+}
+
+type MigrationState struct {
+	Status      MigrationStatus `json:"status"`       // Status is the current status of the migration
+	StartHeight int64           `json:"start_height"` // StartHeight is the block height at which the migration started
+	EndHeight   int64           `json:"end_height"`   // EndHeight is the block height at which the migration ends
 }
 
 // MigrationMetadata holds metadata about a migration, informing
 // consumers of what information the current node has available
 // for the migration.
 type MigrationMetadata struct {
-	InMigration      bool            `json:"in_migration"`      // InMigration is true if the node is in migration state i.e current height is between StartHeight and EndHeight
-	StartHeight      int64           `json:"start_height"`      // StartHeight is the block height at which the migration starts
-	EndHeight        int64           `json:"end_height"`        // EndHeight is the block height at which the migration ends
-	GenesisConfig    json.RawMessage `json:"genesis_config"`    // GenesisConfig is the genesis file data
-	SnapshotMetadata json.RawMessage `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
+	MigrationState   MigrationState `json:"migration_state"`   // MigrationState is the current state of the migration
+	GenesisConfig    []byte         `json:"genesis_config"`    // GenesisConfig is the genesis file data
+	SnapshotMetadata []byte         `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
 }

--- a/internal/abci/cometbft/genesis.go
+++ b/internal/abci/cometbft/genesis.go
@@ -6,6 +6,7 @@ import (
 	cmtproto "github.com/cometbft/cometbft/proto/tendermint/types"
 	cmtTypes "github.com/cometbft/cometbft/types"
 
+	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/common/chain"
 	"github.com/kwilteam/kwil-db/extensions/consensus"
 )
@@ -47,6 +48,39 @@ func ExtractConsensusParams(cp *chain.BaseConsensusParams) *cmtTypes.ConsensusPa
 		ABCI: cmtTypes.ABCIParams{
 			VoteExtensionsEnableHeight: cp.ABCI.VoteExtensionsEnableHeight,
 		},
+	}
+}
+
+// MergeConsensusParams merges cometbft's ConsensusParams with kwild's NetworkParameters
+// to create a unified representation of the chain's consensus parameters.
+func MergeConsensusParams(cometbftParams *cmtTypes.ConsensusParams, abciParams *common.NetworkParameters) *chain.ConsensusParams {
+	return &chain.ConsensusParams{
+		BaseConsensusParams: chain.BaseConsensusParams{
+			Block: chain.BlockParams{
+				MaxBytes: abciParams.MaxBlockSize,
+				MaxGas:   cometbftParams.Block.MaxGas,
+			},
+			Evidence: chain.EvidenceParams{
+				MaxAgeNumBlocks: cometbftParams.Evidence.MaxAgeNumBlocks,
+				MaxAgeDuration:  cometbftParams.Evidence.MaxAgeDuration,
+				MaxBytes:        cometbftParams.Evidence.MaxBytes,
+			},
+			Version: chain.VersionParams{
+				App: cometbftParams.Version.App,
+			},
+			Validator: chain.ValidatorParams{
+				PubKeyTypes: cometbftParams.Validator.PubKeyTypes,
+				JoinExpiry:  abciParams.JoinExpiry,
+			},
+			Votes: chain.VoteParams{
+				VoteExpiry:    abciParams.VoteExpiry,
+				MaxVotesPerTx: abciParams.MaxVotesPerTx,
+			},
+			ABCI: chain.ABCIParams{
+				VoteExtensionsEnableHeight: cometbftParams.ABCI.VoteExtensionsEnableHeight,
+			},
+		},
+		WithoutGasCosts: abciParams.DisabledGasCosts,
 	}
 }
 

--- a/internal/abci/cometbft/node.go
+++ b/internal/abci/cometbft/node.go
@@ -17,6 +17,7 @@ import (
 	cometNodes "github.com/cometbft/cometbft/node"
 	"github.com/cometbft/cometbft/p2p"
 	"github.com/cometbft/cometbft/proxy"
+	cometLocal "github.com/cometbft/cometbft/rpc/client/local"
 	"github.com/cometbft/cometbft/types"
 
 	"go.uber.org/zap"
@@ -252,4 +253,14 @@ func PubkeyToAddr(pubkey []byte) (string, error) {
 	}
 	publicKey := cometEd25519.PubKey(pubkey)
 	return publicKey.Address().String(), nil
+}
+
+func (n *CometBftNode) ConsensusParams(ctx context.Context, height *int64) *types.ConsensusParams {
+	clt := cometLocal.New(n.Node)
+	res, err := clt.ConsensusParams(ctx, height)
+	if err != nil {
+		n.Node.Logger.Error("failed to get consensus params", "err", err)
+		return nil
+	}
+	return &res.ConsensusParams
 }

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -94,6 +94,6 @@ type WhitelistPeersModule interface {
 type MigratorModule interface {
 	NotifyHeight(ctx context.Context, block *common.BlockContext, db migrations.Database) error
 	StoreChangesets(height int64, changes <-chan any)
-	InMigration(height int64) bool
+	MigrationStatus() types.MigrationStatus
 	PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error
 }

--- a/internal/abci/meta/meta_test.go
+++ b/internal/abci/meta/meta_test.go
@@ -63,7 +63,7 @@ func Test_NetworkParams(t *testing.T) {
 	param2.MaxBlockSize = 2000
 	param2.JoinExpiry = 200
 	param2.DisabledGasCosts = false
-	param2.InMigration = true
+	param2.MigrationStatus = 1
 
 	err = meta.StoreDiff(ctx, tx, param, param2)
 	require.NoError(t, err)

--- a/internal/migrations/changeset_listener.go
+++ b/internal/migrations/changeset_listener.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kwilteam/kwil-db/core/client"
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/extensions/listeners"
+	"github.com/kwilteam/kwil-db/internal/voting"
 )
 
 // Changeset Extension polls the changesets from the old chain  during migration.
@@ -166,7 +167,7 @@ func (ml *migrationListener) RetrieveChangesets(ctx context.Context) error {
 				ml.logger.Info("broadcasting changeset migration event", "height", ml.currentHeight, "chunk", chunkIdx, "size", len(cs))
 
 				// Broadcast the changeset migration event to the event store for voting
-				err = ml.eventStore.Broadcast(ctx, ChangesetMigrationEventType, csEvt)
+				err = ml.eventStore.Broadcast(ctx, voting.ChangesetMigrationEventType, csEvt)
 				if err != nil {
 					errChan <- fmt.Errorf("failed to broadcast changeset migration event: %w", err)
 					return

--- a/internal/txapp/interfaces.go
+++ b/internal/txapp/interfaces.go
@@ -56,9 +56,9 @@ var (
 	createResolution                 = voting.CreateResolution
 	approveResolution                = voting.ApproveResolution
 	getVoterPower                    = voting.GetValidatorPower
-	resolutionExists                 = voting.ResolutionExists
-	resolutionByID                   = voting.GetResolutionInfo
-	deleteResolution                 = voting.DeleteResolution
+	// resolutionExists                 = voting.ResolutionExists
+	resolutionByID   = voting.GetResolutionInfo
+	deleteResolution = voting.DeleteResolution
 
 	// account functions
 	getAccount = accounts.GetAccount

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -232,8 +232,9 @@ func (d *deployDatasetRoute) Price(ctx context.Context, app *common.App, tx *tra
 }
 
 func (d *deployDatasetRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot deploy dataset during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot deploy dataset during migration")
 	}
 
 	schemaPayload := &transactions.Schema{}
@@ -280,8 +281,9 @@ func (d *dropDatasetRoute) Price(ctx context.Context, app *common.App, tx *trans
 }
 
 func (d *dropDatasetRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot drop dataset during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot drop dataset during migration")
 	}
 
 	drop := &transactions.DropSchema{}
@@ -382,8 +384,9 @@ func (d *transferRoute) Price(ctx context.Context, app *common.App, tx *transact
 }
 
 func (d *transferRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot transfer during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot transfer during migration")
 	}
 
 	transferBody := &transactions.Transfer{}
@@ -437,8 +440,9 @@ func (d *validatorJoinRoute) Price(ctx context.Context, app *common.App, tx *tra
 }
 
 func (d *validatorJoinRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot join validator during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot join validator during migration")
 	}
 
 	join := &transactions.ValidatorJoin{}
@@ -509,8 +513,9 @@ func (d *validatorApproveRoute) Price(ctx context.Context, app *common.App, tx *
 }
 
 func (d *validatorApproveRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot approve validator join during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot approve validator join during migration")
 	}
 
 	approve := &transactions.ValidatorApprove{}
@@ -574,8 +579,9 @@ func (d *validatorRemoveRoute) Price(ctx context.Context, app *common.App, tx *t
 }
 
 func (d *validatorRemoveRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot remove validator during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot remove validator during migration")
 	}
 
 	remove := &transactions.ValidatorRemove{}
@@ -645,8 +651,9 @@ func (d *validatorLeaveRoute) Price(ctx context.Context, app *common.App, tx *tr
 }
 
 func (d *validatorLeaveRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot leave validator during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot leave validator during migration")
 	}
 	return 0, nil // no payload to decode or validate for this route
 }
@@ -689,8 +696,9 @@ func (d *validatorVoteIDsRoute) Price(ctx context.Context, app *common.App, tx *
 }
 
 func (d *validatorVoteIDsRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot vote during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot vote during migration")
 	}
 	return 0, nil
 }
@@ -769,9 +777,9 @@ func (d *validatorVoteBodiesRoute) Price(ctx context.Context, _ *common.App, tx 
 }
 
 func (d *validatorVoteBodiesRoute) PreTx(ctx *common.TxContext, _ *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot vote during migration")
-
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot vote during migration")
 	}
 
 	// Only proposer can issue a VoteBody transaction.
@@ -859,7 +867,8 @@ func (d *createResolutionRoute) Price(ctx context.Context, app *common.App, tx *
 }
 
 func (d *createResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
 		return transactions.CodeNetworkInMigration, errors.New("cannot create resolution during migration")
 	}
 
@@ -867,6 +876,12 @@ func (d *createResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service
 	err := res.UnmarshalBinary(tx.Body.Payload)
 	if err != nil {
 		return transactions.CodeEncodingError, err
+	}
+
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationNotStarted {
+		if res.Resolution.Type == voting.StartMigrationEventType {
+			return transactions.CodeNetworkInMigration, errors.New("migration is about to start, cannot accept new migration proposals")
+		}
 	}
 
 	// Check if its a valid event type
@@ -922,8 +937,9 @@ func (d *approveResolutionRoute) Price(ctx context.Context, app *common.App, tx 
 }
 
 func (d *approveResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, errors.New("cannot approve a resolution during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, fmt.Errorf("cannot approve a resolution during migration")
 	}
 
 	res := &transactions.ApproveResolution{}
@@ -948,12 +964,17 @@ func (d *approveResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx
 
 	// Check if the resolution exists and is still pending
 	// You can only vote on a resolution that already exists
-	exists, err := resolutionExists(ctx.Ctx, app.DB, d.resolutionID)
+	resolution, err := resolutionByID(ctx.Ctx, app.DB, d.resolutionID)
 	if err != nil {
 		return transactions.CodeUnknownError, err
 	}
-	if !exists {
+	if resolution == nil {
 		return transactions.CodeUnknownError, fmt.Errorf("resolution with ID %s does not exist", d.resolutionID)
+	}
+
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationNotStarted &&
+		resolution.Type == voting.StartMigrationEventType {
+		return transactions.CodeNetworkInMigration, fmt.Errorf("migration is about to start, cannot accept new migration proposals")
 	}
 
 	// vote on the resolution
@@ -980,8 +1001,9 @@ func (d *deleteResolutionRoute) Price(ctx context.Context, app *common.App, tx *
 }
 
 func (d *deleteResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *transactions.Transaction) (transactions.TxCode, error) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
-		return transactions.CodeNetworkInMigration, errors.New("cannot vote during migration")
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress ||
+		ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationCompleted {
+		return transactions.CodeNetworkInMigration, errors.New("cannot delete resolution during migration")
 	}
 
 	res := &transactions.DeleteResolution{}

--- a/internal/txapp/txapp.go
+++ b/internal/txapp/txapp.go
@@ -675,8 +675,8 @@ func (r *TxApp) ProposerTxs(ctx context.Context, db sql.DB, txNonce uint64, maxT
 		})
 	}
 
-	if len(finalEvents) == 0 {
-		r.service.Logger.Debug("found proposer events to propose, but cannot fit them in a block",
+	if len(finalEvents) == 0 && len(ids) > 0 {
+		r.service.Logger.Warn("found proposer events to propose, but cannot fit them in a block",
 			log.Int("height", block.Height),
 			log.Int("maxTxsSize", maxTxsSize),
 			log.Int("emptyVoteBodyTxSize", r.emptyVoteBodyTxSize),
@@ -782,7 +782,7 @@ func (s *Spend) ApplySpend(ctx context.Context, db sql.DB) error {
 // recordSpend records a spend occurred during the block execution.
 // This only records spends during migrations.
 func (r *TxApp) recordSpend(ctx *common.TxContext, spend *Spend) {
-	if ctx.BlockContext.ChainContext.NetworkParameters.InMigration {
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationInProgress {
 		r.spends = append(r.spends, spend)
 	}
 }

--- a/internal/voting/sql.go
+++ b/internal/voting/sql.go
@@ -113,6 +113,11 @@ const (
 	// deleteResolution deletes a resolution
 	deleteResolution = `DELETE FROM ` + votingSchemaName + `.resolutions WHERE id = $1;`
 
+	deleteResolutionsByTypeSQL = `DELETE FROM ` + votingSchemaName + `.resolutions WHERE type = ANY($1);`
+
+	// Subtracts the start height from the expiration height of all resolutions.
+	readjustExpirationsSQL = `UPDATE ` + votingSchemaName + `.resolutions SET expiration = expiration - $1;`
+
 	// createResolutionType creates a resolution type
 	createResolutionType = `INSERT INTO ` + votingSchemaName + `.resolution_types (id, name) VALUES ($1, $2)
 		ON CONFLICT(id) DO NOTHING;`
@@ -206,4 +211,15 @@ const (
 // upgrades V1 -> V2
 const (
 	dropExtraVoteID = `ALTER TABLE ` + votingSchemaName + `.resolutions DROP COLUMN extra_vote_id;`
+)
+
+// registered resolution types
+const (
+	// ummm.. import cycle issues, so moving them here from migrations pkg.
+
+	// "migration" is the event type used for
+	StartMigrationEventType = "migration"
+
+	// "changeset_migration" is the event type used for replication of changesets from old chain to new chain during migration.
+	ChangesetMigrationEventType = "changeset_migration"
 )

--- a/internal/voting/voting.go
+++ b/internal/voting/voting.go
@@ -607,3 +607,18 @@ func ResolutionStatus(ctx context.Context, db sql.DB, resolution *resolutions.Re
 
 	return resolution.ExpirationHeight, board, approvals, nil
 }
+
+func DeleteResolutionsByType(ctx context.Context, db sql.Executor, resTypes []string) error {
+	uuids := make([]*types.UUID, len(resTypes))
+	for i, resType := range resTypes {
+		uuids[i] = types.NewUUIDV5([]byte(resType))
+	}
+	_, err := db.Execute(ctx, deleteResolutionsByTypeSQL, types.UUIDArray(uuids).Bytes())
+	return err
+}
+
+func ReadjustExpirations(ctx context.Context, db sql.Executor, startHeight int64) error {
+	// Subtracts the start height from the expiration height of all resolutions
+	_, err := db.Execute(ctx, readjustExpirationsSQL, startHeight)
+	return err
+}

--- a/test/driver/operator/client_driver.go
+++ b/test/driver/operator/client_driver.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/kwilteam/kwil-db/core/adminclient"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 	"github.com/kwilteam/kwil-db/internal/migrations"
+	"github.com/kwilteam/kwil-db/internal/voting"
 	"github.com/kwilteam/kwil-db/test/driver"
 )
 
@@ -95,13 +97,14 @@ func (a *AdminClientDriver) SubmitMigrationProposal(ctx context.Context, activat
 		ActivationPeriod: activationHeight,
 		Duration:         dur,
 		ChainID:          chainID,
+		Timestamp:        time.Now().String(),
 	}
 	proposalBts, err := res.MarshalBinary()
 	if err != nil {
 		return nil, err
 	}
 
-	return a.Client.CreateResolution(ctx, proposalBts, migrations.StartMigrationEventType)
+	return a.Client.CreateResolution(ctx, proposalBts, voting.StartMigrationEventType)
 }
 
 func (a *AdminClientDriver) ApproveMigration(ctx context.Context, migrationResolutionID *types.UUID) ([]byte, error) {

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -1000,7 +1000,7 @@ func TestLongRunningNetworkMigrations(t *testing.T) {
 			1. This checks if the database exists on the new node
 			2. Verify if the user and posts are synced to the new node
 		*/
-		time.Sleep(time.Second * 20) // This is for the changesets to be synced and voted and resolved in the new network
+		time.Sleep(time.Second * 30) // This is for the changesets to be synced and voted and resolved in the new network
 
 		newNodeDriver := helper.GetMigrationUserDriver(ctx, "new-node0", "jsonrpc", nil)
 		specifications.DatabaseVerifySpecification(ctx, t, newNodeDriver, true)
@@ -1008,7 +1008,7 @@ func TestLongRunningNetworkMigrations(t *testing.T) {
 		// The user and posts should be synced to the new node through the changeset_listener extension
 		// Below specification checks if the user and posts are synced to the new node correctly
 		expectPosts := 1
-		specifications.ExecuteDBRecordsVerifySpecification(ctx, t, newNodeDriver, expectPosts)
+		specifications.ExecuteDBRecordsVerifySpecificationEventually(ctx, t, newNodeDriver, expectPosts)
 
 		// Bring up node3-1 using statesync
 		helper.EnableStatesync(ctx, newDir, "new-node3", []string{"new-node0", "new-node1", "new-node2"})
@@ -1018,9 +1018,7 @@ func TestLongRunningNetworkMigrations(t *testing.T) {
 
 		specifications.DatabaseVerifySpecificationEventually(ctx, t, newNode3Driver)
 
-		time.Sleep(30 * time.Second) // need time to catch up on changesets
-
-		specifications.ExecuteDBRecordsVerifySpecification(ctx, t, newNode3Driver, expectPosts)
+		specifications.ExecuteDBRecordsVerifySpecificationEventually(ctx, t, newNode3Driver, expectPosts)
 
 		t.Logf("Long Running Network Migration Test: Completed Successfully")
 	})

--- a/test/specifications/migration.go
+++ b/test/specifications/migration.go
@@ -25,7 +25,7 @@ func SubmitMigrationProposal(ctx context.Context, t *testing.T, netops Migration
 	t.Log("Executing migration trigger specification")
 
 	// Trigger migration"
-	txHash, err := netops.SubmitMigrationProposal(ctx, big.NewInt(5), big.NewInt(200), chainID)
+	txHash, err := netops.SubmitMigrationProposal(ctx, big.NewInt(1), big.NewInt(200), chainID)
 	require.NoError(t, err)
 
 	// Ensure that the Tx is mined.
@@ -76,7 +76,7 @@ func InstallGenesisState(ctx context.Context, t *testing.T, netops MigrationOpsD
 	require.Eventually(t, func() bool {
 		metadata, err = netops.GenesisState(ctx)
 		require.NoError(t, err)
-		return metadata.InMigration
+		return metadata.MigrationState.Status == types.MigrationInProgress
 	}, 6*time.Second, 500*time.Millisecond)
 
 	// Verify genesis state


### PR DESCRIPTION
We attempted a zdt migration and ran into some issues.  A few of these affect regular stop-and-start migrations, so listing here to make sure they are addressed:

- [x] migration type resolutions almost certainly should be removed in either type of migration (zdt or offline)
- [x] on the new network, another migration should not be allowed to start before the previous migration is completed.
- [x] resolution expirations have an expiry height column that is incorrect
- [x] because the validator set can change, pending resolution can suddenly become approved/finalized on the first block (conversely, some resolutions may actually "lose" their approving validators, which could be a non-issue)
- [x] I started the one node of the new network the first time with an empty `migrate_from`, so it didn't start the migration listener, which is expected, however, genesis.json had a `"migration"` so the node just sat there.  Should / can we shut it down instead?  This is a non-workable config.
- [x] The `migrate propose` command wrote out a `genesis.json` with `"without_gas_costs": true`, but the original network had `"without_gas_costs": false`.  What other flags are being reset to defaults?
- [x] The `migrate status` and `migrate list` command only pertain to pending (not yet approved) migrations. Once they are approved, there is no way to determine the status of a migration.  It could be awaiting it's activation/start height, or it could be in migration and generating/transmitting changesets, or it could have reached end and halted the chain.  This is begin documented behavior, but surprising.
- [x] `kwil-admin node status` should probably have a field(s) to indicate if the network is in a migration, and another if it has halted, perhaps even list migration status.
- [x] When the nodes on the old network reached the end height, they both correctly halted (`NETWORK HALTED: migration to chain "staging-migrated0" has completed`), but they did not shutdown.  This actually made some sense to me as (read-only) RPCs should still be usable and maybe other uses.  However, after stopping one, I could not start it again.  (`failed to build comet node: failed to create CometBFT node: error during handshake: error on replay: failed to notify migrator of changeset: NETWORK HALTED: migration to chain "staging-migrated0" has completed`).  I think the consensus failure prior to stopping actually should have shut it down.
- [x] Should be able to resubmit migration proposals with the same migration params after expiry. Add, timestamp to make the migration proposals unique. 
- [ ] Optimize changesets listener to maybe not submit empty resolutions to the vote store for blocks that have no changesets? This is to avoid heavy load on the system due to the vote store consensus mechanism for empty resolutions.