### PR TITLE
minor documentation updates, config name changes

### DIFF
--- a/cmd/kwil-admin/cmds/setup/init.go
+++ b/cmd/kwil-admin/cmds/setup/init.go
@@ -120,14 +120,14 @@ func initCmd() *cobra.Command {
 	config.AddConfigFlags(cmd1.Flags(), cfg)
 
 	// TODO: deprecate below flags in v0.10.0
-	cmd1.Flags().StringVarP(&out, "output-dir", "o", "./.testnet", "generated node parent directory. To be deprecated in v0.10.0, until then --root-dir is ignored")
-	err := cmd1.Flags().MarkDeprecated("output-dir", "use --cfg.root-dir instead from v0.10.0")
+	cmd1.Flags().StringVarP(&out, "output-dir", "o", "./.testnet", "generated node parent directory")
+	err := cmd1.Flags().MarkDeprecated("output-dir", "use --root-dir instead")
 	if err != nil {
 		panic(err)
 	}
 
-	cmd1.Flags().DurationVarP(&blockInterval, "block-interval", "i", 6*time.Second, "shortest block interval in seconds. To be deprecated in v0.10.0")
-	err = cmd1.Flags().MarkDeprecated("block-interval", "use --chain.consensus.timeout-commit instead from v0.10.0")
+	cmd1.Flags().DurationVarP(&blockInterval, "block-interval", "i", 6*time.Second, "shortest block interval in seconds")
+	err = cmd1.Flags().MarkDeprecated("block-interval", "use --chain.consensus.timeout-commit instead")
 	if err != nil {
 		panic(err)
 	}

--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -125,7 +125,7 @@ rpc_timeout = "{{ .AppConfig.RPCTimeout }}"
 db_read_timeout = "{{ .AppConfig.ReadTxTimeout }}"
 
 # RPC request size limit in bytes
-rpc_req_limit = {{ .AppConfig.RPCMaxReqSize }}
+rpc_max_req_size = {{ .AppConfig.RPCMaxReqSize }}
 
 # Enforce data privacy: authenticate JSON-RPC call requests using challenge-based
 # authentication. the node will only accept JSON-RPC requests that has a valid signed

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -142,6 +142,15 @@ func GetCfg(flagCfg *config.KwildConfig) (*config.KwildConfig, bool, error) {
 
 	cfg.AppConfig.JSONRPCListenAddress = cleanListenAddr(cfg.AppConfig.JSONRPCListenAddress, defaultListenJSONRPC)
 
+	// handling deprecation of configs:
+	if cfg.AppConfig.DEPRECATED_RPCReqLimit != 0 {
+		if cfg.AppConfig.RPCMaxReqSize != cmd.DefaultConfig().AppConfig.RPCMaxReqSize {
+			return nil, false, fmt.Errorf("cannot set both deprecated rpc request limit and rpc max request size")
+		}
+		cfg.AppConfig.RPCMaxReqSize = cfg.AppConfig.DEPRECATED_RPCReqLimit
+		fmt.Println("WARNING: app.rpc_req_limit is deprecated and will be removed in Kwil v0.10. use app.rpc_max_req_size instead")
+	}
+
 	return cfg, configFileExists, nil
 }
 

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -41,7 +41,7 @@ rpc_timeout = "45s"
 db_read_timeout = "5s"
 
 # RPC request size limit in bytes
-rpc_req_limit = 4200000
+rpc_max_req_size = 4200000
 
 # Enforce data privacy: authenticate JSON-RPC call requests using challenge-based
 # authentication. the node will only accept JSON-RPC requests that has a valid signed

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -51,6 +51,9 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 
 	flagSet.Var(&cfg.AppConfig.RPCTimeout, "app.rpc-timeout", "timeout for RPC requests (through reading the request, handling the request, and sending the response)")
 	flagSet.IntVar(&cfg.AppConfig.RPCMaxReqSize, "app.max-req-size", cfg.AppConfig.RPCMaxReqSize, "RPC request size limit")
+	flagSet.IntVar(&cfg.AppConfig.RPCMaxReqSize, "app.rpc-req-limit", cfg.AppConfig.RPCMaxReqSize, "RPC request size limit")
+	flagSet.MarkDeprecated("app.rpc-req-limit", "use --app.max-req-size instead")
+
 	flagSet.Var(&cfg.AppConfig.ReadTxTimeout, "app.db-read-timeout", "timeout for database reads initiated by RPC requests")
 
 	// Extension endpoints flags

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -50,9 +50,9 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 	flagSet.StringVar(&cfg.AppConfig.ProfileFile, "app.profile-file", cfg.AppConfig.ProfileFile, format("%s profile output file path (e.g. cpu.pprof)"))
 
 	flagSet.Var(&cfg.AppConfig.RPCTimeout, "app.rpc-timeout", "timeout for RPC requests (through reading the request, handling the request, and sending the response)")
-	flagSet.IntVar(&cfg.AppConfig.RPCMaxReqSize, "app.max-req-size", cfg.AppConfig.RPCMaxReqSize, "RPC request size limit")
-	flagSet.IntVar(&cfg.AppConfig.RPCMaxReqSize, "app.rpc-req-limit", cfg.AppConfig.RPCMaxReqSize, "RPC request size limit")
-	flagSet.MarkDeprecated("app.rpc-req-limit", "use --app.max-req-size instead")
+	flagSet.IntVar(&cfg.AppConfig.RPCMaxReqSize, "app.rpc-max-req-size", cfg.AppConfig.RPCMaxReqSize, "RPC request size limit")
+	flagSet.IntVar(&cfg.AppConfig.DEPRECATED_RPCReqLimit, "app.rpc-req-limit", cfg.AppConfig.DEPRECATED_RPCReqLimit, "RPC request size limit")
+	flagSet.MarkDeprecated("app.rpc-req-limit", "use --app.rpc-max-req-size instead")
 
 	flagSet.Var(&cfg.AppConfig.ReadTxTimeout, "app.db-read-timeout", "timeout for database reads initiated by RPC requests")
 

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -19,7 +19,7 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 	// logging
 	flagSet.StringVarP(&cfg.Logging.Level, "log.level", "l", cfg.Logging.Level, format("%s log level"))
 	flagSet.StringVar(&cfg.Logging.RPCLevel, "log.rpc-level", cfg.Logging.RPCLevel, "user rpc server log level")
-	flagSet.StringVar(&cfg.Logging.ConsensusLevel, "log.consensus_level", cfg.Logging.ConsensusLevel, "consensus (cometbft) log level")
+	flagSet.StringVar(&cfg.Logging.ConsensusLevel, "log.consensus-level", cfg.Logging.ConsensusLevel, "consensus (cometbft) log level")
 	flagSet.StringVar(&cfg.Logging.DBLevel, "log.db-level", cfg.Logging.DBLevel, "database backend (postgres) log level")
 	flagSet.StringVar(&cfg.Logging.Format, "log.format", cfg.Logging.Format, format("%s log format"))
 	flagSet.StringVar(&cfg.Logging.TimeEncoding, "log.time-format", cfg.Logging.TimeEncoding, format("%s time log format"))
@@ -50,7 +50,7 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 	flagSet.StringVar(&cfg.AppConfig.ProfileFile, "app.profile-file", cfg.AppConfig.ProfileFile, format("%s profile output file path (e.g. cpu.pprof)"))
 
 	flagSet.Var(&cfg.AppConfig.RPCTimeout, "app.rpc-timeout", "timeout for RPC requests (through reading the request, handling the request, and sending the response)")
-	flagSet.IntVar(&cfg.AppConfig.RPCMaxReqSize, "app.rpc-req-limit", cfg.AppConfig.RPCMaxReqSize, "RPC request size limit")
+	flagSet.IntVar(&cfg.AppConfig.RPCMaxReqSize, "app.max-req-size", cfg.AppConfig.RPCMaxReqSize, "RPC request size limit")
 	flagSet.Var(&cfg.AppConfig.ReadTxTimeout, "app.db-read-timeout", "timeout for database reads initiated by RPC requests")
 
 	// Extension endpoints flags
@@ -86,6 +86,8 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 	flagSet.BoolVar(&cfg.ChainConfig.P2P.SeedMode, "chain.p2p.seed-mode", cfg.ChainConfig.P2P.SeedMode, format(`Run %s in a special "seed" mode where it crawls the network for peer addresses,
 sharing them with incoming peers before immediately disconnecting. It is recommended
 to instead run a dedicated seeder like https://github.com/kwilteam/cometseed.`))
+	flagSet.Var(&cfg.ChainConfig.P2P.HandshakeTimeout, "chain.p2p.handshake-timeout", "Chain P2P handshake timeout")
+	flagSet.Var(&cfg.ChainConfig.P2P.DialTimeout, "chain.p2p.dial-timeout", "Chain P2P dial timeout")
 
 	// Network flags
 	flagSet.BoolVarP(&cfg.ChainConfig.P2P.PrivateMode, "chain.p2p.private-mode", "p", cfg.ChainConfig.P2P.PrivateMode, "Run the node in private mode. In private mode, the connectivity to the node is restricted to the current validators and whitelist peers.")

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -44,7 +44,7 @@ rpc_timeout = "45s"
 db_read_timeout = "5s"
 
 # RPC request size limit in bytes
-rpc_req_limit = 4200000
+rpc_max_req_size = 4200000
 
 # Enforce data privacy: authenticate JSON-RPC call requests using challenge-based
 # authentication. the node will only accept JSON-RPC requests that has a valid signed

--- a/common/common.go
+++ b/common/common.go
@@ -73,6 +73,8 @@ type TxContext struct {
 	Authenticator string
 }
 
+// Engine is an interface for the main database engine that is responsible for deploying
+// and executing Kuneiform datasets.
 type Engine interface {
 	SchemaGetter
 	// CreateDataset deploys a new dataset from a schema.
@@ -95,6 +97,7 @@ type Engine interface {
 	Reload(ctx context.Context, tx sql.Executor) error
 }
 
+// SchemaGetter is an interface for getting the schema of a dataset.
 type SchemaGetter interface {
 	// GetSchema returns the schema of a dataset.
 	// It will return an error if the dataset does not exist.

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -61,7 +61,7 @@ type AppConfig struct {
 	DBName string `mapstructure:"pg_db_name"`
 
 	RPCTimeout         Duration                     `mapstructure:"rpc_timeout"`
-	RPCMaxReqSize      int                          `mapstructure:"rpc_req_limit"`
+	RPCMaxReqSize      int                          `mapstructure:"max_req_size"`
 	PrivateRPC         bool                         `mapstructure:"private_rpc"`
 	ChallengeExpiry    Duration                     `mapstructure:"challenge_expiry"`
 	ChallengeRateLimit float64                      `mapstructure:"challenge_rate_limit"`

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -60,21 +60,23 @@ type AppConfig struct {
 	DBPass string `mapstructure:"pg_db_pass"`
 	DBName string `mapstructure:"pg_db_name"`
 
-	RPCTimeout         Duration                     `mapstructure:"rpc_timeout"`
-	RPCMaxReqSize      int                          `mapstructure:"max_req_size"`
-	PrivateRPC         bool                         `mapstructure:"private_rpc"`
-	ChallengeExpiry    Duration                     `mapstructure:"challenge_expiry"`
-	ChallengeRateLimit float64                      `mapstructure:"challenge_rate_limit"`
-	ReadTxTimeout      Duration                     `mapstructure:"db_read_timeout"`
-	ExtensionEndpoints []string                     `mapstructure:"extension_endpoints"`
-	AdminRPCPass       string                       `mapstructure:"admin_pass"`
-	NoTLS              bool                         `mapstructure:"admin_notls"`
-	TLSCertFile        string                       `mapstructure:"tls_cert_file"`
-	TLSKeyFile         string                       `mapstructure:"tls_key_file"`
-	Hostname           string                       `mapstructure:"hostname"`
-	ProfileMode        string                       `mapstructure:"profile_mode"`
-	ProfileFile        string                       `mapstructure:"profile_file"`
-	Extensions         map[string]map[string]string `mapstructure:"extensions"`
+	RPCTimeout    Duration `mapstructure:"rpc_timeout"`
+	RPCMaxReqSize int      `mapstructure:"rpc_max_req_size"`
+	// TODO: remove DEPRECATED_RPCReqLimit in v0.10
+	DEPRECATED_RPCReqLimit int                          `mapstructure:"rpc_req_limit"` // DEPRECATED: use RPCMaxReqSize
+	PrivateRPC             bool                         `mapstructure:"private_rpc"`
+	ChallengeExpiry        Duration                     `mapstructure:"challenge_expiry"`
+	ChallengeRateLimit     float64                      `mapstructure:"challenge_rate_limit"`
+	ReadTxTimeout          Duration                     `mapstructure:"db_read_timeout"`
+	ExtensionEndpoints     []string                     `mapstructure:"extension_endpoints"`
+	AdminRPCPass           string                       `mapstructure:"admin_pass"`
+	NoTLS                  bool                         `mapstructure:"admin_notls"`
+	TLSCertFile            string                       `mapstructure:"tls_cert_file"`
+	TLSKeyFile             string                       `mapstructure:"tls_key_file"`
+	Hostname               string                       `mapstructure:"hostname"`
+	ProfileMode            string                       `mapstructure:"profile_mode"`
+	ProfileFile            string                       `mapstructure:"profile_file"`
+	Extensions             map[string]map[string]string `mapstructure:"extensions"`
 
 	Snapshots SnapshotConfig `mapstructure:"snapshots"`
 

--- a/common/context.go
+++ b/common/context.go
@@ -35,6 +35,8 @@ type BlockContext struct {
 // MigrationContext provides context for all migration operations.
 // Fields in MigrationContext should never be mutated till the migration is completed.
 type MigrationContext struct {
+	// StartHeight is the height of the first block to start migration.
 	StartHeight int64
-	EndHeight   int64
+	// EndHeight is the height of the last block to end migration.
+	EndHeight int64
 }


### PR DESCRIPTION
While going through the docs, some commands or documentation that I don't like or are incorrect I am making minor changes to. Still WIP.

# Notable Changes

## New flags

I've added a few new flags for configs that were set-able via `config.toml`, but not with flags.
- `--chain.p2p.dial-timeout` flag
- `--chain.p2p.handshake-timeout` flag

I've also fixed the `--log.consensus-level` flag, which previously used an underscore.

## Config Rename

I renamed the `app.rpc-req-limit` config because I felt that it was terribly confusing. The name makes me think that there is some configurable limit to the requests that the RPC can process, but in reality, it is a max request size config. I renamed it to `app.max-req-size`, and have deprecated the old one.