### PR TITLE
added latest snapshot height querying

### DIFF
--- a/internal/statesync/snapshot.go
+++ b/internal/statesync/snapshot.go
@@ -41,3 +41,11 @@ func loadSnapshot(headerFile string) (*Snapshot, error) {
 	}
 	return &snapshot, nil
 }
+
+func (s *Snapshot) MarshalBinary() ([]byte, error) {
+	return json.Marshal(s)
+}
+
+func (s *Snapshot) UnmarshalBinary(data []byte) error {
+	return json.Unmarshal(data, s)
+}


### PR DESCRIPTION
As discussed earlier, we hit a sync issue with TSN testnet due to Comet trying to verify too many block headers. Since our snapshot providers are trusted anyways, this isn't necessary. I added the ability to query ABCI for the latest snapshot from a node, so that we can avoid this.

This is untested, but I just wanted to get something for it because I need to get going and I didn't want to lose my train of thought on it. There is a TODO in there asking about why we don't return errors in a certain part of ABCI (CC @charithabandi you might be able to answer this for me)
