### PR TITLE
systemd: add service definition file

### DIFF
--- a/cmd/kwild/root/root.go
+++ b/cmd/kwild/root/root.go
@@ -126,6 +126,7 @@ func RootCmd() *cobra.Command {
 
 			go func() {
 				<-signalChan
+				fmt.Println("Shutdown signal received.")
 				cancel()
 			}()
 

--- a/deployments/systemd/kwild.service
+++ b/deployments/systemd/kwild.service
@@ -1,0 +1,26 @@
+# This is an example systemd service definition for a Kwil node.
+# Modify the ExecStart and ReadWritePaths with the actual locations of the
+# kwild binary and root_directory on the host system.
+[Unit]
+Description=The Kwil DB node
+Documentation=https://docs.kwil.com/
+Requires=local-fs.target network-online.target network.target
+After=local-fs.target network-online.target network.target
+
+[Service]
+Type=simple
+ExecStart=/opt/kwil/kwild -r /home/kwild/.kwild
+#ExecStop=
+KillSignal=SIGINT
+TimeoutStopSec=15s
+KillMode=process
+Restart=on-abnormal
+RestartSec=20s
+User=kwild
+Group=kwild
+
+ReadWritePaths=/home/kwild/.kwild
+#ReadWritePaths=/opt/kwil
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
This adds an example (but working) systemd service definition file to the new `deployments/systemd` folder.

Edit 

```sh
$ sudo cp deployments/systemd/kwild.service /etc/systemd/system/kwild.service

$ # Edit the /etc/systemd/system/kwild.service

$ sudo systemctl enable kwild.service
Created symlink /etc/systemd/system/multi-user.target.wants/kwild.service → /etc/systemd/system/kwild.service.

$ sudo systemctl start kwild.service
$ sudo systemctl status kwild.service
$  sudo systemctl status kwild
● kwild.service - The Kwil DB node
     Loaded: loaded (/etc/systemd/system/kwild.service; enabled; vendor preset: enabled)
     Active: active (running) since Thu 2024-09-26 18:16:14 CDT; 1s ago
       Docs: https://docs.kwil.com/
   Main PID: 4012010 (kwild)
      Tasks: 17 (limit: 38223)
     Memory: 33.3M
        CPU: 322ms
     CGroup: /system.slice/kwild.service
             └─4012010 /opt/kwil/kwild -r /home/kwild/.kwild

Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.524-05:00        info        kwild.cometbft        service start        {"module": "pex", "msg": "Starting PEX service", "impl": "PEX"}
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.524-05:00        info        kwild.cometbft        service start        {"module": "p2p", "book": "/home/kwild/.kwild/abci/addrbook.json", "msg": "Starting AddrBook>
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.524-05:00        info        kwild.cometbft        service start        {"module": "mempool", "msg": "Starting Mempool service", "impl": "Mempool"}
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.524-05:00        info        kwild.cometbft        Saving AddrBook to file        {"module": "p2p", "book": "/home/kwild/.kwild/abci/addrbook.json", "size": 0}
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.524-05:00        info        kwild.cometbft        Ensure peers        {"module": "pex", "numOutPeers": 0, "numInPeers": 0, "numDialing": 0, "numToDial": 10}
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.532-05:00        info        kwild.server        comet node is now started
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.532-05:00        info        kwild.cometbft        No addresses to dial. Falling back to seeds        {"module": "pex"}
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.996-05:00        info        kwild.listener-manager        Node is a validator and caught up with the network, starting listeners
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.996-05:00        warn        kwild.listener-manager.migrations        no migration config provided, skipping migration listener
Sep 26 18:16:14 pop-os kwild[4012010]: 2024-09-26T18:16:14.996-05:00        warn        kwild.listener-manager.eth_deposits        no eth_deposit configuration found, eth_deposit oracle will not start
```


NOTE: The "deployments" folder is odd, but it already exits with docker compose definitions.  I would tend to put files like this into a top level `"contrib"` folder, but the repo is already a bit crowded and I didn't feel like renaming "deployments" given all the docs that would be affected.