### PR TITLE
config: 1 week join expiry default

### DIFF
--- a/cmd/kwil-admin/cmds/setup/init.go
+++ b/cmd/kwil-admin/cmds/setup/init.go
@@ -123,7 +123,7 @@ func initCmd() *cobra.Command {
 	// genesis.json flags
 	cmd1.Flags().StringVarP(&genesisPath, "genesis", "g", "", "path to genesis file")
 	cmd1.Flags().StringVar(&chainId, "chain-id", "", "chain ID to use for the genesis file")
-	cmd1.Flags().Int64Var(&joinExpiry, "join-expiry", 14400, "number of blocks before a join request expires")
+	cmd1.Flags().Int64Var(&joinExpiry, "join-expiry", 100800, "number of blocks before a join request expires")
 	cmd1.Flags().BoolVar(&withGas, "gas", false, "enable gas")
 	cmd1.Flags().Var(&allocs, "alloc", "account=amount pairs of genesis account allocations")
 	cmd1.Flags().StringVarP(&genesisState, "genesis-state", "s", "", "path to genesis state snapshot file")

--- a/cmd/kwil-admin/cmds/setup/testnet.go
+++ b/cmd/kwil-admin/cmds/setup/testnet.go
@@ -90,7 +90,7 @@ func testnetCmd() *cobra.Command {
 	cmd.Flags().StringSliceVar(&hostnames, "hostnames", []string{}, "override all hostnames of the nodes (list of hostnames must be the same length as the number of nodes)")
 	cmd.Flags().IntVarP(&p2pPort, "p2p-port", "p", 26656, "p2p port for nodes")
 	cmd.Flags().DurationVarP(&blockInterval, "block-interval", "i", 6*time.Second, "shortest block interval in seconds")
-	cmd.Flags().Int64Var(&joinExpiry, "join-expiry", 14400, "number of blocks before a join request expires")
+	cmd.Flags().Int64Var(&joinExpiry, "join-expiry", 100800, "number of blocks before a join request expires")
 	cmd.Flags().IntVarP(&validatorAmount, "validators", "v", 3, "number of validators to generate")
 	cmd.Flags().IntVarP(&nonValidatorAmount, "non-validators", "n", 0, "number of non-validators to generate")
 	cmd.Flags().BoolVar(&withGas, "gas", false, "enable gas")

--- a/common/chain/chaincfg.go
+++ b/common/chain/chaincfg.go
@@ -155,7 +155,7 @@ func defaultConsensusParams() *ConsensusParams {
 			},
 			Validator: ValidatorParams{
 				PubKeyTypes: []string{abciPubKeyTypeEd25519},
-				JoinExpiry:  14400, // approx 1 day considering block rate of 6 sec/blk
+				JoinExpiry:  100800, // approx 1 week considering block rate of 6 sec/blk
 			},
 			Votes: VoteParams{
 				VoteExpiry:    14400, // approx 1 day considering block rate of 6 sec/blk


### PR DESCRIPTION
The default validator join expiry of 1 day turned out to be too short in practice.  This increases it to 1 week (100800 blocks of 6 second blocks by default).