### PR TITLE
fix: kwil-admin setup reset does not use custom pg config

### DIFF
--- a/cmd/kwil-admin/cmds/common/rpc.go
+++ b/cmd/kwil-admin/cmds/common/rpc.go
@@ -193,32 +193,57 @@ func BindPostgresFlags(cmd *cobra.Command) {
 
 // GetPostgresFlags returns the postgres flags from the given command.
 func GetPostgresFlags(cmd *cobra.Command) (*pg.ConnConfig, error) {
-	conf := &pg.ConnConfig{}
+	return MergePostgresFlags(DefaultPostgresConnConfig(), cmd)
+}
+
+// MergePostgresFlags merges the given connection config with the flags from the given command.
+// It only sets the fields that are set in the flags.
+func MergePostgresFlags(conf *pg.ConnConfig, cmd *cobra.Command) (*pg.ConnConfig, error) {
 	var err error
-	conf.DBName, err = cmd.Flags().GetString("dbname")
-	if err != nil {
-		return nil, err
+	if cmd.Flags().Changed("dbname") {
+		conf.DBName, err = cmd.Flags().GetString("dbname")
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	conf.User, err = cmd.Flags().GetString("user")
-	if err != nil {
-		return nil, err
+	if cmd.Flags().Changed("user") {
+		conf.User, err = cmd.Flags().GetString("user")
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	conf.Pass, err = cmd.Flags().GetString("password")
-	if err != nil {
-		return nil, err
+	if cmd.Flags().Changed("password") {
+		conf.Pass, err = cmd.Flags().GetString("password")
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	conf.Host, err = cmd.Flags().GetString("host")
-	if err != nil {
-		return nil, err
+	if cmd.Flags().Changed("host") {
+		conf.Host, err = cmd.Flags().GetString("host")
+		if err != nil {
+			return nil, err
+		}
 	}
 
-	conf.Port, err = cmd.Flags().GetString("port")
-	if err != nil {
-		return nil, err
+	if cmd.Flags().Changed("port") {
+		conf.Port, err = cmd.Flags().GetString("port")
+		if err != nil {
+			return nil, err
+		}
 	}
 
 	return conf, nil
+}
+
+// DefaultPostgresConnConfig returns a default connection config for a postgres database.
+func DefaultPostgresConnConfig() *pg.ConnConfig {
+	return &pg.ConnConfig{
+		DBName: "kwild",
+		User:   "postgres",
+		Host:   "localhost",
+		Port:   "5432",
+	}
 }

--- a/cmd/kwil-admin/cmds/setup/genesis-hash.go
+++ b/cmd/kwil-admin/cmds/setup/genesis-hash.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/snapshot"
 	"github.com/kwilteam/kwil-db/common/chain"
+	"github.com/kwilteam/kwil-db/internal/sql/pg"
 	"github.com/spf13/cobra"
 )
 
@@ -87,18 +88,15 @@ func genesisHashCmd() *cobra.Command { //nolint:unused
 				appHash = hash.Sum(nil)
 			} else {
 
-				pgConf, err := common.GetPostgresFlags(cmd)
-				if err != nil {
-					return display.PrintErr(cmd, err)
-				}
-
+				var pgConf *pg.ConnConfig
+				var err error
 				if rootDir != "" {
 					rootDir, err = common.ExpandPath(rootDir)
 					if err != nil {
 						return display.PrintErr(cmd, err)
 					}
 
-					pgConf, err = getPGConnUsingLocalConfig(pgConf, rootDir)
+					pgConf, err = getPGConnUsingLocalConfig(cmd, rootDir)
 					if err != nil {
 						return display.PrintErr(cmd, err)
 					}

--- a/cmd/kwil-admin/cmds/setup/reset-state.go
+++ b/cmd/kwil-admin/cmds/setup/reset-state.go
@@ -1,6 +1,8 @@
 package setup
 
 import (
+	"fmt"
+
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/spf13/cobra"
@@ -33,7 +35,7 @@ func resetStateCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			return display.PrintCmd(cmd, display.RespString("Reset state in Postgres"))
+			return display.PrintCmd(cmd, display.RespString(fmt.Sprintf("Reset state in Postgres. Host: %s; Port: %s; Database: %s", pgConf.Host, pgConf.Port, pgConf.DBName)))
 		},
 	}
 

--- a/cmd/kwil-admin/cmds/setup/reset.go
+++ b/cmd/kwil-admin/cmds/setup/reset.go
@@ -3,6 +3,7 @@ package setup
 import (
 	"context"
 	"errors"
+	"fmt"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
@@ -43,17 +44,14 @@ func resetCmd() *cobra.Command {
 				}
 			}
 
-			pgConn, err := common.GetPostgresFlags(cobraCmd)
+			fmt.Println("Resetting all data in", rootDir)
+
+			pgConf, err := getPGConnUsingLocalConfig(cobraCmd, rootDir)
 			if err != nil {
 				return display.PrintErr(cobraCmd, err)
 			}
 
-			pgConf, err := getPGConnUsingLocalConfig(pgConn, rootDir)
-			if err != nil {
-				return display.PrintErr(cobraCmd, err)
-			}
-
-			err = resetPGState(context.Background(), pgConf)
+			err = resetPGState(cobraCmd.Context(), pgConf)
 			if err != nil {
 				return display.PrintErr(cobraCmd, err)
 			}
@@ -85,13 +83,8 @@ func resetCmd() *cobra.Command {
 
 // getPGConnUsingLocalConfig gets the postgres connection that should be used, including configurations set by the local config.
 // It uses the same precedence as `kwild`, which is (lowest to highest): default, config file, env. flag.
-func getPGConnUsingLocalConfig(conn *pg.ConnConfig, rootDir string) (*pg.ConnConfig, error) {
+func getPGConnUsingLocalConfig(cmd *cobra.Command, rootDir string) (*pg.ConnConfig, error) {
 	cfg := config.EmptyConfig()
-	cfg.AppConfig.DBHost = conn.Host
-	cfg.AppConfig.DBPort = conn.Port
-	cfg.AppConfig.DBUser = conn.User
-	cfg.AppConfig.DBPass = conn.Pass
-	cfg.AppConfig.DBName = conn.DBName
 	cfg.RootDir = rootDir
 
 	// merge it with any configured values
@@ -100,13 +93,15 @@ func getPGConnUsingLocalConfig(conn *pg.ConnConfig, rootDir string) (*pg.ConnCon
 		return nil, err
 	}
 
-	return &pg.ConnConfig{
+	conf := &pg.ConnConfig{
 		Host:   cfg.AppConfig.DBHost,
 		Port:   cfg.AppConfig.DBPort,
 		User:   cfg.AppConfig.DBUser,
 		Pass:   cfg.AppConfig.DBPass,
 		DBName: cfg.AppConfig.DBName,
-	}, nil
+	}
+
+	return common.MergePostgresFlags(conf, cmd)
 }
 
 // resetPGState drops and creates the database.

--- a/cmd/kwil-admin/cmds/setup/reset.go
+++ b/cmd/kwil-admin/cmds/setup/reset.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"context"
 	"errors"
-	"fmt"
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
@@ -43,8 +42,6 @@ func resetCmd() *cobra.Command {
 					return display.PrintErr(cobraCmd, err)
 				}
 			}
-
-			fmt.Println("Resetting all data in", rootDir)
 
 			pgConf, err := getPGConnUsingLocalConfig(cobraCmd, rootDir)
 			if err != nil {


### PR DESCRIPTION
Fixes a bug where `kwil-admin setup reset` was not properly reading in Postgres configs from the `config.toml` in the root directory.