### PR TITLE
deprecates --action, should now be passed as positional argument

### DIFF
--- a/cmd/kwil-admin/cmds/setup/init.go
+++ b/cmd/kwil-admin/cmds/setup/init.go
@@ -121,9 +121,17 @@ func initCmd() *cobra.Command {
 
 	// TODO: deprecate below flags in v0.10.0
 	cmd1.Flags().StringVarP(&out, "output-dir", "o", "./.testnet", "generated node parent directory. To be deprecated in v0.10.0, until then --root-dir is ignored")
-	cmd1.Flags().MarkDeprecated("output-dir", "use --cfg.root-dir instead from v0.10.0")
+	err := cmd1.Flags().MarkDeprecated("output-dir", "use --cfg.root-dir instead from v0.10.0")
+	if err != nil {
+		panic(err)
+	}
+
 	cmd1.Flags().DurationVarP(&blockInterval, "block-interval", "i", 6*time.Second, "shortest block interval in seconds. To be deprecated in v0.10.0")
-	cmd1.Flags().MarkDeprecated("block-interval", "use --chain.consensus.timeout-commit instead from v0.10.0")
+	err = cmd1.Flags().MarkDeprecated("block-interval", "use --chain.consensus.timeout-commit instead from v0.10.0")
+	if err != nil {
+		panic(err)
+	}
+
 	return cmd1
 }
 

--- a/cmd/kwil-cli/cmds/database/batch.go
+++ b/cmd/kwil-cli/cmds/database/batch.go
@@ -21,11 +21,11 @@ var (
 )
 
 var (
-	batchLong = `Batch executes an action on a database using inputs from a CSV file.
+	batchLong = `Batch executes an action or procedure on a database using inputs from a CSV file.
 
-To map a CSV column name to an action input, use the ` + "`" + `--map-inputs` + "`" + ` flag.
-The format is ` + "`" + `--map-inputs "<csv_column_1>:<action_input_1>,<csv_column_2>:<action_input_2>"` + "`" + `.  If the ` + "`" + `--map-inputs` + "`" + ` flag is not passed,
-the CSV column name will be used as the action input name.
+To map a CSV column name to a procedure input, use the ` + "`" + `--map-inputs` + "`" + ` flag.
+The format is ` + "`" + `--map-inputs "<csv_column_1>:<procedure_input_1>,<csv_column_2>:<procedure_input_2>"` + "`" + `.  If the ` + "`" + `--map-inputs` + "`" + ` flag is not passed,
+the CSV column name will be used as the procedure input name.
 
 You can also specify the input values directly using the ` + "`" + `--values` + "`" + ` flag, delimited by a colon.
 These values will apply to all inserted rows, and will override the CSV column mappings.
@@ -112,7 +112,6 @@ func batchCmd() *cobra.Command {
 	cmd.Flags().StringVarP(&filePath, "path", "p", "", "path to the CSV file to use")
 
 	cmd.MarkFlagRequired("path")
-	cmd.MarkFlagRequired("action")
 	return cmd
 }
 

--- a/cmd/kwil-cli/cmds/database/batch.go
+++ b/cmd/kwil-cli/cmds/database/batch.go
@@ -41,7 +41,7 @@ flag is passed and no ` + "`" + `--owner` + "`" + ` flag is passed, the owner wi
 # 3,jack,35
 
 # Executing the ` + "`" + `create_user($user_id, $username, $user_age, $created_at)` + "`" + ` action on the "mydb" database
-kwil-cli database batch --path ./users.csv --target create_user --name mydb --owner 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 --map-inputs "id:user_id,name:username,age:user_age" --values created_at:$(date +%s)`
+kwil-cli database batch create_user --path ./users.csv --name mydb --owner 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 --map-inputs "id:user_id,name:username,age:user_age" --values created_at:$(date +%s)`
 )
 
 // batch is used for batch operations on databases
