### PR TITLE
deps (1/2): update go.mod core deps, next is parse

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/jackc/pglogrepl v0.0.0-20240307033717-828fbfe908e9
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/jpillora/backoff v1.0.0
-	github.com/kwilteam/kwil-db/core v0.2.0
+	github.com/kwilteam/kwil-db/core v0.2.1-0.20240909192711-653711416339
 	github.com/kwilteam/kwil-db/parse v0.2.0-beta.1
 	github.com/kwilteam/kwil-extensions v0.0.0-20230727040522-1cfd930226b7
 	github.com/manifoldco/promptui v0.9.0

--- a/parse/go.mod
+++ b/parse/go.mod
@@ -7,7 +7,7 @@ replace github.com/kwilteam/kwil-db/core => ../core
 require (
 	github.com/antlr4-go/antlr/v4 v4.13.0
 	github.com/google/go-cmp v0.6.0
-	github.com/kwilteam/kwil-db/core v0.2.0
+	github.com/kwilteam/kwil-db/core v0.2.1-0.20240909192711-653711416339
 	github.com/pganalyze/pg_query_go/v5 v5.1.0
 	github.com/stretchr/testify v1.9.0
 )

--- a/test/go.mod
+++ b/test/go.mod
@@ -16,7 +16,7 @@ require (
 	github.com/drhodes/golorem v0.0.0-20220328165741-da82e5b29246
 	github.com/ethereum/go-ethereum v1.14.8
 	github.com/kwilteam/kwil-db v0.7.2
-	github.com/kwilteam/kwil-db/core v0.2.0
+	github.com/kwilteam/kwil-db/core v0.2.1-0.20240909192711-653711416339
 	github.com/kwilteam/kwil-db/parse v0.2.0-beta.1
 	github.com/stretchr/testify v1.9.0
 	github.com/testcontainers/testcontainers-go v0.31.0


### PR DESCRIPTION
We aren't branching or removing `replace` statements for the `v0.9.0-beta` release, but to assist custom builds, this updates the `core` entries in each go.mod with a *pseudo-version*.  This can also be done manually in the consuming project, but this provides the hint to get a non-broken build.

After this is merged, one more PR with updates for `parse` should follow.

As a reminder, with the `replace` statements remaining in the go.mod, files: (1) it is an error if trying to `go install` or `go run` one of the `cmd/...` apps, and (2) any `replace` statements get **ignored** if you are importing one of our packages like `core` or the main  module to build a custom app, like `tsn`.  Hence, `replace` statements will be removed for final/candidate release.