### PR TITLE
abci: handle misbehavior more gracefully

### DIFF
--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -504,10 +504,14 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 		logger.Info("punish validator", zap.String("addr", addr))
 		// FORKSITE: could alter punishment system (consider misbehavior Type)
 
-		// This is why we need the addr=>pubkey map. Why, comet, why?
+		// CometBFT gives the address, not public key, so we have to remember them.
 		pubkey, ok := a.validatorAddressToPubKey[addr]
 		if !ok {
-			return nil, fmt.Errorf("unknown validator address %v", addr)
+			// It is possible or likely that a misbehaving validator will
+			// misbehave in consecutive blocks, so it should not be an error
+			// here since it could merely be a subsequent misbehavior if we have
+			// removed them from our app's map.
+			continue
 		}
 
 		const punishDelta = 1
@@ -524,6 +528,8 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 		// only if the block has no transactions.
 		return nil, fmt.Errorf("failed to find proposer pubkey corresponding to address %v", addr)
 	}
+	// Note that in the !ok case, empty Txs is required, and the proposerPubKey
+	// may be empty!
 
 	res := &abciTypes.ResponseFinalizeBlock{}
 


### PR DESCRIPTION
This is already on `preview` to resolve a consensus failure resulting in a second block with a misbehavior report for a certain validator.

```
Do not have consensus failure if a misbehavior is reported to ABCI for a validator that has already been forgotten (removed).
```