@@ -56,11 +56,16 @@ func batchCmd() *cobra.Command {
 		Long:    batchLong,
 		Example: batchExample,
 		Args:    cobra.NoArgs,
-		RunE: func(cmd *cobra.Command, _ []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 			return common.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl clientType.Client, conf *config.KwilCliConfig) error {
-				dbid, action, err := getSelectedProcedureAndDBID(cmd, conf)
+				dbid, err := getSelectedDbid(cmd, conf)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("error getting selected procedure and dbid: %w", err))
+				}
+
+				action, _, err := getSelectedActionOrProcedure(cmd, args)
+				if err != nil {
+					return display.PrintErr(cmd, fmt.Errorf("error getting selected action or procedure: %w", err))
 				}
 
 				fileType, err := getFileType(filePath)

--- a/cmd/kwil-cli/cmds/database/batch.go
+++ b/cmd/kwil-cli/cmds/database/batch.go
@@ -51,7 +51,7 @@ func batchCmd() *cobra.Command {
 	var inputValueMappings []string // these override the csv column mappings
 
 	cmd := &cobra.Command{
-		Use:     "batch",
+		Use:     "batch <procedure_or_action>",
 		Short:   "Batch execute an action using inputs from a CSV file.",
 		Long:    batchLong,
 		Example: batchExample,

--- a/cmd/kwil-cli/cmds/database/batch.go
+++ b/cmd/kwil-cli/cmds/database/batch.go
@@ -60,7 +60,7 @@ func batchCmd() *cobra.Command {
 			return common.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl clientType.Client, conf *config.KwilCliConfig) error {
 				dbid, err := getSelectedDbid(cmd, conf)
 				if err != nil {
-					return display.PrintErr(cmd, fmt.Errorf("error getting selected procedure and dbid: %w", err))
+					return display.PrintErr(cmd, fmt.Errorf("error getting selected dbid from CLI flags: %w", err))
 				}
 
 				action, _, err := getSelectedActionOrProcedure(cmd, args)

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -18,17 +18,17 @@ import (
 )
 
 var (
-	callLong = `Call a ` + "`" + `view` + "`" + ` action, returning the result.
+	callLong = `Call a ` + "`" + `view` + "`" + ` procedure or action, returning the result.
 
-` + "`" + `view` + "`" + ` actions are read-only actions that do not require gas to execute.  They are
+` + "`" + `view` + "`" + ` procedure are read-only procedure that do not require gas to execute.  They are
 the primary way to query the state of a database. The ` + "`" + `call` + "`" + ` command is used to call
-a ` + "`" + `view` + "`" + ` action on a database.  It takes the action name as a required flag, and the
-action inputs as arguments.
+a ` + "`" + `view` + "`" + ` procedure on a database.  It takes the procedure name as a required flag, and the
+procedure inputs as arguments.
 
-To specify an action input, you first need to specify the input name, then the input value, delimited by a colon.
-For example, for action ` + "`" + `get_user($username)` + "`" + `, you would specify the action as follows:
+To specify a procedure input, you first need to specify the input name, then the input value, delimited by a colon.
+For example, for procedure ` + "`" + `get_user($username)` + "`" + `, you would specify the procedure as follows:
 
-` + "`" + `username:satoshi` + "`" + ` --action=get_user
+` + "`" + `username:satoshi` + "`" + ` --target=get_user
 
 You can either specify the database to execute this against with the ` + "`" + `--name` + "`" + ` and ` + "`" + `--owner` + "`" + `
 flags, or you can specify the database by passing the database id with the ` + "`" + `--dbid` + "`" + ` flag.  If a ` + "`" + `--name` + "`" + `
@@ -36,15 +36,14 @@ flag is passed and no ` + "`" + `--owner` + "`" + ` flag is passed, the owner wi
 
 If you are interacting with a Kwil gateway, you can also pass the ` + "`" + `--authenticate` + "`" + ` flag to authenticate the call with your private key.`
 
-	callExample = `# Calling the ` + "`" + `get_user($username)` + "`" + ` action on the "mydb" database
-kwil-cli database call --action get_user --name mydb --owner 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi
+	callExample = `# Calling the ` + "`" + `get_user($username)` + "`" + ` procedure on the "mydb" database
+kwil-cli database call --target get_user --name mydb --owner 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi
 
-# Calling the ` + "`" + `get_user($username)` + "`" + ` action on a database using a dbid, authenticating with a private key
-kwil-cli database call --action get_user --dbid 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi --authenticate`
+# Calling the ` + "`" + `get_user($username)` + "`" + ` procedure on a database using a dbid, authenticating with a private key
+kwil-cli database call --target get_user --dbid 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi --authenticate`
 )
 
 func callCmd() *cobra.Command {
-	var action string
 	var gwAuth, logs, signCall bool
 
 	cmd := &cobra.Command{
@@ -67,30 +66,28 @@ func callCmd() *cobra.Command {
 			}
 
 			return common.DialClient(cmd.Context(), cmd, dialFlags, func(ctx context.Context, clnt clientType.Client, conf *config.KwilCliConfig) error {
-				dbid, err := getSelectedDbid(cmd, conf)
+				dbid, action, err := getSelectedProcedureAndDBID(cmd, conf)
 				if err != nil {
-					return display.PrintErr(cmd, fmt.Errorf("target database not properly specified: %w", err))
+					return display.PrintErr(cmd, fmt.Errorf("error getting selected procedure and dbid: %w", err))
 				}
-
-				lowerName := strings.ToLower(action)
 
 				inputs, err := parseInputs(args)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("error getting inputs: %w", err))
 				}
 
-				tuples, err := buildExecutionInputs(ctx, clnt, dbid, lowerName, inputs)
+				tuples, err := buildExecutionInputs(ctx, clnt, dbid, action, inputs)
 				if err != nil {
-					return display.PrintErr(cmd, fmt.Errorf("error creating action inputs: %w", err))
+					return display.PrintErr(cmd, fmt.Errorf("error creating action/procedure inputs: %w", err))
 				}
 
 				if len(tuples) == 0 {
 					tuples = append(tuples, []any{})
 				}
 
-				data, err := clnt.Call(ctx, dbid, lowerName, tuples[0])
+				data, err := clnt.Call(ctx, dbid, action, tuples[0])
 				if err != nil {
-					return display.PrintErr(cmd, fmt.Errorf("error calling action: %w", err))
+					return display.PrintErr(cmd, fmt.Errorf("error calling action/procedure: %w", err))
 				}
 
 				if data == nil {
@@ -105,10 +102,7 @@ func callCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP(nameFlag, "n", "", "the target database schema name")
-	cmd.Flags().StringP(ownerFlag, "o", "", "the target database schema owner")
-	cmd.Flags().StringP(dbidFlag, "i", "", "the target database id")
-	cmd.Flags().StringVarP(&action, actionNameFlag, "a", "", "the target action name (required)")
+	bindFlagsTargetingProcedureOrAction(cmd)
 	cmd.Flags().BoolVar(&gwAuth, "authenticate", false, "authenticate signals that the call is being made to a gateway and should be authenticated with the private key")
 	cmd.Flags().BoolVar(&signCall, "callauth", false, "authenticate call RPCs by signing a challenge response with the call data")
 	cmd.Flags().BoolVar(&logs, "logs", false, "result will include logs from notices raised during the call")

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -106,8 +106,6 @@ func callCmd() *cobra.Command {
 	cmd.Flags().BoolVar(&gwAuth, "authenticate", false, "authenticate signals that the call is being made to a gateway and should be authenticated with the private key")
 	cmd.Flags().BoolVar(&signCall, "callauth", false, "authenticate call RPCs by signing a challenge response with the call data")
 	cmd.Flags().BoolVar(&logs, "logs", false, "result will include logs from notices raised during the call")
-
-	cmd.MarkFlagRequired(actionNameFlag)
 	return cmd
 }
 

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -68,7 +68,7 @@ func callCmd() *cobra.Command {
 			return common.DialClient(cmd.Context(), cmd, dialFlags, func(ctx context.Context, clnt clientType.Client, conf *config.KwilCliConfig) error {
 				dbid, err := getSelectedDbid(cmd, conf)
 				if err != nil {
-					return display.PrintErr(cmd, fmt.Errorf("error getting selected procedure and dbid: %w", err))
+					return display.PrintErr(cmd, fmt.Errorf("error getting selected dbid from CLI flags: %w", err))
 				}
 
 				action, args, err := getSelectedActionOrProcedure(cmd, args)

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -22,13 +22,13 @@ var (
 
 ` + "`" + `view` + "`" + ` procedure are read-only procedure that do not require gas to execute.  They are
 the primary way to query the state of a database. The ` + "`" + `call` + "`" + ` command is used to call
-a ` + "`" + `view` + "`" + ` procedure on a database.  It takes the procedure name as a required flag, and the
-procedure inputs as arguments.
+a ` + "`" + `view` + "`" + ` procedure on a database.  It takes the procedure name as the first positional
+argument, and the procedure inputs as all subsequent arguments.
 
 To specify a procedure input, you first need to specify the input name, then the input value, delimited by a colon.
 For example, for procedure ` + "`" + `get_user($username)` + "`" + `, you would specify the procedure as follows:
 
-` + "`" + `username:satoshi` + "`" + ` --target=get_user
+` + "`" + `call get_user username:satoshi` + "`" + `
 
 You can either specify the database to execute this against with the ` + "`" + `--name` + "`" + ` and ` + "`" + `--owner` + "`" + `
 flags, or you can specify the database by passing the database id with the ` + "`" + `--dbid` + "`" + ` flag.  If a ` + "`" + `--name` + "`" + `
@@ -37,10 +37,10 @@ flag is passed and no ` + "`" + `--owner` + "`" + ` flag is passed, the owner wi
 If you are interacting with a Kwil gateway, you can also pass the ` + "`" + `--authenticate` + "`" + ` flag to authenticate the call with your private key.`
 
 	callExample = `# Calling the ` + "`" + `get_user($username)` + "`" + ` procedure on the "mydb" database
-kwil-cli database call --target get_user --name mydb --owner 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi
+kwil-cli database call get_user --name mydb --owner 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi
 
 # Calling the ` + "`" + `get_user($username)` + "`" + ` procedure on a database using a dbid, authenticating with a private key
-kwil-cli database call --target get_user --dbid 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi --authenticate`
+kwil-cli database call get_user --dbid 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64 username:satoshi --authenticate`
 )
 
 func callCmd() *cobra.Command {
@@ -66,9 +66,14 @@ func callCmd() *cobra.Command {
 			}
 
 			return common.DialClient(cmd.Context(), cmd, dialFlags, func(ctx context.Context, clnt clientType.Client, conf *config.KwilCliConfig) error {
-				dbid, action, err := getSelectedProcedureAndDBID(cmd, conf)
+				dbid, err := getSelectedDbid(cmd, conf)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("error getting selected procedure and dbid: %w", err))
+				}
+
+				action, args, err := getSelectedActionOrProcedure(cmd, args)
+				if err != nil {
+					return display.PrintErr(cmd, fmt.Errorf("error getting selected action or procedure: %w", err))
 				}
 
 				inputs, err := parseInputs(args)

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -47,7 +47,7 @@ func callCmd() *cobra.Command {
 	var gwAuth, logs, signCall bool
 
 	cmd := &cobra.Command{
-		Use:     "call <parameter_1:value_1> <parameter_2:value_2> ...",
+		Use:     "call <procedure_or_action> <parameter_1:value_1> <parameter_2:value_2> ...",
 		Short:   "Call a 'view' action, returning the result.",
 		Long:    callLong,
 		Example: callExample,

--- a/cmd/kwil-cli/cmds/database/deploy.go
+++ b/cmd/kwil-cli/cmds/database/deploy.go
@@ -102,8 +102,6 @@ func deployCmd() *cobra.Command {
 
 	cmd.Flags().StringVarP(&fileType, "type", "t", "kf", "file type of the database definition file (kf or json)")
 	cmd.Flags().StringVarP(&overrideName, "name", "n", "", "set the name of the database, overriding the name in the schema file")
-
-	cmd.MarkFlagRequired("path")
 	return cmd
 }
 

--- a/cmd/kwil-cli/cmds/database/execute.go
+++ b/cmd/kwil-cli/cmds/database/execute.go
@@ -79,8 +79,6 @@ func executeCmd() *cobra.Command {
 	}
 
 	bindFlagsTargetingProcedureOrAction(cmd)
-
-	cmd.MarkFlagRequired(actionNameFlag)
 	return cmd
 }
 

--- a/cmd/kwil-cli/cmds/database/execute.go
+++ b/cmd/kwil-cli/cmds/database/execute.go
@@ -36,7 +36,7 @@ kwil-cli database execute create_user username:satoshi age:32 --dbid 0x9228624C3
 
 func executeCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "execute <parameter_1:value_1> <parameter_2:value_2> ...",
+		Use:     "execute <procedure_or_action> <parameter_1:value_1> <parameter_2:value_2> ...",
 		Short:   "Execute a procedure or action against a database.",
 		Long:    executeLong,
 		Example: executeExample,

--- a/cmd/kwil-cli/cmds/database/execute.go
+++ b/cmd/kwil-cli/cmds/database/execute.go
@@ -44,7 +44,7 @@ func executeCmd() *cobra.Command {
 			return common.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl clientType.Client, conf *config.KwilCliConfig) error {
 				dbid, err := getSelectedDbid(cmd, conf)
 				if err != nil {
-					return display.PrintErr(cmd, fmt.Errorf("error getting selected procedure and dbid: %w", err))
+					return display.PrintErr(cmd, fmt.Errorf("error getting selected dbid from CLI flags: %w", err))
 				}
 
 				action, args, err := getSelectedActionOrProcedure(cmd, args)

--- a/cmd/kwil-cli/cmds/database/flags.go
+++ b/cmd/kwil-cli/cmds/database/flags.go
@@ -16,7 +16,6 @@ const (
 	nameFlag       = "name"
 	ownerFlag      = "owner"
 	actionNameFlag = "action"
-	targetFlag     = "target"
 )
 
 // getSelectedOwner is used to get the owner flag.  Since the owner flag is usually optional,

--- a/cmd/kwil-cli/cmds/database/flags.go
+++ b/cmd/kwil-cli/cmds/database/flags.go
@@ -83,8 +83,7 @@ func getSelectedDbid(cmd *cobra.Command, conf *config.KwilCliConfig) (string, er
 func bindFlagsTargetingProcedureOrAction(cmd *cobra.Command) {
 	bindFlagsTargetingDatabase(cmd)
 	cmd.Flags().StringP(actionNameFlag, "a", "", "the target action name")
-	cmd.Flags().MarkDeprecated(actionNameFlag, "please use --target instead")
-	cmd.Flags().StringP(targetFlag, "t", "", "the target action or procedure name")
+	cmd.Flags().MarkDeprecated(actionNameFlag, "pass the action name as the first argument")
 }
 
 func getSelectedProcedureAndDBID(cmd *cobra.Command, conf *config.KwilCliConfig) (dbid string, procOrAction string, err error) {
@@ -109,6 +108,31 @@ func getSelectedProcedureAndDBID(cmd *cobra.Command, conf *config.KwilCliConfig)
 	}
 
 	return dbid, strings.ToLower(name), nil
+}
+
+// getSelectedActionOrProcedure returns the action or procedure name that the user selected.
+// It is made to be backwards compatible with the old way of passing the action name as the --action flag.
+// In v0.9, we changed this to have the action / procedure be passed as the first positional argument in
+// all commands that require it.  This function will check if the --action flag was passed, and if it was,
+// it will return that.  If it was not passed, it will return the first positional argument, and return the args
+// with the first element removed.
+func getSelectedActionOrProcedure(cmd *cobra.Command, args []string) (actionOrProc string, args2 []string, err error) {
+	var actionOrProcedure string
+	if cmd.Flags().Changed(actionNameFlag) {
+		actionOrProcedure, err = cmd.Flags().GetString(actionNameFlag)
+		if err != nil {
+			return "", nil, err
+		}
+	} else {
+		if len(args) < 1 {
+			return "", nil, fmt.Errorf("missing action or procedure name")
+		}
+
+		actionOrProcedure = args[0]
+		args = args[1:]
+	}
+
+	return strings.ToLower(actionOrProcedure), args, nil
 }
 
 // bindFlagsTargetingDatabase binds the flags for any command that targets a database.

--- a/cmd/kwil-cli/cmds/database/flags.go
+++ b/cmd/kwil-cli/cmds/database/flags.go
@@ -83,7 +83,10 @@ func getSelectedDbid(cmd *cobra.Command, conf *config.KwilCliConfig) (string, er
 func bindFlagsTargetingProcedureOrAction(cmd *cobra.Command) {
 	bindFlagsTargetingDatabase(cmd)
 	cmd.Flags().StringP(actionNameFlag, "a", "", "the target action name")
-	cmd.Flags().MarkDeprecated(actionNameFlag, "pass the action name as the first argument")
+	err := cmd.Flags().MarkDeprecated(actionNameFlag, "pass the action name as the first argument")
+	if err != nil {
+		panic(err)
+	}
 }
 
 // getSelectedActionOrProcedure returns the action or procedure name that the user selected.

--- a/cmd/kwil-cli/cmds/database/flags.go
+++ b/cmd/kwil-cli/cmds/database/flags.go
@@ -86,30 +86,6 @@ func bindFlagsTargetingProcedureOrAction(cmd *cobra.Command) {
 	cmd.Flags().MarkDeprecated(actionNameFlag, "pass the action name as the first argument")
 }
 
-func getSelectedProcedureAndDBID(cmd *cobra.Command, conf *config.KwilCliConfig) (dbid string, procOrAction string, err error) {
-	dbid, err = getSelectedDbid(cmd, conf)
-	if err != nil {
-		return "", "", fmt.Errorf("failed to get dbid: %w", err)
-	}
-
-	var name string
-	if cmd.Flags().Changed(targetFlag) {
-		name, err = cmd.Flags().GetString(targetFlag)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to get procedure name: %w", err)
-		}
-	} else if cmd.Flags().Changed(actionNameFlag) {
-		name, err = cmd.Flags().GetString(actionNameFlag)
-		if err != nil {
-			return "", "", fmt.Errorf("failed to get action name: %w", err)
-		}
-	} else {
-		return "", "", fmt.Errorf("neither procedure nor action was provided")
-	}
-
-	return dbid, strings.ToLower(name), nil
-}
-
 // getSelectedActionOrProcedure returns the action or procedure name that the user selected.
 // It is made to be backwards compatible with the old way of passing the action name as the --action flag.
 // In v0.9, we changed this to have the action / procedure be passed as the first positional argument in

--- a/cmd/kwil-cli/cmds/database/query.go
+++ b/cmd/kwil-cli/cmds/database/query.go
@@ -52,8 +52,6 @@ func queryCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP(nameFlag, "n", "", "the target database name")
-	cmd.Flags().StringP(ownerFlag, "o", "", "the target database owner")
-	cmd.Flags().StringP(dbidFlag, "i", "", "the target database id")
+	bindFlagsTargetingDatabase(cmd)
 	return cmd
 }

--- a/cmd/kwil-cli/cmds/database/read_schema.go
+++ b/cmd/kwil-cli/cmds/database/read_schema.go
@@ -49,8 +49,6 @@ func readSchemaCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().StringP(nameFlag, "n", "", "the target database name")
-	cmd.Flags().StringP(ownerFlag, "o", "", "the target database owner")
-	cmd.Flags().StringP(dbidFlag, "i", "", "the target database id")
+	bindFlagsTargetingDatabase(cmd)
 	return cmd
 }

--- a/cmd/kwil-cli/cmds/database/read_schema.go
+++ b/cmd/kwil-cli/cmds/database/read_schema.go
@@ -15,9 +15,9 @@ import (
 var (
 	readSchemaLong = `Read schema is used to view the details of a deployed database schema.
 
-	You can either specify the database to execute this against with the ` + "`" + `--name` + "`" + ` and ` + "`" + `--owner` + "`" + `
-	flags, or you can specify the database by passing the database id with the ` + "`" + `--dbid` + "`" + ` flag.  If a ` + "`" + `--name` + "`" + `
-	flag is passed and no ` + "`" + `--owner` + "`" + ` flag is passed, the owner will be inferred from your configured wallet.`
+You can either specify the database to execute this against with the ` + "`" + `--name` + "`" + ` and ` + "`" + `--owner` + "`" + `
+flags, or you can specify the database by passing the database id with the ` + "`" + `--dbid` + "`" + ` flag.  If a ` + "`" + `--name` + "`" + `
+flag is passed and no ` + "`" + `--owner` + "`" + ` flag is passed, the owner will be inferred from your configured wallet.`
 
 	readSchemaExample = `# Reading the schema of the "mydb" database, owned by 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64
 kwil-cli database read-schema --name mydb --owner 0x9228624C3185FCBcf24c1c9dB76D8Bef5f5DAd64`

--- a/cmd/kwil-cli/config/flags.go
+++ b/cmd/kwil-cli/config/flags.go
@@ -58,5 +58,8 @@ func BindGlobalFlags(fs *pflag.FlagSet) {
 
 	// Add deprecated flag
 	fs.String("kwil-provider", cliCfg.Provider, "the Kwil provider RPC endpoint")
-	fs.MarkDeprecated("kwil-provider", "use '--provider' instead")
+	err := fs.MarkDeprecated("kwil-provider", "use '--provider' instead")
+	if err != nil {
+		panic(err)
+	}
 }

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -339,7 +339,7 @@ func (d *KwilCliDriver) Execute(_ context.Context, dbid string, action string, i
 		return nil, fmt.Errorf("failed to get action params: %w", err)
 	}
 
-	args := []string{"database", "execute", "--dbid", dbid, "--target", action}
+	args := []string{"database", "execute", action, "--dbid", dbid}
 	args = append(args, actionInputs...)
 
 	cmd := d.newKwilCliCmd(args...)
@@ -379,7 +379,7 @@ func (d *KwilCliDriver) Call(_ context.Context, dbid, action string, inputs []an
 		return nil, fmt.Errorf("failed to prepare action params: %w", err)
 	}
 
-	args := []string{"database", "call", "--dbid", dbid, "--target", action, "--logs"}
+	args := []string{"database", "call", action, "--dbid", dbid, "--logs"}
 	args = append(args, actionInputs...)
 
 	if d.gatewayProvider {

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -339,7 +339,7 @@ func (d *KwilCliDriver) Execute(_ context.Context, dbid string, action string, i
 		return nil, fmt.Errorf("failed to get action params: %w", err)
 	}
 
-	args := []string{"database", "execute", "--dbid", dbid, "--action", action}
+	args := []string{"database", "execute", "--dbid", dbid, "--target", action}
 	args = append(args, actionInputs...)
 
 	cmd := d.newKwilCliCmd(args...)
@@ -379,7 +379,7 @@ func (d *KwilCliDriver) Call(_ context.Context, dbid, action string, inputs []an
 		return nil, fmt.Errorf("failed to prepare action params: %w", err)
 	}
 
-	args := []string{"database", "call", "--dbid", dbid, "--action", action, "--logs"}
+	args := []string{"database", "call", "--dbid", dbid, "--target", action, "--logs"}
 	args = append(args, actionInputs...)
 
 	if d.gatewayProvider {

--- a/test/driver/cli_driver.go
+++ b/test/driver/cli_driver.go
@@ -191,7 +191,7 @@ func (d *KwilCliDriver) DeployDatabase(_ context.Context, db *types.Schema) (txH
 		return nil, fmt.Errorf("failed to write database schema: %w", err)
 	}
 
-	cmd := d.newKwilCliCmd("database", "deploy", "-p", schemaFile, "-t", "json")
+	cmd := d.newKwilCliCmd("database", "deploy", schemaFile, "-t", "json")
 	out, err := mustRun[respTxHash](cmd, d.logger)
 	if err != nil {
 		return nil, fmt.Errorf("failed to deploy database: %w", err)


### PR DESCRIPTION
While going through the docs, I noticed that we liberally use `--action` everywhere with `kwil-cli`. This isn't quite accurate, since anywhere we specify `--action` we can also use a procedure. Therefore, I deprecated `--action`, and added a `--target` flag.
