### PR TITLE
pg,abci: unblock notice subscribers on DB shutdown

### DIFF
--- a/common/sql/sql.go
+++ b/common/sql/sql.go
@@ -156,10 +156,13 @@ type AccessModer interface {
 // When subscribed, the passed channel will receive notifications.
 // Only one subscription is allowed per transaction.
 type Subscriber interface {
-	// Subscribe subscribes to notifications passed using the special
-	// `notice()` function. Only `notice()` calls made after the subscription,
-	// on this tx, will be received. It returns a done function that should be
-	// called when the subscription is no longer needed. It is the callers
-	// responsibility to call done and close the channel.
+	// Subscribe subscribes to notifications passed using the special `notice()`
+	// function. Only `notice()` calls made after the subscription, on this tx,
+	// will be received. A done function is returned that should be called to
+	// signal that no more statements that emit notices will be executed. The
+	// channel will only be closed after all notices have been sent AND the done
+	// is called, or if the database shuts down prematurely. In case of an
+	// unexpected DB shutdown, an empty string is sent on the channel before it
+	// is closed. It is the caller's responsibility to call done.
 	Subscribe(ctx context.Context) (ch <-chan string, done func(context.Context) error, err error)
 }


### PR DESCRIPTION
This resolves a possible hang in `FinalizeBlock` if the DB shuts down / dies while waiting for the completion of the notice stream at `wg.Wait()`.  When the `pg.DB` instance closes up in response to the replication connection terminating, we also make sure to close the subscriber channels to unblock the receivers.  To ensure the receivers handle this as an error rather than assuming all notices have been received successfully, an empty string is first sent on the channel.  Since all notice messages have a special prefix (`pgtx:`), this is easily recognized as an exception.