### PR TITLE
Cleanup snapshots, statesync and whitelist peers

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -79,7 +79,6 @@ var DefaultConfig = func() *commonConfig.KwildConfig {
 				RecurringHeight: 14400, // 1 day at 6s block time
 				MaxSnapshots:    3,
 				SnapshotDir:     "snapshots",
-				MaxRowSize:      4 * 1024 * 1024,
 			},
 			GenesisState: "",
 		},

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -119,7 +119,6 @@ var DefaultConfig = func() *commonConfig.KwildConfig {
 				SnapshotDir:         "rcvdSnaps",
 				DiscoveryTime:       commonConfig.Duration(15 * time.Second),
 				ChunkRequestTimeout: commonConfig.Duration(10 * time.Second),
-				TrustPeriod:         commonConfig.Duration(36000 * time.Second),
 			},
 			Consensus: &commonConfig.ConsensusConfig{
 				TimeoutPropose:   commonConfig.Duration(3 * time.Second),

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -80,7 +80,7 @@ var DefaultConfig = func() *commonConfig.KwildConfig {
 				MaxSnapshots:    3,
 				SnapshotDir:     "snapshots",
 			},
-			GenesisState: "",
+			GenesisState: "genesis-state.sql.gz",
 		},
 		Logging: &commonConfig.Logging{
 			Level:        "info",

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -80,7 +80,7 @@ var DefaultConfig = func() *commonConfig.KwildConfig {
 				MaxSnapshots:    3,
 				SnapshotDir:     "snapshots",
 			},
-			GenesisState: "genesis-state.sql.gz",
+			GenesisState: "",
 		},
 		Logging: &commonConfig.Logging{
 			Level:        "info",

--- a/cmd/kwil-admin/cmds/root.go
+++ b/cmd/kwil-admin/cmds/root.go
@@ -9,11 +9,11 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/key"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/migration"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/node"
-	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/peers"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/setup"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/snapshot"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/utils"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/validators"
+	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/whitelist"
 	"github.com/spf13/cobra"
 )
 
@@ -34,7 +34,7 @@ func NewRootCmd() *cobra.Command {
 		validators.NewValidatorsCmd(),
 		utils.NewUtilsCmd(),
 		snapshot.NewSnapshotCmd(),
-		peers.PeersCmd(),
+		whitelist.WhitelistCmd(),
 		migration.NewMigrationCmd(),
 	)
 

--- a/cmd/kwil-admin/cmds/setup/init.go
+++ b/cmd/kwil-admin/cmds/setup/init.go
@@ -66,6 +66,20 @@ func initCmd() *cobra.Command {
 			}
 			cfg.RootDir = expandedDir
 
+			// saves genesis state snapshot file in the root directory under the name "genesis_state.sql.gz"
+			if genesisState != "" {
+				if genesisState, err = common.ExpandPath(genesisState); err != nil {
+					return display.PrintErr(cmd, err)
+				}
+
+				stateFile := filepath.Join(expandedDir, config.GenesisStateFileName)
+				if err = copyFile(genesisState, stateFile); err != nil {
+					return display.PrintErr(cmd, err)
+				}
+
+				cfg.AppConfig.GenesisState = config.GenesisStateFileName
+			}
+
 			// saves config and private key files in the root directory
 			pub, err := nodecfg.GenerateNodeFiles(expandedDir, cfg, true)
 			if err != nil {
@@ -99,18 +113,6 @@ func initCmd() *cobra.Command {
 					if err = genesisCfg.SaveAs(genFile); err != nil {
 						return display.PrintErr(cmd, err)
 					}
-				}
-			}
-
-			// saves genesis state snapshot file in the root directory under the name "genesis_state.sql.gz"
-			if genesisState != "" {
-				if genesisState, err = common.ExpandPath(genesisState); err != nil {
-					return display.PrintErr(cmd, err)
-				}
-
-				stateFile := filepath.Join(expandedDir, config.GenesisStateFileName)
-				if err = copyFile(genesisState, stateFile); err != nil {
-					return display.PrintErr(cmd, err)
 				}
 			}
 

