### PR TITLE
abci,consensus: include MaxVotesPerTx in abci db and param updates

### DIFF
--- a/extensions/consensus/consensus.go
+++ b/extensions/consensus/consensus.go
@@ -215,14 +215,24 @@ func MergeConsensusUpdates(params, update *ParamUpdates) {
 				params.Validator = new(chain.ValidatorParams)
 			}
 			params.Validator.PubKeyTypes = slices.Clone(update.Validator.PubKeyTypes)
+		}
+		if update.Validator.JoinExpiry != 0 { // a kwil param
+			if params.Validator == nil {
+				params.Validator = new(chain.ValidatorParams)
+			}
 			params.Validator.JoinExpiry = update.Validator.JoinExpiry
 		}
 	}
-	if update.Votes != nil {
+	if update.Votes != nil { // entirely kwil params
 		if params.Votes == nil {
 			params.Votes = new(chain.VoteParams)
 		}
-		params.Votes.VoteExpiry = update.Votes.VoteExpiry
+		if ve := update.Votes.VoteExpiry; ve != 0 {
+			params.Votes.VoteExpiry = ve
+		}
+		if mv := update.Votes.MaxVotesPerTx; mv != 0 {
+			params.Votes.MaxVotesPerTx = mv
+		}
 	}
 	if update.Version != nil {
 		if update.Version.App > 0 {

--- a/internal/abci/utils.go
+++ b/internal/abci/utils.go
@@ -70,6 +70,9 @@ func updateConsensusParams(p *chain.ConsensusParams, up *consensus.ParamUpdates)
 		if exp := up.Votes.VoteExpiry; exp != 0 {
 			p.Votes.VoteExpiry = exp
 		}
+		if mv := up.Votes.MaxVotesPerTx; mv != 0 {
+			p.Votes.MaxVotesPerTx = mv
+		}
 	}
 	if up.ABCI != nil {
 		// Disabling this after it was enabled is impossible under cometbft


### PR DESCRIPTION
Updates to the recently added `MaxVotesPerTx` consensus parameter (kwil-specific, not cometbft) was omitted from the ABCI DB.  This updates ABCI and the param merge helper function.