### PR TITLE
CI: use app health check endpoint

### DIFF
--- a/build/package/docker/kwild.debug.dockerfile
+++ b/build/package/docker/kwild.debug.dockerfile
@@ -26,7 +26,7 @@ FROM alpine:3.19
 COPY --from=build /go/bin/dlv /dlv
 WORKDIR /app
 RUN mkdir -p /var/run/kwil && chmod 777 /var/run/kwil
-RUN apk --no-cache add postgresql-client
+RUN apk --no-cache add postgresql-client curl
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/dist/kwild ./kwild
 COPY --from=build /app/dist/kwil-admin ./kwil-admin

--- a/build/package/docker/kwild.dockerfile
+++ b/build/package/docker/kwild.dockerfile
@@ -22,7 +22,7 @@ RUN chmod +x /app/dist/kwild /app/dist/kwil-admin /app/dist/kwil-cli
 FROM ubuntu:24.04
 WORKDIR /app
 RUN mkdir -p /var/run/kwil && chmod 777 /var/run/kwil 
-RUN apt update &&  apt install -y postgresql-client
+RUN apt update &&  apt install -y postgresql-client curl
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/dist/kwild ./kwild
 COPY --from=build /app/dist/kwil-admin ./kwil-admin

--- a/deployments/compose/kwil/docker-compose.yml
+++ b/deployments/compose/kwil/docker-compose.yml
@@ -71,7 +71,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10

--- a/test/acceptance/docker-compose-dev.yml
+++ b/test/acceptance/docker-compose-dev.yml
@@ -40,7 +40,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10

--- a/test/acceptance/docker-compose.yml
+++ b/test/acceptance/docker-compose.yml
@@ -38,7 +38,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10

--- a/test/integration/docker-compose-dev.yml
+++ b/test/integration/docker-compose-dev.yml
@@ -35,7 +35,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -97,7 +97,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -160,7 +160,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -225,7 +225,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -287,7 +287,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -349,7 +349,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10

--- a/test/integration/docker-compose-migration.yml.template
+++ b/test/integration/docker-compose-migration.yml.template
@@ -37,7 +37,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -101,7 +101,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -165,7 +165,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -232,7 +232,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10

--- a/test/integration/docker-compose.yml.template
+++ b/test/integration/docker-compose.yml.template
@@ -37,7 +37,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -101,7 +101,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -165,7 +165,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -232,7 +232,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -296,7 +296,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10
@@ -360,7 +360,7 @@ services:
       --app.pg-db-user=kwild
       --app.pg-db-pass=kwild
     healthcheck:
-      test: ["CMD-SHELL", "/app/kwil-cli utils chain-info"]
+      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s
       timeout: 6s
       retries: 10


### PR DESCRIPTION
This uses the new health check endpoints with CI to get a more meaningful idea of node container readiness.
This is an effort to resolve #967 