--- a/cmd/kwil-admin/cmds/setup/init.go
+++ b/cmd/kwil-admin/cmds/setup/init.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"errors"
 	"fmt"
+	"io"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -78,13 +79,7 @@ func initCmd() *cobra.Command {
 					return display.PrintErr(cmd, err)
 				}
 
-				file, err := os.ReadFile(genesisPath)
-				if err != nil {
-					return display.PrintErr(cmd, err)
-				}
-
-				err = os.WriteFile(genFile, file, 0644)
-				if err != nil {
+				if err = copyFile(genesisPath, genFile); err != nil {
 					return display.PrintErr(cmd, err)
 				}
 			} else {
@@ -113,14 +108,8 @@ func initCmd() *cobra.Command {
 					return display.PrintErr(cmd, err)
 				}
 
-				file, err := os.ReadFile(genesisState)
-				if err != nil {
-					return display.PrintErr(cmd, err)
-				}
-
 				stateFile := filepath.Join(expandedDir, config.GenesisStateFileName)
-				err = os.WriteFile(stateFile, file, 0644)
-				if err != nil {
+				if err = copyFile(genesisState, stateFile); err != nil {
 					return display.PrintErr(cmd, err)
 				}
 			}
@@ -182,4 +171,21 @@ func (a *AllocsFlag) Set(value string) error {
 
 func (a *AllocsFlag) Type() string {
 	return "allocFlag"
+}
+
+func copyFile(src, dst string) error {
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	_, err = io.Copy(out, in)
+	return err
 }

--- a/cmd/kwil-admin/cmds/snapshot/create.go
+++ b/cmd/kwil-admin/cmds/snapshot/create.go
@@ -84,7 +84,7 @@ func createCmd() *cobra.Command {
 	cmd.Flags().StringVar(&dbHost, "host", "localhost", "Host of the database")
 	cmd.Flags().StringVar(&dbPort, "port", "5432", "Port of the database")
 
-	// TODO: Deprecate below flags
+	// TODO: Remove below flags
 	cmd.Flags().IntVar(&maxRowSize, "max-row-size", 4*1024*1024, "Maximum row size to read from pg_dump (default: 4MB). Adjust this accordingly if you encounter 'bufio.Scanner: token too long' error.")
 	cmd.Flags().MarkDeprecated("max-row-size", "max-row-size has no more influence on the snapshot creation process. It is deprecated and will be removed in v0.10.0")
 	return cmd
@@ -211,7 +211,7 @@ func pgDump(ctx context.Context, dbName, dbUser, dbPass, dbHost, dbPort string, 
 		if inVotersBlock {
 			// Example voter: \\xdae5e91f74b95a9db05fc0f1f8c07f95	\\x9e52ff636caf4988e72e4ac865e6ef83a1e262d1a6376a300f3db8884e1f2253	1
 
-			if trimLine == "\\." { // End of voters block
+			if trimLine == `\.` { // End of voters block
 				inVotersBlock = false
 				n, err := multiWriter.Write([]byte(line)) // line includes the \n
 				if err != nil {
@@ -246,7 +246,7 @@ func pgDump(ctx context.Context, dbName, dbUser, dbPass, dbHost, dbPort string, 
 				continue
 			} else if strings.HasPrefix(trimLine, "--") { // Skip comments
 				continue
-			} else if !schemaStarted && (strings.HasPrefix(trimLine, "SET") || strings.HasPrefix(trimLine, "SELECT") || strings.HasPrefix(trimLine, "\\connect") || strings.HasPrefix(trimLine, "CREATE DATABASE")) {
+			} else if !schemaStarted && (strings.HasPrefix(trimLine, "SET") || strings.HasPrefix(trimLine, "SELECT") || strings.HasPrefix(trimLine, `\connect`) || strings.HasPrefix(trimLine, "CREATE DATABASE")) {
 				// Skip SET and SELECT and connect and create database statements
 				continue
 			} else {

--- a/cmd/kwil-admin/cmds/whitelist/add.go
+++ b/cmd/kwil-admin/cmds/whitelist/add.go
@@ -1,4 +1,4 @@
-package peers
+package whitelist
 
 import (
 	"context"
@@ -9,11 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func removeCmd() *cobra.Command {
+func addCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "remove <peerID>",
-		Short:   "Remove a peer from the node's whitelist peers and disconnect the peer",
-		Example: "kwil-admin peers remove <peerID>",
+		Use:     "add <peerID>",
+		Short:   "Add a peer to the node's whitelist peers to accept connections from.",
+		Example: "kwil-admin whitelist add <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -22,12 +22,12 @@ func removeCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			err = client.RemovePeer(ctx, args[0])
+			err = client.AddPeer(ctx, args[0])
 			if err != nil {
 				return display.PrintErr(cmd, err)
 			}
 
-			return display.PrintCmd(cmd, &removeMsg{peerID: args[0]})
+			return display.PrintCmd(cmd, &addMsg{peerID: args[0]})
 		},
 	}
 	common.BindRPCFlags(cmd)
@@ -35,16 +35,16 @@ func removeCmd() *cobra.Command {
 	return cmd
 }
 
-type removeMsg struct {
+type addMsg struct {
 	peerID string
 }
 
 var _ display.MsgFormatter = (*addMsg)(nil)
 
-func (a *removeMsg) MarshalText() ([]byte, error) {
-	return []byte("Removed peer " + a.peerID), nil
+func (a *addMsg) MarshalText() ([]byte, error) {
+	return []byte("Whitelisted peer " + a.peerID), nil
 }
 
-func (a *removeMsg) MarshalJSON() ([]byte, error) {
+func (a *addMsg) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.peerID)
 }

--- a/cmd/kwil-admin/cmds/whitelist/add.go
+++ b/cmd/kwil-admin/cmds/whitelist/add.go
@@ -12,7 +12,7 @@ import (
 func addCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "add <peerID>",
-		Short:   "Add a peer to the node's whitelist peers to accept connections from.",
+		Short:   "Add a peer to the node's whitelist of peers to accept connections from.",
 		Example: "kwil-admin whitelist add <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kwil-admin/cmds/whitelist/cmd.go
+++ b/cmd/kwil-admin/cmds/whitelist/cmd.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var peersCmd = &cobra.Command{
 	Use:   "whitelist",
-	Short: "manages the node's whitelist peers",
+	Short: "The whitelist command is used to manage a node's peer whitelist.",
 }
 
 func WhitelistCmd() *cobra.Command {

--- a/cmd/kwil-admin/cmds/whitelist/cmd.go
+++ b/cmd/kwil-admin/cmds/whitelist/cmd.go
@@ -1,14 +1,13 @@
-package peers
+package whitelist
 
 import "github.com/spf13/cobra"
 
 var peersCmd = &cobra.Command{
-	Use:     "peers",
-	Short:   "manages the node's peers",
-	Aliases: []string{"peer"},
+	Use:   "whitelist",
+	Short: "manages the node's whitelist peers",
 }
 
-func PeersCmd() *cobra.Command {
+func WhitelistCmd() *cobra.Command {
 	peersCmd.AddCommand(
 		addCmd(),
 		removeCmd(),

--- a/cmd/kwil-admin/cmds/whitelist/list.go
+++ b/cmd/kwil-admin/cmds/whitelist/list.go
@@ -13,7 +13,7 @@ import (
 func listCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "list",
-		Short:   "List all peers in the node's whitelist.",
+		Short:   "List the peers in the node's whitelist.",
 		Example: "kwil-admin whitelist list",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kwil-admin/cmds/whitelist/list.go
+++ b/cmd/kwil-admin/cmds/whitelist/list.go
@@ -1,4 +1,4 @@
-package peers
+package whitelist
 
 import (
 	"context"
@@ -14,7 +14,7 @@ func listCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "list",
 		Short:   "List all peers in the node's whitelist.",
-		Example: "kwil-admin peers list",
+		Example: "kwil-admin whitelist list",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -43,7 +43,7 @@ type listPeersMsg struct {
 var _ display.MsgFormatter = (*listPeersMsg)(nil)
 
 func (l *listPeersMsg) MarshalText() ([]byte, error) {
-	return []byte("Peers:  \n" + strings.Join(l.peers, "\n")), nil
+	return []byte("Whitelisted Peers:  \n" + strings.Join(l.peers, "\n")), nil
 }
 
 func (l *listPeersMsg) MarshalJSON() ([]byte, error) {

--- a/cmd/kwil-admin/cmds/whitelist/remove.go
+++ b/cmd/kwil-admin/cmds/whitelist/remove.go
@@ -12,7 +12,7 @@ import (
 func removeCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "remove <peerID>",
-		Short:   "Remove a peer from the node's whitelist peers and disconnect the peer",
+		Short:   "Remove a peer from the node's whitelist and disconnect it",
 		Example: "kwil-admin whitelist remove <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kwil-admin/cmds/whitelist/remove.go
+++ b/cmd/kwil-admin/cmds/whitelist/remove.go
@@ -12,7 +12,7 @@ import (
 func removeCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "remove <peerID>",
-		Short:   "Remove a peer from the node's whitelist and disconnect it",
+		Short:   "Remove a peer from the node's whitelist and disconnect it.",
 		Example: "kwil-admin whitelist remove <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/kwil-admin/cmds/whitelist/remove.go
+++ b/cmd/kwil-admin/cmds/whitelist/remove.go
@@ -1,4 +1,4 @@
-package peers
+package whitelist
 
 import (
 	"context"
@@ -9,11 +9,11 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func addCmd() *cobra.Command {
+func removeCmd() *cobra.Command {
 	var cmd = &cobra.Command{
-		Use:     "add <peerID>",
-		Short:   "Add a peer to the node's whitelist peers to accept connections from",
-		Example: "kwil-admin peers add <peerID>",
+		Use:     "remove <peerID>",
+		Short:   "Remove a peer from the node's whitelist peers and disconnect the peer",
+		Example: "kwil-admin whitelist remove <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
@@ -22,12 +22,12 @@ func addCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			err = client.AddPeer(ctx, args[0])
+			err = client.RemovePeer(ctx, args[0])
 			if err != nil {
 				return display.PrintErr(cmd, err)
 			}
 
-			return display.PrintCmd(cmd, &addMsg{peerID: args[0]})
+			return display.PrintCmd(cmd, &removeMsg{peerID: args[0]})
 		},
 	}
 	common.BindRPCFlags(cmd)
@@ -35,16 +35,16 @@ func addCmd() *cobra.Command {
 	return cmd
 }
 
-type addMsg struct {
+type removeMsg struct {
 	peerID string
 }
 
 var _ display.MsgFormatter = (*addMsg)(nil)
 
-func (a *addMsg) MarshalText() ([]byte, error) {
-	return []byte("Added peer " + a.peerID), nil
+func (a *removeMsg) MarshalText() ([]byte, error) {
+	return []byte("Removed peer " + a.peerID), nil
 }
 
-func (a *addMsg) MarshalJSON() ([]byte, error) {
+func (a *removeMsg) MarshalJSON() ([]byte, error) {
 	return json.Marshal(a.peerID)
 }

--- a/cmd/kwild/config/folders.go
+++ b/cmd/kwild/config/folders.go
@@ -14,5 +14,7 @@ const (
 	MigrationsDirName = "migrations"
 	ChangesetsDirName = "changesets"
 	ChunksDirName     = "chunks"
+
+	GenesisStateFileName = "genesis-state.sql.gz"
 	// Note that the sqlLite file path is user-configurable e.g. "data/kwil.db"
 )

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -13,7 +13,6 @@ import (
 	"net"
 	neturl "net/url"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -363,15 +362,15 @@ func (c *closeFuncs) closeAll() error {
 }
 
 func verifyDependencies(d *coreDependencies) {
-	// Check if pg_dump is installed, which is necessary for snapshotting during migrations and when snapshots are enabled
-	if _, err := exec.LookPath("pg_dump"); err != nil {
-		failBuild(err, "pg_dump is not installed. Please install it to use snapshots or migrations.")
+	// Check if pg_dump is installed, which is necessary for snapshotting during migrations and when snapshots are enabled. Ensure that the version is 16.x
+	if err := checkVersion("pg_dump", 16); err != nil {
+		failBuild(err, "pg_dump version is not 16.x. Please install the correct version.")
 	}
 
 	if d.cfg.ChainConfig.StateSync.Enable {
-		// Check if psql is installed, which is required for state-sync
-		if _, err := exec.LookPath("psql"); err != nil {
-			failBuild(err, "psql is not installed. Please install it to use statesync.")
+		// Check if psql is installed and is on version 16.x, which is required for state-sync
+		if err := checkVersion("psql", 16); err != nil {
+			failBuild(err, "psql version is not 16.x. Please install the correct version.")
 		}
 	}
 }

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -661,7 +661,7 @@ func restoreDB(d *coreDependencies) bool {
 	// Snapshot file exists
 	snapFile, err := os.Open(appCfg.GenesisState)
 	if err != nil {
-		failBuild(err, "failed to open snapshot file")
+		failBuild(err, "failed to open genesis state file")
 	}
 
 	// Check if the snapshot file is compressed, if yes decompress it

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -513,7 +513,6 @@ func buildMigrator(d *coreDependencies, db *pg.DB, txApp *txapp.TxApp) *migratio
 		SnapshotDir:     filepath.Join(migrationsDir, cmd.DefaultConfig().AppConfig.Snapshots.SnapshotDir),
 		RecurringHeight: 0,
 		MaxSnapshots:    1, // only one snapshot is needed for network migrations, taken at the activation height
-		MaxRowSize:      cfg.Snapshots.MaxRowSize,
 	}
 
 	ss, err := statesync.NewSnapshotStore(snapshotCfg, dbCfg, *d.log.Named("migrations-snapshots"))
@@ -752,7 +751,6 @@ func buildSnapshotter(d *coreDependencies) *statesync.SnapshotStore {
 		SnapshotDir:     cfg.Snapshots.SnapshotDir,
 		RecurringHeight: cfg.Snapshots.RecurringHeight,
 		MaxSnapshots:    int(cfg.Snapshots.MaxSnapshots),
-		MaxRowSize:      cfg.Snapshots.MaxRowSize,
 	}
 
 	ss, err := statesync.NewSnapshotStore(snapshotCfg, dbCfg, *d.log.Named("snapshot-store"))

--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -105,9 +105,7 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 	nodeCfg.StateSync.ChunkRequestTimeout = time.Duration(userChainCfg.StateSync.ChunkRequestTimeout)
 
 	// Light client verification
-	nodeCfg.StateSync.TrustHash = userChainCfg.StateSync.TrustHash
-	nodeCfg.StateSync.TrustHeight = userChainCfg.StateSync.TrustHeight
-	nodeCfg.StateSync.TrustPeriod = time.Duration(userChainCfg.StateSync.TrustPeriod)
+	nodeCfg.StateSync.TrustPeriod = time.Duration(36000 * time.Second)
 
 	// Standardize the paths.
 	nodeCfg.DBPath = cometbft.DataDir // i.e. "data", we do not allow users to change

--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -105,7 +105,7 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 	nodeCfg.StateSync.ChunkRequestTimeout = time.Duration(userChainCfg.StateSync.ChunkRequestTimeout)
 
 	// Light client verification
-	nodeCfg.StateSync.TrustPeriod = time.Duration(36000 * time.Second)
+	nodeCfg.StateSync.TrustPeriod = 36000 * time.Second // 10 hours (6s block time)
 
 	// Standardize the paths.
 	nodeCfg.DBPath = cometbft.DataDir // i.e. "data", we do not allow users to change

--- a/cmd/kwild/server/cometbft_test.go
+++ b/cmd/kwild/server/cometbft_test.go
@@ -2,6 +2,8 @@ package server
 
 import (
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func Test_cleanListenAddr(t *testing.T) {
@@ -67,6 +69,60 @@ func Test_cleanListenAddr(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := cleanListenAddr(tt.args.addr, tt.args.defaultPort); got != tt.want {
 				t.Errorf("cleanListenAddr() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_getPGVersion(t *testing.T) {
+	tests := []struct {
+		name           string
+		versionOutput  string
+		expectedMajor  int
+		expectedMinor  int
+		expectedErrMsg string
+	}{
+		{
+			name:          "Valid version string",
+			versionOutput: "psql (PostgreSQL) 14.5",
+			expectedMajor: 14,
+			expectedMinor: 5,
+		},
+		{
+			name:          "Valid version string with patch",
+			versionOutput: "psql (PostgreSQL) 13.2.1",
+			expectedMajor: 13,
+			expectedMinor: 2,
+		},
+		{
+			name:           "Invalid version string",
+			versionOutput:  "psql (PostgreSQL) invalid",
+			expectedErrMsg: "could not find a valid version in output: psql (PostgreSQL) invalid",
+		},
+		{
+			name:           "Empty version string",
+			versionOutput:  "",
+			expectedErrMsg: "could not find a valid version in output: ",
+		},
+		{
+			name:          "Version with extra information",
+			versionOutput: "psql (PostgreSQL) 15.3 (Debian 15.3-1.pgdg110+1)",
+			expectedMajor: 15,
+			expectedMinor: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			major, minor, err := getPGVersion(tt.versionOutput)
+
+			if tt.expectedErrMsg != "" {
+				assert.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedErrMsg)
+			} else {
+				assert.NoError(t, err)
+				assert.Equal(t, tt.expectedMajor, major)
+				assert.Equal(t, tt.expectedMinor, minor)
 			}
 		})
 	}

--- a/cmd/kwild/server/cometbft_test.go
+++ b/cmd/kwild/server/cometbft_test.go
@@ -1,6 +1,8 @@
 package server
 
-import "testing"
+import (
+	"testing"
+)
 
 func Test_cleanListenAddr(t *testing.T) {
 	type args struct {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -92,7 +92,6 @@ type SnapshotConfig struct {
 	RecurringHeight uint64 `mapstructure:"recurring_height"`
 	MaxSnapshots    uint64 `mapstructure:"max_snapshots"`
 	SnapshotDir     string `mapstructure:"snapshot_dir"`
-	MaxRowSize      int    `mapstructure:"max_row_size"`
 }
 
 type ChainRPCConfig struct {

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -193,12 +193,6 @@ type StateSyncConfig struct {
 	// The timeout duration before re-requesting a chunk, possibly from a different
 	// peer (default: 1 minute).
 	ChunkRequestTimeout Duration `mapstructure:"chunk_request_timeout"`
-
-	// Light client verification options, Automatically fetched from the RPC Servers
-	// during the node initialization.
-	TrustHeight int64
-	TrustHash   string
-	TrustPeriod Duration
 }
 
 type ChainConfig struct {

--- a/internal/statesync/snapshotter.go
+++ b/internal/statesync/snapshotter.go
@@ -233,7 +233,7 @@ func (s *Snapshotter) sanitizeDump(height uint64, format uint32) ([]byte, error)
 				3 entry3
 				\.
 			*/
-			if trimLine == "\\." { // end of COPY block
+			if trimLine == `\.` { // end of COPY block
 				inCopyBlock = false
 
 				// Inline sort the lineHashes array based on the row hash
@@ -302,7 +302,7 @@ func (s *Snapshotter) sanitizeDump(height uint64, format uint32) ([]byte, error)
 					return nil, fmt.Errorf("failed to write to sanitized dump file: %w", err)
 				}
 			} else if !schemaStarted && (strings.HasPrefix(trimLine, "SET") || strings.HasPrefix(trimLine, "SELECT") ||
-				strings.HasPrefix(trimLine, "\\connect") || strings.HasPrefix(trimLine, "CREATE DATABASE")) {
+				strings.HasPrefix(trimLine, `\connect`) || strings.HasPrefix(trimLine, "CREATE DATABASE")) {
 				// skip any SET, SELECT, CREATE DATABASE and connect statements that appear before the schema definition
 				// These are postgres specific commands that should not be included in the snapshot
 				continue

--- a/internal/statesync/snapshotter_test.go
+++ b/internal/statesync/snapshotter_test.go
@@ -14,14 +14,13 @@ import (
 const (
 	dump1File = "test_data/dump1.sql"
 	dump2File = "test_data/dump2.sql"
-	tokenSize = 64 * 1024 // 64KB
 )
 
 func TestSanitizeLogicalDump(t *testing.T) {
 	dir := t.TempDir()
 	logger := log.NewStdOut(log.DebugLevel)
 	// Create a snapshotter
-	snapshotter := NewSnapshotter(nil, dir, tokenSize, logger)
+	snapshotter := NewSnapshotter(nil, dir, logger)
 
 	// Create snapshot directory
 	height := uint64(1)

--- a/internal/statesync/store.go
+++ b/internal/statesync/store.go
@@ -57,7 +57,6 @@ type SnapshotConfig struct {
 	SnapshotDir     string
 	MaxSnapshots    int
 	RecurringHeight uint64
-	MaxRowSize      int
 }
 
 type SnapshotStore struct {
@@ -81,7 +80,7 @@ type DBSnapshotter interface {
 }
 
 func NewSnapshotStore(cfg *SnapshotConfig, dbCfg *DBConfig, logger log.Logger) (*SnapshotStore, error) {
-	snapshotter := NewSnapshotter(dbCfg, cfg.SnapshotDir, cfg.MaxRowSize, logger)
+	snapshotter := NewSnapshotter(dbCfg, cfg.SnapshotDir, logger)
 	ss := &SnapshotStore{
 		cfg:         cfg,
 		snapshots:   make(map[uint64]*Snapshot),

--- a/test/driver/operator/cli_driver.go
+++ b/test/driver/operator/cli_driver.go
@@ -138,17 +138,17 @@ func (o *OperatorCLIDriver) ValidatorsList(ctx context.Context) ([]*types.Valida
 
 func (o *OperatorCLIDriver) AddPeer(ctx context.Context, peerID string) error {
 	var peer string
-	return o.runCommand(ctx, &peer, "peers", "add", peerID)
+	return o.runCommand(ctx, &peer, "whitelist", "add", peerID)
 }
 
 func (o *OperatorCLIDriver) RemovePeer(ctx context.Context, peerID string) error {
 	var peer string
-	return o.runCommand(ctx, &peer, "peers", "remove", peerID)
+	return o.runCommand(ctx, &peer, "whitelist", "remove", peerID)
 }
 
 func (o *OperatorCLIDriver) ListPeers(ctx context.Context) ([]string, error) {
 	var res []string
-	err := o.runCommand(ctx, &res, "peers", "list")
+	err := o.runCommand(ctx, &res, "whitelist", "list")
 	if err != nil {
 		return nil, err
 	}

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -100,12 +100,18 @@ func TestKwildDatabaseIntegration(t *testing.T) {
 			specifications.DatabaseVerifySpecification(ctx, t, node2Driver, true)
 
 			specifications.ExecuteDBInsertSpecification(ctx, t, node0Driver)
+
+			// restart node1 and ensure that the app state is synced
+			helper.RestartNode(ctx, "node1", 15*time.Second)
+			node1Driver = helper.GetUserDriver(ctx, "node1", driverType, nil)
+
 			specifications.ExecuteDBUpdateSpecification(ctx, t, node1Driver)
 			specifications.ExecuteDBDeleteSpecification(ctx, t, node2Driver)
 
 			// specifications.ExecutePermissionedActionSpecification(ctx, t, invalidUserDriver)
 
 			specifications.DatabaseDropSpecification(ctx, t, node1Driver)
+
 		})
 	}
 }


### PR DESCRIPTION
- Remove max-row-size config and update snapshot creation process to handle any row data sizes
- unexpose(removed) trust options in the statesync config as they are not user configurable. 
- Rename `kwil-admin peers` to `kwil-admin whitelist`