### PR TITLE
add prometheus metrics server and config

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -92,6 +92,11 @@ var DefaultConfig = func() *commonConfig.KwildConfig {
 			MaxLogSizeKB: 100_000, // 100 MB uncompressed threshold
 			MaxLogRolls:  0,       // the zero value means retain all (don't delete oldest archived logs)
 		},
+		Instrumentation: &commonConfig.InstrumentationConfig{
+			Prometheus:     false,
+			PromListenAddr: "0.0.0.0:26660",
+			MaxConnections: 1,
+		},
 
 		ChainConfig: &commonConfig.ChainConfig{
 			P2P: &commonConfig.P2PConfig{

--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -365,27 +365,28 @@ func DefaultEmptyConfig() *config.KwildConfig {
 			StateSync: &config.StateSyncConfig{},
 			Consensus: &config.ConsensusConfig{},
 		},
-		Logging: &config.Logging{},
+		Logging:         &config.Logging{},
+		Instrumentation: &config.InstrumentationConfig{},
 	}
 }
 
-// EmptyConfig returns a config with all fields set to their zero values.
-// This is useful for guaranteeing that all fields are set when merging
+// EmptyConfig returns a config with all fields set to their zero values (except
+// no nil pointers for the sub-sections structs). This is useful for
+// guaranteeing that all fields are set when merging.
 func EmptyConfig() *config.KwildConfig {
 	return &config.KwildConfig{
 		AppConfig: &config.AppConfig{
 			ExtensionEndpoints: []string{},
 		},
 		ChainConfig: &config.ChainConfig{
-			P2P:     &config.P2PConfig{},
-			RPC:     &config.ChainRPCConfig{},
-			Mempool: &config.MempoolConfig{},
-			StateSync: &config.StateSyncConfig{
-				RPCServers: "",
-			},
+			P2P:       &config.P2PConfig{},
+			RPC:       &config.ChainRPCConfig{},
+			Mempool:   &config.MempoolConfig{},
+			StateSync: &config.StateSyncConfig{},
 			Consensus: &config.ConsensusConfig{},
 		},
-		Logging: &config.Logging{},
+		Logging:         &config.Logging{},
+		Instrumentation: &config.InstrumentationConfig{},
 	}
 }
 

--- a/cmd/kwild/config/config_test.go
+++ b/cmd/kwild/config/config_test.go
@@ -35,6 +35,10 @@ func Test_Config_Toml(t *testing.T) {
 	assert.Equal(t, "localhost:50052", cfg.AppConfig.ExtensionEndpoints[0])
 	assert.Equal(t, "localhost:50053", cfg.AppConfig.ExtensionEndpoints[1])
 
+	assert.Equal(t, true, cfg.Instrumentation.Prometheus)
+	assert.Equal(t, 6, cfg.Instrumentation.MaxConnections)
+	assert.Equal(t, "9.8.7.6:20660", cfg.Instrumentation.PromListenAddr)
+
 	// TODO: Add bunch of other validations for different types
 }
 

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -308,3 +308,15 @@ chunk_request_timeout = "10s"
 
 # Note: If the requested chunk is not received for a duration of 2 minutes (hard-coded default), 
 # the state sync process is aborted and the node will fall back to the regular block sync process.
+
+[instrumentation]
+
+# collect and serve are served under /metrics
+prometheus = false
+
+# listen address for prometheus metrics
+prometheus_listen_addr = "0.0.0.0:26660"
+
+# Maximum number of simultaneous connections.
+# 0 - unlimited.
+max_open_connections = 1

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -114,6 +114,11 @@ to instead run a dedicated seeder like https://github.com/kwilteam/cometseed.`))
 	flagSet.Var(&cfg.ChainConfig.StateSync.DiscoveryTime, "chain.statesync.discovery-time", "Chain state sync discovery time")
 	flagSet.Var(&cfg.ChainConfig.StateSync.ChunkRequestTimeout, "chain.statesync.chunk-request-timeout", "Chain state sync chunk request timeout")
 
+	// Instrumentation flags
+	flagSet.BoolVar(&cfg.Instrumentation.Prometheus, "instrumentation.prometheus", cfg.Instrumentation.Prometheus, "collect and serve prometheus metrics")
+	flagSet.StringVar(&cfg.Instrumentation.PromListenAddr, "instrumentation.prometheus-listen-addr", cfg.Instrumentation.PromListenAddr, "listen address for prometheus metrics")
+	flagSet.IntVar(&cfg.Instrumentation.MaxConnections, "instrumentation.max-open-connections", cfg.Instrumentation.MaxConnections, "maximum number of simultaneous connections")
+
 	// TODO: delete in v0.10.0
 	flagSet.String("app.snapshots.snapshot-dir", "", "Snapshot directory path")
 	flagSet.MarkDeprecated("app.snapshots.snapshot-dir", "this value is no longer configurable")

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -301,3 +301,15 @@ chunk_request_timeout = "10s"
 
 # Note: If the requested chunk is not received for a duration of 2 minutes (hard-coded default), 
 # the state sync process is aborted and the node will fall back to the regular block sync process.
