### PR TITLE
kwild: write version to log file too

### DIFF
--- a/cmd/kwild/server/server.go
+++ b/cmd/kwild/server/server.go
@@ -57,6 +57,8 @@ func New(ctx context.Context, cfg *config.KwildConfig, genesisCfg *chain.Genesis
 	}
 	logger = *logger.Named("kwild")
 
+	logger.Infof("version %s commit %s", version.KwilVersion, version.Build.RevisionShort)
+
 	closers := &closeFuncs{
 		closers: []func() error{}, // logger.Close is not in here; do it in a defer in Start
 		logger:  logger,

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,7 +28,7 @@ var (
 func init() {
 	if KwilVersion == "" { // not set via ldflags
 		KwilVersion = kwilVersion
-		if Build != nil {
+		if Build != nil && Build.RevisionShort != "" {
 			// Append VCS revision and workspace dirty flag.
 			sep := "+" // start build metadata
 			if strings.Contains(KwilVersion, "+") {


### PR DESCRIPTION
Resolves https://github.com/kwilteam/kwil-db/issues/1016

Although we print the version string to stdout, we didn't write it to logger.

I think we should still write to std out important info before we start the logger, but this will now write to the logger (i.e. their log file and not lost to stdout):

```
2024-09-25T13:41:57.435-05:00	info	kwild	version 0.9.0-pre+b35de9da4.dirty commit b35de9da4
```

in context:

```
$  ./kwild -r ~/.kwild-junk3
kwild version 0.9.0-pre+b35de9da4.dirty (Go version go1.23.1)
Root directory "/home/jon/.kwild-junk3"
Private key path: /home/jon/.kwild-junk3/private_key
WARNING: app.rpc_req_limit is deprecated and will be removed in Kwil v0.10. use app.rpc_max_req_size instead
Started with 0 configured hard fork heights:
- halt: <nil> (disabled)

2024-09-25T13:41:57.486-05:00	info	kwild.pg	Connected to PostgreSQL 16.4 (Ubuntu 16.4-1.pgdg22.04+1) on x86_64-pc-linux-gnu, compiled by gcc (Ubuntu 11.4.0-1ubuntu1~22.04) 11.4.0, 64-bit
```