### PR TITLE
Optimize the migration process on the new network

### DIFF
--- a/internal/migrations/changeset_listener.go
+++ b/internal/migrations/changeset_listener.go
@@ -245,7 +245,7 @@ func (ml *migrationListener) addChangesetEvent(ctx context.Context, height uint6
 
 	if numChunks == 0 && height == ml.config.EndHeight {
 		// Add the changeset migration event for the end height even if it is empty
-		if err := ml.addEvent(height, prevHeight, uint64(totalChunks), 0, nil); err != nil {
+		if err := ml.addEvent(height, prevHeight, 1, 0, nil); err != nil {
 			return err
 		}
 	} else {

--- a/internal/migrations/changesets.go
+++ b/internal/migrations/changesets.go
@@ -23,7 +23,7 @@ var (
 	ErrNoMoreChunksToRead = errors.New("no more chunks to read")
 	ErrChangesetNotFound  = errors.New("changeset not found")
 
-	migrationCompleted = "migration completed. `migration` section of `genesis.json` and `migrate_from` config in `config.toml` is no longer relevant and should be removed"
+	migrationCompleted = "Migration completed. The migration section in genesis.json and the migrate_from configuration in config.toml are no longer relevant and should be removed."
 )
 
 func init() {

--- a/internal/migrations/changesets.go
+++ b/internal/migrations/changesets.go
@@ -58,6 +58,9 @@ type changesetMigration struct {
 
 	// Changeset is the serialized changeset chunk.
 	Changeset []byte
+
+	// PreviousBlock is the last block with non empty changesets.
+	PreviousBlock uint64
 }
 
 // MarshalBinary marshals the ChangesetMigration into a binary format.
@@ -119,7 +122,6 @@ func applyChangesets(ctx context.Context, app *common.App, blockCtx *common.Bloc
 	}
 	defer tx.Rollback(ctx)
 
-	var currentHeight int64
 	// get the last changeset height applied
 	lastChangeset, err := getLastChangeset(ctx, tx)
 	if err != nil {
@@ -132,24 +134,24 @@ func applyChangesets(ctx context.Context, app *common.App, blockCtx *common.Bloc
 		return nil // migration completed
 	}
 
-	currentHeight = lastChangeset + 1
-	if currentHeight == 0 {
-		currentHeight = startHeight
+	if lastChangeset == -1 {
+		lastChangeset = 0 // set the last changeset to 0, because migration declaration doesn't accept int64 (-1)
 	}
 
-	// Apply the changesets in the order of block heights
 	for {
-		// If the current height is greater than the migration end height, break
-		if currentHeight >= endHeight {
-			blockCtx.ChainContext.MigrationParams = nil
-			app.Service.Logger.Info(migrationCompleted, log.Int("height", currentHeight))
+		// get the metadata for the earliest height that has not been applied
+		height, prevHeight, totalChunks, chunksReceived, err := getEarliestChangesetMetadata(ctx, tx)
+		if err != nil {
+			return err
+		}
+
+		if height == -1 { // no changesets to apply
 			break
 		}
 
-		// Check if all chunks have been received for the current height, if not, break
-		totalChunks, chunksReceived, err := getChangesetMetadata(ctx, tx, currentHeight)
-		if err != nil {
-			return err
+		if height != startHeight && prevHeight != lastChangeset {
+			// If the previous changeset is not applied, break
+			break
 		}
 
 		// If no chunks have been received or all chunks have not been received, break
@@ -157,24 +159,29 @@ func applyChangesets(ctx context.Context, app *common.App, blockCtx *common.Bloc
 			break
 		}
 
-		// Apply the changeset
-		if err = applyChangeset(ctx, tx, currentHeight, totalChunks); err != nil {
+		// Apply the changeset if all chunks have been received
+		if err = applyChangeset(ctx, tx, height, totalChunks); err != nil {
 			return err
 		}
 
-		app.Service.Logger.Info("Applied changesets", log.Int("height", currentHeight))
+		app.Service.Logger.Info("Applied changesets", log.Int("height", height))
 
 		// Delete the changeset after it has been applied
-		if err = deleteChangesets(ctx, tx, currentHeight); err != nil {
+		if err = deleteChangesets(ctx, tx, height); err != nil {
 			return err
 		}
 
 		// Increment the last changeset
-		if err = setLastChangeset(ctx, tx, currentHeight); err != nil {
+		if err = setLastChangeset(ctx, tx, height); err != nil {
 			return err
 		}
+		lastChangeset = height
 
-		currentHeight += 1 // move to the next height
+		if height == endHeight {
+			blockCtx.ChainContext.MigrationParams = nil
+			app.Service.Logger.Info(migrationCompleted, log.Int("height", height))
+			break
+		}
 	}
 
 	return tx.Commit(ctx)
@@ -293,7 +300,7 @@ func (cm *changesetMigration) insertChangeset(ctx context.Context, db sql.TxMake
 	defer tx.Rollback(ctx)
 
 	//  Check if the changeset metadata entry exists, if not, create it
-	if err := insertChangesetMetadata(ctx, tx, int64(cm.Height), int64(cm.TotalChunks)); err != nil {
+	if err := insertChangesetMetadata(ctx, tx, int64(cm.Height), int64(cm.TotalChunks), int64(cm.PreviousBlock)); err != nil {
 		return err
 	}
 

--- a/internal/migrations/migrator.go
+++ b/internal/migrations/migrator.go
@@ -639,7 +639,7 @@ func (cw *chunkWriter) SaveMetadata() error {
 	filename := formatChangesetMetadataFilename(cw.dir, cw.height)
 	metadata := &ChangesetMetadata{
 		Height:     cw.height,
-		Chunks:     cw.chunkIdx + 1, // + 1 ?
+		Chunks:     cw.chunkIdx + 1,
 		ChunkSizes: cw.chunkSizes,
 	}
 	return metadata.saveAs(filename)
@@ -686,7 +686,7 @@ func (m *Migrator) StoreChangesets(height int64, changes <-chan any) {
 	bs := &BlockSpends{
 		Spends: m.accounts.GetBlockSpends(),
 	}
-	if bs.Spends != nil {
+	if len(bs.Spends) > 0 {
 		if pg.StreamElement(chunkWriter, bs); err != nil {
 			m.errChan <- err
 			return

--- a/internal/migrations/sql.go
+++ b/internal/migrations/sql.go
@@ -50,8 +50,8 @@ var (
 	// Primary key should always be 1, to help us ensure there are no bugs in the code.
 	tableMigrationsSQL = `CREATE TABLE IF NOT EXISTS ` + migrationsSchemaName + `.migration (
 		id INT PRIMARY KEY,
-		start_height INT NOT NULL,
-		end_height INT NOT NULL,
+		start_height INT8 NOT NULL,
+		end_height INT8 NOT NULL,
 		chain_id TEXT NOT NULL
 	)`
 
@@ -67,7 +67,7 @@ var (
 	// tableLastChangesetSQL is the table that tracks last stored changeset. It is a single row table with the row name as "last_stored_changeset".
 	tableLastStoredChangesetSQL = `CREATE TABLE IF NOT EXISTS ` + migrationsSchemaName + `.last_stored_changeset (
 			name TEXT PRIMARY KEY,
-			height INT -- height of the last stored changeset
+			height INT8 -- height of the last stored changeset
 		)`
 
 	// upsertLastChangesetSQL is the sql query used to set the last changeset.
@@ -182,7 +182,7 @@ var (
 	// tableLastChangesetSQL is the table that tracks last applied changeset. It is a single row table with the row name as "last_changeset".
 	tableLastChangesetSQL = `CREATE TABLE IF NOT EXISTS ` + migrationsSchemaName + `.last_changeset (
 		name TEXT PRIMARY KEY, -- name of the row, should always be "height"
-		height INT
+		height INT8
 	)`
 
 	// upsertLastChangesetSQL is the sql query used to set the last changeset.
@@ -193,15 +193,15 @@ var (
 
 	// tableChangesetMetadataSQL is the table that stores changesets.
 	tableChangesetsMetadataSQL = `CREATE TABLE IF NOT EXISTS ` + migrationsSchemaName + `.changesets_metadata (
-		height INT PRIMARY KEY,
+		height INT8 PRIMARY KEY,
 		total_chunks INT, -- total number of chunks in the changeset
 		received INT, -- number of chunks received
-		prev_height INT -- height of the previous changeset
+		prev_height INT8 -- height of the previous changeset
 	)`
 
 	// tableChangesetsSQL is the table that stores changeset chunks. These are identified by height and index.
 	tableChangesetsSQL = `CREATE TABLE IF NOT EXISTS ` + migrationsSchemaName + `.changesets (
-		height INT,
+		height INT8,
 		index INT,
 		changeset BYTEA,
 		FOREIGN KEY (height) REFERENCES ` + migrationsSchemaName + `.changesets_metadata(height) ON DELETE CASCADE,

--- a/internal/migrations/sql.go
+++ b/internal/migrations/sql.go
@@ -195,7 +195,8 @@ var (
 	tableChangesetsMetadataSQL = `CREATE TABLE IF NOT EXISTS ` + migrationsSchemaName + `.changesets_metadata (
 		height INT PRIMARY KEY,
 		total_chunks INT, -- total number of chunks in the changeset
-		received INT -- number of chunks received
+		received INT, -- number of chunks received
+		prev_height INT -- height of the previous changeset
 	)`
 
 	// tableChangesetsSQL is the table that stores changeset chunks. These are identified by height and index.
@@ -208,7 +209,7 @@ var (
 	)`
 
 	// insertChangesetMetadataSQL is the sql query used to insert changeset metadata.
-	insertChangesetMetadataSQL = `INSERT INTO ` + migrationsSchemaName + `.changesets_metadata (height, total_chunks, received) VALUES ($1, $2, $3) ON CONFLICT (height) DO NOTHING;`
+	insertChangesetMetadataSQL = `INSERT INTO ` + migrationsSchemaName + `.changesets_metadata (height, total_chunks, received, prev_height) VALUES ($1, $2, $3, $4) ON CONFLICT (height) DO NOTHING;`
 
 	// updateChangesetMetadataSQL is the sql query used to update changeset metadata.
 	updateChangesetMetadataSQL = `UPDATE ` + migrationsSchemaName + `.changesets_metadata SET received = received + 1 WHERE height = $1;`
@@ -217,7 +218,10 @@ var (
 	deleteChangesetMetadataSQL = `DELETE FROM ` + migrationsSchemaName + `.changesets_metadata WHERE height = $1;`
 
 	// getChangesetMetadataSQL is the sql query used to get changeset metadata.
-	getChangesetMetadataSQL = `SELECT total_chunks, received FROM ` + migrationsSchemaName + `.changesets_metadata WHERE height = $1;`
+	// getChangesetMetadataSQL = `SELECT total_chunks, received, prev_height FROM ` + migrationsSchemaName + `.changesets_metadata WHERE height = $1;`
+
+	// get the metadata for the earliest changeset.
+	getEarliestChangesetMetadataSQL = `SELECT height, total_chunks, received, prev_height FROM ` + migrationsSchemaName + `.changesets_metadata ORDER BY height ASC LIMIT 1;`
 
 	// insertChangesetSQL is the sql query used to insert changeset.
 	insertChangesetSQL = `INSERT INTO ` + migrationsSchemaName + `.changesets (height, index, changeset) VALUES ($1, $2, $3) ON CONFLICT (height, index) DO NOTHING;`
@@ -264,8 +268,8 @@ func getLastChangeset(ctx context.Context, db sql.Executor) (int64, error) {
 }
 
 // insertChangesetMetadata inserts the changeset metadata into the database.
-func insertChangesetMetadata(ctx context.Context, db sql.Executor, height int64, totalChunks int64) error {
-	_, err := db.Execute(ctx, insertChangesetMetadataSQL, height, totalChunks, 0)
+func insertChangesetMetadata(ctx context.Context, db sql.Executor, height int64, totalChunks int64, prev_height int64) error {
+	_, err := db.Execute(ctx, insertChangesetMetadataSQL, height, totalChunks, 0, prev_height)
 	return err
 }
 
@@ -282,40 +286,51 @@ func insertChangesetChunk(ctx context.Context, db sql.Executor, height int64, in
 	return err
 }
 
-// getChangesetMetadata gets the changeset metadata from the database.
-func getChangesetMetadata(ctx context.Context, db sql.Executor, height int64) (int64, int64, error) {
-	res, err := db.Execute(ctx, getChangesetMetadataSQL, height)
+// getEarliestChangesetMetadata gets the changeset metadata from the database for the earliest changeset received.
+func getEarliestChangesetMetadata(ctx context.Context, db sql.Executor) (height int64, prevHeight int64, chunksToReceive int64, totalChunks int64, err error) {
+	res, err := db.Execute(ctx, getEarliestChangesetMetadataSQL)
 	if err != nil {
-		return 0, 0, err
+		return -1, -1, 0, 0, err
 	}
 
 	// row doesnt exist.
 	if len(res.Rows) == 0 {
-		return -1, -1, nil
+		return -1, -1, -1, -1, nil
 	}
 
 	if len(res.Rows) != 1 {
 		// should never happen
-		return 0, 0, fmt.Errorf("internal bug: expected one row for changeset metadata, got %d", len(res.Rows))
+		return -1, -1, 0, 0, fmt.Errorf("internal bug: expected one row for changeset metadata, got %d", len(res.Rows))
 	}
 
-	if len(res.Rows[0]) != 2 {
+	if len(res.Rows[0]) != 4 {
 		// should never happen
-		return 0, 0, fmt.Errorf("internal bug: expected two columns for changeset metadata, got %d", len(res.Rows[0]))
+		return -1, -1, 0, 0, fmt.Errorf("internal bug: expected four columns for changeset metadata, got %d", len(res.Rows[0]))
 	}
 
 	row := res.Rows[0]
-	chunksToReceive, ok := row[0].(int64)
+	var ok bool
+	height, ok = row[0].(int64)
 	if !ok {
-		return 0, 0, fmt.Errorf("internal bug: chunks to receive is not an int64")
+		return -1, -1, 0, 0, fmt.Errorf("internal bug: height is not an int64")
 	}
 
-	totalChunks, ok := row[1].(int64)
+	chunksToReceive, ok = row[1].(int64)
 	if !ok {
-		return 0, 0, fmt.Errorf("internal bug: total chunks is not an int64")
+		return -1, -1, 0, 0, fmt.Errorf("internal bug: chunks to receive is not an int64")
 	}
 
-	return totalChunks, chunksToReceive, nil
+	totalChunks, ok = row[2].(int64)
+	if !ok {
+		return -1, -1, 0, 0, fmt.Errorf("internal bug: total chunks is not an int64")
+	}
+
+	prevHeight, ok = row[3].(int64)
+	if !ok {
+		return -1, -1, 0, 0, fmt.Errorf("internal bug: prev height is not an int64")
+	}
+
+	return height, prevHeight, chunksToReceive, totalChunks, nil
 }
 
 // changesetChunkExists checks if a changeset chunk already exists in the database.

--- a/internal/txapp/interfaces.go
+++ b/internal/txapp/interfaces.go
@@ -56,9 +56,9 @@ var (
 	createResolution                 = voting.CreateResolution
 	approveResolution                = voting.ApproveResolution
 	getVoterPower                    = voting.GetValidatorPower
-	// resolutionExists                 = voting.ResolutionExists
-	resolutionByID   = voting.GetResolutionInfo
-	deleteResolution = voting.DeleteResolution
+	resolutionExists                 = voting.ResolutionExists
+	resolutionByID                   = voting.GetResolutionInfo
+	deleteResolution                 = voting.DeleteResolution
 
 	// account functions
 	getAccount = accounts.GetAccount

--- a/internal/voting/vote_test.go
+++ b/internal/voting/vote_test.go
@@ -54,6 +54,10 @@ func Test_Voting(t *testing.T) {
 				err = CreateResolution(ctx, db, testEvent, 10, []byte("a"))
 				require.NoError(t, err)
 
+				// duplicate creation should fail
+				err = CreateResolution(ctx, db, testEvent, 10, []byte("a"))
+				require.Error(t, err)
+
 				err = ApproveResolution(ctx, db, testEvent.ID(), []byte("a"))
 				require.NoError(t, err)
 
@@ -128,6 +132,10 @@ func Test_Voting(t *testing.T) {
 
 				processed, err = IsProcessed(ctx, db, testEvent.ID())
 				require.NoError(t, err)
+
+				// Resolution creation should fail if the resolution is already processed
+				err = CreateResolution(ctx, db, testEvent, 10, []byte("a"))
+				require.Error(t, err)
 
 				require.True(t, processed)
 			},

--- a/test/specifications/migration.go
+++ b/test/specifications/migration.go
@@ -25,7 +25,7 @@ func SubmitMigrationProposal(ctx context.Context, t *testing.T, netops Migration
 	t.Log("Executing migration trigger specification")
 
 	// Trigger migration"
-	txHash, err := netops.SubmitMigrationProposal(ctx, big.NewInt(1), big.NewInt(200), chainID)
+	txHash, err := netops.SubmitMigrationProposal(ctx, big.NewInt(1), big.NewInt(50), chainID)
 	require.NoError(t, err)
 
 	// Ensure that the Tx is mined.


### PR DESCRIPTION
This PR optimizes the migration process on the new network, by not submitting the resolutions with empty changesets thereby reducing the number of resolutions to be processed and voted on the new network.

Also fixes any issues concerning if the changeset migration resolution can fit within a block. All the changeset chunks are readjusted to the blocksize/3 on the new network.