### PR TITLE
test: allow config private rpc

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -190,7 +190,7 @@ tasks:
     desc: Start the dev environment(with testnet) without rebuilding docker image
     dir: test # different module
     cmds:
-      - go test ./integration -run ^TestLocalDevSetup$ -timeout 12h -dev -v
+      - go test ./integration -run ^TestLocalDevSetup$ -timeout 12h -dev -v {{.CLI_ARGS}}
 
   # ************ test ************
   # test with build:docker task support passing CLI_ARGS to go test, e.g. task test:act -- -debug

--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -79,6 +79,7 @@ type TestnetGenerateConfig struct {
 	SnapshotHeights         uint64
 	Forks                   map[string]*uint64
 	PrivateMode             bool
+	AuthenticateRPCs        bool
 }
 
 // ConfigOpts is a struct to alter the generation of the node config.
@@ -388,6 +389,8 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 				cfg.AppConfig.Extensions = make(map[string]map[string]string)
 			}
 		}
+
+		cfg.AppConfig.PrivateRPC = genCfg.AuthenticateRPCs
 
 		err = WriteConfigFile(kwildcfg.ConfigFilePath(nodeDir), cfg)
 		if err != nil {

--- a/cmd/kwil-admin/nodecfg/generate.go
+++ b/cmd/kwil-admin/nodecfg/generate.go
@@ -79,7 +79,7 @@ type TestnetGenerateConfig struct {
 	SnapshotHeights         uint64
 	Forks                   map[string]*uint64
 	PrivateMode             bool
-	AuthenticateRPCs        bool
+	PrivateRPC              bool
 }
 
 // ConfigOpts is a struct to alter the generation of the node config.
@@ -390,7 +390,7 @@ func GenerateTestnetConfig(genCfg *TestnetGenerateConfig, opts *ConfigOpts) erro
 			}
 		}
 
