### PR TITLE
ci: non-overlapping net for gh actions

### DIFF
--- a/test/go.mod
+++ b/test/go.mod
@@ -12,6 +12,7 @@ replace (
 
 require (
 	github.com/cometbft/cometbft v0.38.12
+	github.com/docker/docker v26.1.5+incompatible
 	github.com/docker/go-connections v0.5.0
 	github.com/drhodes/golorem v0.0.0-20220328165741-da82e5b29246
 	github.com/ethereum/go-ethereum v1.14.8
@@ -91,7 +92,6 @@ require (
 	github.com/docker/cli v26.1.2+incompatible // indirect
 	github.com/docker/compose/v2 v2.27.0 // indirect
 	github.com/docker/distribution v2.8.3+incompatible // indirect
-	github.com/docker/docker v26.1.5+incompatible // indirect
 	github.com/docker/docker-credential-helpers v0.8.1 // indirect
 	github.com/docker/go v1.5.1-1.0.20160303222718-d30aec9fd63c // indirect
 	github.com/docker/go-metrics v0.0.1 // indirect

--- a/test/utils/container.go
+++ b/test/utils/container.go
@@ -17,7 +17,6 @@ func EnsureNetworkExist(ctx context.Context, testName string) (
 	net, err := network.New(ctx,
 		network.WithCheckDuplicate(),
 		network.WithAttachable(),
-		network.WithEnableIPv6(),
 		network.WithIPAM(&dockerNet.IPAM{
 			Driver:  "default",
 			Options: map[string]string{},

--- a/test/utils/container.go
+++ b/test/utils/container.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	dockerNet "github.com/docker/docker/api/types/network"
 	"github.com/docker/go-connections/nat"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/network"
@@ -16,6 +17,16 @@ func EnsureNetworkExist(ctx context.Context, testName string) (
 	net, err := network.New(ctx,
 		network.WithCheckDuplicate(),
 		network.WithAttachable(),
+		network.WithEnableIPv6(),
+		network.WithIPAM(&dockerNet.IPAM{
+			Driver:  "default",
+			Options: map[string]string{},
+			Config: []dockerNet.IPAMConfig{
+				{
+					Subnet: "10.9.0.0/16",
+				},
+			},
+		}),
 		//network.WithInternal(), // we need to expose the network to the host
 		network.WithLabels(map[string]string{"test": "integration"}),
 		network.WithDriver("bridge"),


### PR DESCRIPTION
@Yaiba had the idea that perhaps the integration test's network needs to be different, in particular, not overlapping with the subnet used by the github actions environment