+
+[instrumentation]
+
+# collect and serve are served under /metrics
+prometheus = true
+
+# listen address for prometheus metrics
+prometheus_listen_addr = "9.8.7.6:20660"
+
+# Maximum number of simultaneous connections.
+# 0 - unlimited.
+max_open_connections = 6

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -163,7 +163,8 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	jsonRPCServer, err := rpcserver.NewServer(d.cfg.AppConfig.JSONRPCListenAddress,
 		*rpcServerLogger, rpcserver.WithTimeout(time.Duration(d.cfg.AppConfig.RPCTimeout)),
 		rpcserver.WithReqSizeLimit(d.cfg.AppConfig.RPCMaxReqSize),
-		rpcserver.WithCORS(), rpcserver.WithServerInfo(&usersvc.SpecInfo))
+		rpcserver.WithCORS(), rpcserver.WithServerInfo(&usersvc.SpecInfo),
+		rpcserver.WithMetricsNamespace("kwil_json_rpc_user_server"))
 	if err != nil {
 		failBuild(err, "unable to create json-rpc server")
 	}

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -20,6 +20,8 @@ import (
 	abciTypes "github.com/cometbft/cometbft/abci/types"
 	cmtEd "github.com/cometbft/cometbft/crypto/ed25519"
 	cmtlocal "github.com/cometbft/cometbft/rpc/client/local"
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/collectors"
 
 	kwildcfg "github.com/kwilteam/kwil-db/cmd/kwild/config"
 	"github.com/kwilteam/kwil-db/common"
@@ -111,6 +113,11 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 	// replaying blocks (and using atomic db tx commits), i.e. calling
 	// FinalizeBlock+Commit. This is not just a constructor, sadly.
 	cometBftNode := buildCometNode(d, closers, abciApp)
+
+	prometheus.MustRegister(
+		collectors.NewBuildInfoCollector(),
+		// collectors.NewDBStatsCollector() // TODO: do something like this for pg.DB
+	)
 
 	// Give abci p2p module access to removing peers
 	p2p.SetRemovePeerFn(cometBftNode.RemovePeer)

--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -105,6 +105,13 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 	nodeCfg.StateSync.DiscoveryTime = time.Duration(userChainCfg.StateSync.DiscoveryTime)
 	nodeCfg.StateSync.ChunkRequestTimeout = time.Duration(userChainCfg.StateSync.ChunkRequestTimeout)
 
+	nodeCfg.Instrumentation = &cmtCfg.InstrumentationConfig{
+		Prometheus:           cfg.Instrumentation.Prometheus,
+		PrometheusListenAddr: cfg.Instrumentation.PromListenAddr,
+		MaxOpenConnections:   cfg.Instrumentation.MaxConnections,
+		Namespace:            "cometbft",
+	}
+
 	// Light client verification
 	nodeCfg.StateSync.TrustPeriod = 36000 * time.Second // 10 hours (6s block time)
 

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -19,9 +19,10 @@ import (
 type KwildConfig struct {
 	RootDir string
 
-	AppConfig   *AppConfig   `mapstructure:"app"`
-	ChainConfig *ChainConfig `mapstructure:"chain"`
-	Logging     *Logging     `mapstructure:"log"`
+	AppConfig       *AppConfig             `mapstructure:"app"`
+	ChainConfig     *ChainConfig           `mapstructure:"chain"`
+	Logging         *Logging               `mapstructure:"log"`
+	Instrumentation *InstrumentationConfig `mapstructure:"instrumentation"`
 }
 
 type Logging struct {
@@ -34,6 +35,12 @@ type Logging struct {
 	OutputPaths    []string `mapstructure:"output_paths"`
 	MaxLogSizeKB   int64    `mapstructure:"file_roll_size"`
 	MaxLogRolls    int      `mapstructure:"retain_max_rolls"`
+}
+
+type InstrumentationConfig struct {
+	Prometheus     bool   `mapstructure:"prometheus"`
+	PromListenAddr string `mapstructure:"prometheus_listen_addr"`
+	MaxConnections int    `mapstructure:"max_open_connections"`
 }
 
 type AppConfig struct {

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/near/borsh-go v0.3.1
 	github.com/olekukonko/tablewriter v0.0.6-0.20230925090304-df64c4bbad77
 	github.com/pelletier/go-toml/v2 v2.2.2
+	github.com/prometheus/client_golang v1.20.1
 	github.com/spf13/cobra v1.8.1
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.19.0
@@ -116,7 +117,6 @@ require (
 	github.com/pganalyze/pg_query_go/v5 v5.1.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
-	github.com/prometheus/client_golang v1.20.1 // indirect
 	github.com/prometheus/client_model v0.6.1 // indirect
 	github.com/prometheus/common v0.55.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect


### PR DESCRIPTION
I want to play with prometheus a bit before saying this is right, but it addresses exposing cometbft's metrics as in https://github.com/kwilteam/kwil-db/issues/995#issuecomment-2369289713

Prometheus server + Grafana can talk to this and see cometbft's metrics, so I think this is properly exposing CometBFT's metrics endpoint.

Metrics: https://docs.cometbft.com/v0.38/core/metrics

![image](https://github.com/user-attachments/assets/ad57282f-08f2-4cf3-b54b-9ea7ea3c2a5e)

prometheus config

```yml
global:
  scrape_interval: 15s # Set the scrape interval to every 15 seconds. Default is every 1 minute.
  evaluation_interval: 15s # Evaluate rules every 15 seconds. The default is every 1 minute.
  # scrape_timeout is set to the global default (10s).

# Alertmanager configuration
alerting:
  alertmanagers:
    - static_configs:
        - targets:
          # - alertmanager:9093

# Load rules once and periodically evaluate them according to the global 'evaluation_interval'.
rule_files:
  # - "first_rules.yml"
  # - "second_rules.yml"

# A scrape configuration containing exactly one endpoint to scrape:
# Here it's Prometheus itself.
scrape_configs:
  # The job name is added as a label `job=<job_name>` to any timeseries scraped from this config.
  - job_name: "prometheus"

    # metrics_path defaults to '/metrics'
    # scheme defaults to 'http'.

    scrape_interval: 5s

    static_configs:
      - targets: ['localhost:26660']
```