### PR TITLE
persist app state to disk for clean restarts when the node end up wit…

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -485,6 +485,7 @@ func buildAbci(d *coreDependencies, db *pg.DB, txApp abci.TxApp, snapshotter *st
 		ss = statesyncer
 	}
 
+	abciDir := filepath.Join(d.cfg.RootDir, "abci")
 	cfg := &abci.AbciConfig{
 		GenesisAppHash:     d.genesisCfg.ComputeGenesisHash(),
 		ChainID:            d.genesisCfg.ChainID,
@@ -492,11 +493,11 @@ func buildAbci(d *coreDependencies, db *pg.DB, txApp abci.TxApp, snapshotter *st
 		GenesisAllocs:      d.genesisCfg.Alloc,
 		GasEnabled:         !d.genesisCfg.ConsensusParams.WithoutGasCosts,
 		ForkHeights:        d.genesisCfg.ForkHeights,
+		ABCIDir:            abciDir,
 	}
 
-	abciDir := filepath.Join(d.cfg.RootDir, "abci")
 	app, err := abci.NewAbciApp(d.ctx, cfg, sh, ss, txApp,
-		d.genesisCfg.ConsensusParams, p2p, migrator, db, abciDir, *d.log.Named("abci"))
+		d.genesisCfg.ConsensusParams, p2p, migrator, db, *d.log.Named("abci"))
 	if err != nil {
 		failBuild(err, "failed to build ABCI application")
 	}

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -493,8 +493,10 @@ func buildAbci(d *coreDependencies, db *pg.DB, txApp abci.TxApp, snapshotter *st
 		GasEnabled:         !d.genesisCfg.ConsensusParams.WithoutGasCosts,
 		ForkHeights:        d.genesisCfg.ForkHeights,
 	}
+
+	abciDir := filepath.Join(d.cfg.RootDir, "abci")
 	app, err := abci.NewAbciApp(d.ctx, cfg, sh, ss, txApp,
-		d.genesisCfg.ConsensusParams, p2p, migrator, db, *d.log.Named("abci"))
+		d.genesisCfg.ConsensusParams, p2p, migrator, db, abciDir, *d.log.Named("abci"))
 	if err != nil {
 		failBuild(err, "failed to build ABCI application")
 	}

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -807,7 +807,7 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 			delete(a.validatorAddressToPubKey, addr)
 			if err = a.p2p.RemovePeer(ctx, addr); err != nil {
 				if !errors.Is(err, cometbft.ErrPeerNotWhitelisted) {
-					return nil, fmt.Errorf("failed to remove demoted validator %s from peer list: %w", addr, err)
+					a.log.Warn("failed to remove demoted validator from peer list", zap.String("address", addr), zap.Error(err))
 				}
 			}
 		} else {
@@ -815,7 +815,7 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 			// Add the validator to the peer list
 			if err = a.p2p.AddPeer(ctx, addr); err != nil {
 				if !errors.Is(err, cometbft.ErrPeerAlreadyWhitelisted) {
-					return nil, fmt.Errorf("failed to whitelist promoted validator %s: %w", addr, err)
+					a.log.Warn("failed to whitelist promoted validator", zap.String("address", addr), zap.Error(err))
 				}
 			}
 		}
@@ -844,7 +844,7 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 		}
 		if err = a.p2p.RemovePeer(ctx, addr); err != nil {
 			if !errors.Is(err, cometbft.ErrPeerNotWhitelisted) {
-				return nil, fmt.Errorf("failed to remove expired validator %s from peer list: %w", addr, err)
+				a.log.Warn("failed to remove expired validator from peer list", zap.String("address", addr), zap.Error(err))
 			}
 		}
 	}


### PR DESCRIPTION
Reproduce:
```go
func (a *AbciApp) Commit(ctx context.Context, _ *abciTypes.RequestCommit) (*abciTypes.ResponseCommit, error) {
	err := a.consensusTx.Commit(ctx)
	if err != nil {
		return nil, fmt.Errorf("failed to commit transaction app: %w", err)
	}

	panic("Panic here to put the node in inconsistent state")
}
```

CometBFT persists the FinalizeBlock results, so if a crash occurs in the Commit method, CometBFT doesn't replay FinalizeBlock during restart and directly applies the Commit() method. This breaks the chain if the failure occurs as pointed in the above code, where the database state is committed but not the app hash (currently its []byte{42}). Therefore the replay commits block with incorrect app state and proceeds to the next block, which makes the chain non replay-able. 

This PR fixes this by storing the app state at the end of Finalize Block (cometBFT expects app to persist this info) (This would be way simpler if cometBFT can give us the appHash with the commit method :/)
