### PR TITLE
test: fix generic result unmarshalling

### DIFF
--- a/cmd/common/display/format.go
+++ b/cmd/common/display/format.go
@@ -68,7 +68,10 @@ func (e *emptyResult) MarshalText() ([]byte, error) {
 }
 
 func (e *emptyResult) MarshalJSON() ([]byte, error) {
-	return []byte(`""`), nil
+	// an empty string will fail to unmarshal for all result types. JSON null
+	// (not a string or any type at all) is better, but unmarshalling should be
+	// skipped entirely if the error field of wrappedMsg is set
+	return []byte(`null`), nil
 }
 
 // MsgFormatter is an interface that wraps the MarshalText and MarshalJSON

--- a/cmd/common/display/format_test.go
+++ b/cmd/common/display/format_test.go
@@ -65,7 +65,7 @@ func Example_wrappedMsg_json_withError() {
 	prettyPrint(msg, "json", os.Stdout, os.Stderr)
 	// Output:
 	// {
-	//   "result": "",
+	//   "result": null,
 	//   "error": "an error"
 	// }
 }

--- a/cmd/common/display/message_test.go
+++ b/cmd/common/display/message_test.go
@@ -75,7 +75,7 @@ func ExampleRespTxHash_json_withError() {
 	prettyPrint(msg, "json", os.Stdout, os.Stderr)
 	// Output:
 	// {
-	//   "result": "",
+	//   "result": null,
 	//   "error": "an error"
 	// }
 }


### PR DESCRIPTION
This fixes an error that has been logged on CI for a while, but not actually breaking the test outcomes.

Unmarshalling into a generic struct fails if the typed result field is meant to be unset when an error field is set.

`{"level":"error","ts":1725487903.0891304,"caller":"driver/cli_driver.go:436","msg":"bad cmd output","error":"json: cannot unmarshal string into Go struct field cliResponse[github.com/kwilteam/kwil-db/test/driver.respTxQuery].result of type driver.respTxQuery","output":"{\n  \"result\": \"\",\n  \"error\": \"error querying transaction: not found\\njsonrpc.Error: code = -202, message = transaction not found, data = null\\nerr code = -202, msg = transaction not found\"\n}\n","goversion":"go1.23.0","stacktrace":"github.com/kwilteam/kwil-db/test/driver.mustRun[...] ...}`

A solution is to use `json.RawMessage` for the `Result` field when unmarshalling. This also changes the cmd's `(*emptyResult).MarshalJSON` method to use `null` instead of `""`.  This also avoids the issue in most cases, but the test driver should be more robust and delay unmarshalling of result field until the emptiness of the error field is ensured.