-		cfg.AppConfig.PrivateRPC = genCfg.AuthenticateRPCs
+		cfg.AppConfig.PrivateRPC = genCfg.PrivateRPC
 
 		err = WriteConfigFile(kwildcfg.ConfigFilePath(nodeDir), cfg)
 		if err != nil {

--- a/test/acceptance/helper.go
+++ b/test/acceptance/helper.go
@@ -134,6 +134,9 @@ func (r *ActHelper) LoadConfig() *ActTestCfg {
 		DockerComposeOverrideFile: getEnv("KACT_DOCKER_COMPOSE_OVERRIDE_FILE", "./docker-compose.override.yml"),
 	}
 
+	cfg.AuthenticateRPCs, err = strconv.ParseBool(getEnv("KACT_AUTHENTICATE_RPCS", "false"))
+	require.NoError(r.t, err, "invalid authenticateRPCs bool")
+
 	cfg.GasEnabled, err = strconv.ParseBool(getEnv("KACT_GAS_ENABLED", "false"))
 	require.NoError(r.t, err, "invalid gasEnabled bool")
 

--- a/test/acceptance/helper.go
+++ b/test/acceptance/helper.go
@@ -53,8 +53,8 @@ type ActTestCfg struct {
 	CreatorSigner auth.Signer
 	VisitorSigner auth.Signer
 
-	GasEnabled       bool
-	AuthenticateRPCs bool
+	GasEnabled bool
+	PrivateRPC bool
 }
 
 func (e *ActTestCfg) CreatorIdent() []byte {
@@ -134,8 +134,8 @@ func (r *ActHelper) LoadConfig() *ActTestCfg {
 		DockerComposeOverrideFile: getEnv("KACT_DOCKER_COMPOSE_OVERRIDE_FILE", "./docker-compose.override.yml"),
 	}
 
-	cfg.AuthenticateRPCs, err = strconv.ParseBool(getEnv("KACT_AUTHENTICATE_RPCS", "false"))
-	require.NoError(r.t, err, "invalid authenticateRPCs bool")
+	cfg.PrivateRPC, err = strconv.ParseBool(getEnv("KACT_PRIVATE_RPC", "false"))
+	require.NoError(r.t, err, "invalid privateRPC bool")
 
 	cfg.GasEnabled, err = strconv.ParseBool(getEnv("KACT_GAS_ENABLED", "false"))
 	require.NoError(r.t, err, "invalid gasEnabled bool")
@@ -192,7 +192,7 @@ func (r *ActHelper) generateNodeConfig() {
 		OutputDir:        tmpPath,
 		JoinExpiry:       14400,
 		WithoutGasCosts:  !r.cfg.GasEnabled,
-		AuthenticateRPCs: r.cfg.AuthenticateRPCs,
+		AuthenticateRPCs: r.cfg.PrivateRPC,
 		Allocs: map[string]*big.Int{
 			creatorIdent: bal,
 		},

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -270,7 +270,7 @@ func TestDataPrivateMode(t *testing.T) {
 			// setup for each driver
 			helper := acceptance.NewActHelper(t)
 			cfg := helper.LoadConfig()
-			cfg.AuthenticateRPCs = true
+			cfg.PrivateRPC = true
 			if !*remote {
 				helper.Setup(ctx)
 			}

--- a/test/acceptance/kwild_test.go
+++ b/test/acceptance/kwild_test.go
@@ -254,7 +254,7 @@ func TestTypes(t *testing.T) {
 	}
 }
 
-func TestPrivateMode(t *testing.T) {
+func TestDataPrivateMode(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
 	}

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -120,7 +120,7 @@ type IntTestConfig struct {
 	WithGas                 bool
 	PopulatePersistentPeers bool
 	PrivateMode             bool
-	AuthenticateRPCs        bool
+	PrivateRPC              bool
 
 	// The following options are mutually exclusive, as they are used to use
 	// alternate docker images with kwild variants with differnet extensions.
@@ -325,7 +325,7 @@ func WithPrivateMode() HelperOpt {
 
 func WithAuthenticateRPC() HelperOpt {
 	return func(r *IntHelper) {
-		r.cfg.AuthenticateRPCs = true
+		r.cfg.PrivateRPC = true
 	}
 }
 
@@ -353,8 +353,8 @@ func (r *IntHelper) LoadConfig() {
 		DockerComposeOverrideFile: getEnv("KIT_DOCKER_COMPOSE_OVERRIDE_FILE", "./docker-compose.override.yml"),
 	}
 
-	r.cfg.AuthenticateRPCs, err = strconv.ParseBool(getEnv("KIT_AUTHENTICATE_RPCS", "false"))
-	require.NoError(r.t, err, "invalid authenticateRPCs bool")
+	r.cfg.PrivateRPC, err = strconv.ParseBool(getEnv("KIT_PRIVATE_RPC", "false"))
+	require.NoError(r.t, err, "invalid privateRPC bool")
 
 	creatorPk, err := crypto.Secp256k1PrivateKeyFromHex(r.cfg.CreatorRawPk)
 	require.NoError(r.t, err, "invalid creator private key")
@@ -458,7 +458,7 @@ func (r *IntHelper) generateNodeConfig(homeDir string) {
 		HostnamePrefix:          "kwil-",
 		HostnameSuffix:          "",
 		PrivateMode:             r.cfg.PrivateMode,
-		AuthenticateRPCs:        r.cfg.AuthenticateRPCs,
+		PrivateRPC:              r.cfg.PrivateRPC,
 
 		// use this to ease the process running test parallel
 		// NOTE: need to match docker-compose kwild service name

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -323,7 +323,7 @@ func WithPrivateMode() HelperOpt {
 	}
 }
 
-func WithAuthenticateRPC() HelperOpt {
+func WithPrivateRPC() HelperOpt {
 	return func(r *IntHelper) {
 		r.cfg.PrivateRPC = true
 	}


### PR DESCRIPTION
This pr add support to config `private_rpc`,  so that following cmds work:
- `KACT_PRIVATE_RPC=true task dev:up:nb`
- `KIT_PRIVATE_RPC=true task dev:testnet:up:nb`

This helps to test KGW.

Merge note: squash