### PR TITLE
Simplify Migration Structs

### DIFF
--- a/cmd/kwil-admin/cmds/migration/genesis.go
+++ b/cmd/kwil-admin/cmds/migration/genesis.go
@@ -13,6 +13,7 @@ import (
 	"github.com/kwilteam/kwil-db/common/chain"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/internal/statesync"
+	"github.com/kwilteam/kwil-db/internal/version"
 )
 
 var (
@@ -49,11 +50,18 @@ func genesisStateCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
+			// this check should change in every version:
+			// For backwards compatibility, we should be able to unmarshal structs from previous versions.
+			// Since v0.9 is our first time supporting migration, we only need to check for v0.9.
+			if metadata.KwildMinorVersion != string(version.KwilMinorVersion) {
+				return display.PrintErr(cmd, fmt.Errorf("genesis state download is incompatible. Received version: %s, supported versions: [%s]", metadata.KwildMinorVersion, version.KwilMinorVersion))
+			}
+
 			// If there is no active migration or if the migration has not started yet, return the migration state
 			// indicating that there is no genesis state to download.
 			if metadata.MigrationState.Status == types.NoActiveMigration ||
 				metadata.MigrationState.Status == types.MigrationNotStarted ||
-				metadata.GenesisConfig == nil || metadata.SnapshotMetadata == nil {
+				metadata.GenesisInfo == nil || metadata.SnapshotMetadata == nil {
 				return display.PrintCmd(cmd, &MigrationState{
 					Info: metadata.MigrationState,
 				})
@@ -69,16 +77,31 @@ func genesisStateCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			// retrieve the genesis config
-			var genCfg chain.GenesisConfig
-			if err = json.Unmarshal(metadata.GenesisConfig, &genCfg); err != nil {
-				return display.PrintErr(cmd, err)
-			}
-
 			// retrieve the snapshot metadata
 			var snapshotMetadata statesync.Snapshot
 			if err = json.Unmarshal(metadata.SnapshotMetadata, &snapshotMetadata); err != nil {
 				return display.PrintErr(cmd, err)
+			}
+
+			genCfg := chain.GenesisConfig{
+				DataAppHash:   metadata.GenesisInfo.AppHash,
+				InitialHeight: metadata.MigrationState.StartHeight,
+				ConsensusParams: &chain.ConsensusParams{
+					BaseConsensusParams: chain.BaseConsensusParams{
+						Migration: chain.MigrationParams{
+							StartHeight: metadata.MigrationState.StartHeight,
+							EndHeight:   metadata.MigrationState.EndHeight,
+						},
+					},
+				},
+			}
+
+			for _, nv := range metadata.GenesisInfo.Validators {
+				genCfg.Validators = append(genCfg.Validators, &chain.GenesisValidator{
+					Name:   nv.Name,
+					PubKey: nv.PubKey,
+					Power:  nv.Power,
+				})
 			}
 
 			// Print the genesis state to the genesis.json file

--- a/cmd/kwil-admin/cmds/migration/genesis.go
+++ b/cmd/kwil-admin/cmds/migration/genesis.go
@@ -12,8 +12,8 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
 	"github.com/kwilteam/kwil-db/common/chain"
 	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/kwilteam/kwil-db/internal/migrations"
 	"github.com/kwilteam/kwil-db/internal/statesync"
-	"github.com/kwilteam/kwil-db/internal/version"
 )
 
 var (
@@ -53,8 +53,8 @@ func genesisStateCmd() *cobra.Command {
 			// this check should change in every version:
 			// For backwards compatibility, we should be able to unmarshal structs from previous versions.
 			// Since v0.9 is our first time supporting migration, we only need to check for v0.9.
-			if metadata.KwildMinorVersion != string(version.KwilMinorVersion) {
-				return display.PrintErr(cmd, fmt.Errorf("genesis state download is incompatible. Received version: %s, supported versions: [%s]", metadata.KwildMinorVersion, version.KwilMinorVersion))
+			if metadata.Version != migrations.MigrationVersion {
+				return display.PrintErr(cmd, fmt.Errorf("genesis state download is incompatible. Received version: %d, supported versions: [%d]", metadata.Version, migrations.MigrationVersion))
 			}
 
 			// If there is no active migration or if the migration has not started yet, return the migration state

--- a/cmd/kwil-admin/cmds/migration/list.go
+++ b/cmd/kwil-admin/cmds/migration/list.go
@@ -59,7 +59,6 @@ func (m *MigrationsList) MarshalText() ([]byte, error) {
 		msg.WriteString(fmt.Sprintf("%s:\n", migration.ID))
 		msg.WriteString(fmt.Sprintf("\tactivationPeriod: %d\n", migration.ActivationPeriod))
 		msg.WriteString(fmt.Sprintf("\tmigrationDuration: %d\n", migration.Duration))
-		msg.WriteString(fmt.Sprintf("\tchainID: %s\n", migration.ChainID))
 		msg.WriteString(fmt.Sprintf("\ttimestamp: %s\n", migration.Timestamp))
 	}
 	return msg.Bytes(), nil

--- a/cmd/kwil-admin/cmds/migration/propose.go
+++ b/cmd/kwil-admin/cmds/migration/propose.go
@@ -13,17 +13,20 @@ import (
 )
 
 var (
-	proposeLong = "A Validator operator can submit a migration proposal using the `propose` subcommand. The migration proposal includes the new `chain-id`, `activation-period` and `duration`. This action will generate a migration resolution for the other validators to vote on. If a super-majority of validators approve the migration proposal, the migration will commence after the specified activation-period blocks from approval and will continue for the duration defined by duration blocks."
+	proposeLong = `A validator operator can submit a migration proposal using the ` + "`" + `propose` + "`" + ` subcommand.
+	
+The migration proposal includes the ` + "`" + `activation-period` + "`" + ` and ` + "`" + `duration` + "`" + `. This will generate a migration resolution
+for the other validators to vote on. If a super-majority of validators approve the migration proposal, the migration will
+commence after the specified activation-period blocks from approval and will continue for the duration defined by duration blocks.`
 
-	proposeExample = `# Submit a migration proposal to migrate to a new chain "kwil-chain-new" with activation period 1000 and migration duration of 14400 blocks.
-kwil-admin migrate propose --activation-period 1000 --duration 14400 --chain-id kwil-chain-new
+	proposeExample = `# Submit a migration proposal to migrate to a new chain with activation period 1000 and migration duration of 14400 blocks.
+kwil-admin migrate propose --activation-period 1000 --duration 14400
 (or)
-kwil-admin migrate propose -a 1000 -d 14400 -c kwil-chain-new`
+kwil-admin migrate propose -a 1000 -d 14400`
 )
 
 func proposeCmd() *cobra.Command {
 	var activationPeriod, migrationDuration uint64
-	var chainID string
 
 	cmd := &cobra.Command{
 		Use:     "propose",
@@ -42,14 +45,9 @@ func proposeCmd() *cobra.Command {
 				return display.PrintErr(cmd, errors.New("start-height and migration duration must be greater than 0"))
 			}
 
-			if chainID == "" {
-				return display.PrintErr(cmd, errors.New("chain-id configuration is not set"))
-			}
-
 			proposal := migrations.MigrationDeclaration{
 				ActivationPeriod: activationPeriod,
 				Duration:         migrationDuration,
-				ChainID:          chainID,
 				Timestamp:        time.Now().String(),
 			}
 			proposalBts, err := proposal.MarshalBinary()
@@ -70,6 +68,5 @@ func proposeCmd() *cobra.Command {
 
 	cmd.Flags().Uint64VarP(&activationPeriod, "activation-period", "a", 0, "The number of blocks before the migration is activated since the approval of the proposal.")
 	cmd.Flags().Uint64VarP(&migrationDuration, "duration", "d", 0, "The duration of the migration.")
-	cmd.Flags().StringVarP(&chainID, "chain-id", "c", "", "The chain ID of the migration.")
 	return cmd
 }

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/internal/abci/cometbft"
+	"github.com/kwilteam/kwil-db/internal/migrations"
 	"github.com/kwilteam/kwil-db/internal/statesync"
 )
 
@@ -141,6 +142,13 @@ func (m *migrationClient) downloadGenesisState(ctx context.Context) error {
 	metadata, err := m.clt.GenesisState(ctx)
 	if err != nil {
 		return err
+	}
+
+	// this check should change in every version:
+	// For backwards compatibility, we should be able to unmarshal structs from previous versions.
+	// Since v0.9 is our first time supporting migration, we only need to check for v0.9.
+	if metadata.Version != migrations.MigrationVersion {
+		return fmt.Errorf("genesis state download is incompatible. Received version: %d, supported versions: [%d]", metadata.Version, migrations.MigrationVersion)
 	}
 
 	// Check if the genesis state is ready

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -60,29 +60,29 @@ func PrepareForMigration(ctx context.Context, kwildCfg *commonCfg.KwildConfig, g
 	logger.Info("Entering migration mode", log.String("migrate_from", kwildCfg.MigrationConfig.MigrateFrom))
 
 	snapshotFileName := config.GenesisStateFileName(kwildCfg.RootDir)
-	// check if genesis hash is set in the genesis config
-	if genesisCfg.DataAppHash != nil &&
-		genesisCfg.ConsensusParams.Migration.StartHeight != 0 &&
-		genesisCfg.ConsensusParams.Migration.EndHeight != 0 &&
-		validateGenesisState(snapshotFileName, genesisCfg.DataAppHash) {
-		// genesis state already downloaded. No need to poll for genesis state
+
+	// if the genesis state is already downloaded, then no need to poll for genesis state
+	_, err := os.Stat(snapshotFileName)
+	if err == nil {
 		logger.Info("Genesis state already downloaded", log.String("genesis snapshot", snapshotFileName))
+
+		if !validateGenesisState(snapshotFileName, genesisCfg.DataAppHash) {
+			return nil, nil, errors.New("app hash does not match the genesis state")
+		}
+
 		return kwildCfg, genesisCfg, nil
+	} else if !os.IsNotExist(err) {
+		return nil, nil, fmt.Errorf("failed to check genesis state file: %w", err)
 	}
 
 	// if we reach here, then we still need to download the genesis state
-	// Therefore, the genesis app hash, validator set, chain id, initial height,
-	// and migration info should not already be set in the genesis config.
-	if genesisCfg.DataAppHash != nil {
+	// Therefore, the genesis app hash, initial height, and migration info
+	// should not already be set in the genesis config.
+	if len(genesisCfg.DataAppHash) != 0 {
 		return nil, nil, errors.New("migration genesis config should not have app hash set")
 	}
-	if genesisCfg.Validators != nil {
-		return nil, nil, errors.New("migration genesis config should not have validators set")
-	}
-	if genesisCfg.ChainID != "" {
-		return nil, nil, errors.New("migration genesis config should not have chain id set")
-	}
 	if genesisCfg.InitialHeight != 0 && genesisCfg.InitialHeight != 1 {
+		// we are forcing users to adopt the height provided by the old chain
 		return nil, nil, errors.New("migration genesis config should not have initial height set")
 	}
 	if genesisCfg.ConsensusParams.Migration.IsMigration() {
@@ -149,13 +149,8 @@ func (m *migrationClient) downloadGenesisState(ctx context.Context) error {
 	}
 
 	// Genesis state should ready
-	if metadata.SnapshotMetadata == nil || metadata.GenesisConfig == nil {
+	if metadata.SnapshotMetadata == nil || metadata.GenesisInfo == nil {
 		return errors.New("genesis state not available")
-	}
-
-	var genCfg chain.GenesisConfig
-	if err := json.Unmarshal(metadata.GenesisConfig, &genCfg); err != nil {
-		return fmt.Errorf("failed to unmarshal genesis config: %w", err)
 	}
 
 	// Save the genesis state
@@ -188,10 +183,26 @@ func (m *migrationClient) downloadGenesisState(ctx context.Context) error {
 	}
 
 	// Update the genesis config
-	m.genesisCfg.DataAppHash = genCfg.DataAppHash
-	m.genesisCfg.Validators = genCfg.Validators
-	m.genesisCfg.ConsensusParams.Migration = genCfg.ConsensusParams.Migration
+	m.genesisCfg.DataAppHash = metadata.GenesisInfo.AppHash
+	m.genesisCfg.ConsensusParams.Migration = chain.MigrationParams{
+		StartHeight: metadata.MigrationState.StartHeight,
+		EndHeight:   metadata.MigrationState.EndHeight,
+	}
 	m.genesisCfg.InitialHeight = metadata.MigrationState.StartHeight
+
+	// if validators are not set in the genesis config, then set them.
+	// Otherwise, ignore the validators from the old chain.
+	if len(m.genesisCfg.Validators) == 0 {
+		for _, v := range metadata.GenesisInfo.Validators {
+			m.genesisCfg.Validators = append(m.genesisCfg.Validators, &chain.GenesisValidator{
+				Name:   v.Name,
+				PubKey: v.PubKey,
+				Power:  v.Power,
+			})
+		}
+	} else {
+		m.logger.Warn("Validators already set in the genesis config. Ignoring the validators from the old chain")
+	}
 
 	// persist the genesis config
 	if err := m.genesisCfg.SaveAs(filepath.Join(m.kwildCfg.RootDir, cometbft.GenesisJSONName)); err != nil {

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -73,9 +73,20 @@ func PrepareForMigration(ctx context.Context, kwildCfg *commonCfg.KwildConfig, g
 	// if we reach here, then we still need to download the genesis state
 	// Therefore, the genesis app hash, validator set, chain id, initial height,
 	// and migration info should not already be set in the genesis config.
-	if genesisCfg.DataAppHash != nil || genesisCfg.Validators != nil || genesisCfg.ChainID != "" ||
-		genesisCfg.InitialHeight != 0 || genesisCfg.ConsensusParams.Migration.IsMigration() {
-		return nil, nil, errors.New("migration genesis config should not have app hash, validators, initial height, migration info, or chain id set")
+	if genesisCfg.DataAppHash != nil {
+		return nil, nil, errors.New("migration genesis config should not have app hash set")
+	}
+	if genesisCfg.Validators != nil {
+		return nil, nil, errors.New("migration genesis config should not have validators set")
+	}
+	if genesisCfg.ChainID != "" {
+		return nil, nil, errors.New("migration genesis config should not have chain id set")
+	}
+	if genesisCfg.InitialHeight != 0 && genesisCfg.InitialHeight != 1 {
+		return nil, nil, errors.New("migration genesis config should not have initial height set")
+	}
+	if genesisCfg.ConsensusParams.Migration.IsMigration() {
+		return nil, nil, errors.New("migration genesis config should not have migration info set")
 	}
 
 	// old chain client

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -73,8 +73,9 @@ func PrepareForMigration(ctx context.Context, kwildCfg *commonCfg.KwildConfig, g
 	// if we reach here, then we still need to download the genesis state
 	// Therefore, the genesis app hash, validator set, and chain id should not
 	// already be set in the genesis config.
-	if genesisCfg.DataAppHash != nil || genesisCfg.Validators != nil || genesisCfg.ChainID != "" {
-		return nil, nil, errors.New("migration genesis config should not have app hash, validators or chain id set")
+	if genesisCfg.DataAppHash != nil || genesisCfg.Validators != nil || genesisCfg.ChainID != "" ||
+		genesisCfg.InitialHeight != 0 || genesisCfg.ConsensusParams.Migration.IsMigration() {
+		return nil, nil, errors.New("migration genesis config should not have app hash, validators, initial height, migration info, or chain id set")
 	}
 
 	// old chain client

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -70,6 +70,13 @@ func PrepareForMigration(ctx context.Context, kwildCfg *commonCfg.KwildConfig, g
 		return kwildCfg, genesisCfg, nil
 	}
 
+	// if we reach here, then we still need to download the genesis state
+	// Therefore, the genesis app hash, validator set, and chain id should not
+	// already be set in the genesis config.
+	if genesisCfg.DataAppHash != nil || genesisCfg.Validators != nil || genesisCfg.ChainID != "" {
+		return nil, nil, errors.New("migration genesis config should not have app hash, validators or chain id set")
+	}
+
 	// old chain client
 	clt, err := client.NewClient(ctx, kwildCfg.MigrationConfig.MigrateFrom, nil)
 	if err != nil {

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -71,8 +71,8 @@ func PrepareForMigration(ctx context.Context, kwildCfg *commonCfg.KwildConfig, g
 	}
 
 	// if we reach here, then we still need to download the genesis state
-	// Therefore, the genesis app hash, validator set, and chain id should not
-	// already be set in the genesis config.
+	// Therefore, the genesis app hash, validator set, chain id, initial height,
+	// and migration info should not already be set in the genesis config.
 	if genesisCfg.DataAppHash != nil || genesisCfg.Validators != nil || genesisCfg.ChainID != "" ||
 		genesisCfg.InitialHeight != 0 || genesisCfg.ConsensusParams.Migration.IsMigration() {
 		return nil, nil, errors.New("migration genesis config should not have app hash, validators, initial height, migration info, or chain id set")

--- a/common/chain/chaincfg.go
+++ b/common/chain/chaincfg.go
@@ -135,6 +135,11 @@ type MigrationParams struct {
 	EndHeight int64 `json:"end_height,omitempty"`
 }
 
+// IsMigration returns true if the migration parameters are set.
+func (m *MigrationParams) IsMigration() bool {
+	return m.StartHeight != 0 && m.EndHeight != 0
+}
+
 func defaultConsensusParams() *ConsensusParams {
 	return &ConsensusParams{
 		BaseConsensusParams: BaseConsensusParams{

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -124,10 +124,10 @@ type MigrationState struct {
 // consumers of what information the current node has available
 // for the migration.
 type MigrationMetadata struct {
-	MigrationState    MigrationState `json:"migration_state"`   // MigrationState is the current state of the migration
-	GenesisInfo       *GenesisInfo   `json:"genesis_info"`      // GenesisInfo is the genesis information
-	SnapshotMetadata  []byte         `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
-	KwildMinorVersion string         `json:"kwild_version"`     // KwildVersion is the version of the kwild node
+	MigrationState   MigrationState `json:"migration_state"`   // MigrationState is the current state of the migration
+	GenesisInfo      *GenesisInfo   `json:"genesis_info"`      // GenesisInfo is the genesis information
+	SnapshotMetadata []byte         `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
+	Version          int            `json:"kwild_version"`     // Version of the migration metadata
 }
 
 // GenesisInfo holds the genesis information that the new network should use

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -87,7 +87,6 @@ type Migration struct {
 	ID               *UUID  `json:"id"`                 // ID is the UUID of the migration resolution/proposal
 	ActivationPeriod int64  `json:"activation_height"`  // ActivationPeriod is the amount of blocks before the migration is activated.
 	Duration         int64  `json:"migration_duration"` // MigrationDuration is the duration of the migration process starting from the ActivationHeight
-	ChainID          string `json:"chain_id"`           // ChainID of the new network
 	Timestamp        string `json:"timestamp"`          // Timestamp when the migration was proposed
 }
 
@@ -125,9 +124,27 @@ type MigrationState struct {
 // consumers of what information the current node has available
 // for the migration.
 type MigrationMetadata struct {
-	MigrationState   MigrationState `json:"migration_state"`   // MigrationState is the current state of the migration
-	GenesisConfig    []byte         `json:"genesis_config"`    // GenesisConfig is the genesis file data
-	SnapshotMetadata []byte         `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
+	MigrationState    MigrationState `json:"migration_state"`   // MigrationState is the current state of the migration
+	GenesisInfo       *GenesisInfo   `json:"genesis_info"`      // GenesisInfo is the genesis information
+	SnapshotMetadata  []byte         `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
+	KwildMinorVersion string         `json:"kwild_version"`     // KwildVersion is the version of the kwild node
+}
+
+// GenesisInfo holds the genesis information that the new network should use
+// in its genesis file.
+type GenesisInfo struct {
+	// AppHash is the application hash of the old network at the StartHeight
+	AppHash HexBytes `json:"app_hash"`
+	// Validators is the list of validators that the new network should start with
+	Validators []*NamedValidator `json:"validators"`
+}
+
+// NamedValidator is a validator with a name.
+// Since CometBFT assigns validators human-readable names, this struct
+// is used to represent a validator with its name that will be used in the genesis file.
+type NamedValidator struct {
+	Name      string `json:"name"`
+	Validator `json:"validator"`
 }
 
 // ServiceMode describes the operating mode of the user service. Namely, if the

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -127,7 +127,7 @@ type MigrationMetadata struct {
 	MigrationState   MigrationState `json:"migration_state"`   // MigrationState is the current state of the migration
 	GenesisInfo      *GenesisInfo   `json:"genesis_info"`      // GenesisInfo is the genesis information
 	SnapshotMetadata []byte         `json:"snapshot_metadata"` // SnapshotMetadata is the snapshot metadata
-	Version          int            `json:"kwild_version"`     // Version of the migration metadata
+	Version          int            `json:"version"`           // Version of the migration metadata
 }
 
 // GenesisInfo holds the genesis information that the new network should use

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -42,6 +42,8 @@ func init() {
 	}
 }
 
+const MigrationVersion int = 0
+
 // MigrationDeclaration creates a new migration. It is used to agree on terms of a migration,
 // and is voted on using Kwil's vote store.
 type MigrationDeclaration struct {

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -51,10 +51,6 @@ type MigrationDeclaration struct {
 	ActivationPeriod uint64
 	// Duration is the amount of blocks the migration will take to complete.
 	Duration uint64
-	// ChainID is the new chain ID that the network will migrate to.
-	// A new chain ID should always be used for a new network, to avoid
-	// cross-network replay attacks.
-	ChainID string
 	// Timestamp is the time the migration was created. It is set by the migration
 	// creator. The primary purpose of it is to guarantee uniqueness of the serialized
 	// MigrationDeclaration, since that is a requirement for the voting system.
@@ -116,7 +112,6 @@ func (m *Migrator) startMigration(ctx context.Context, app *common.App, resoluti
 	active := &activeMigration{
 		StartHeight: block.Height + activationPeriod,
 		EndHeight:   block.Height + activationPeriod + dur,
-		ChainID:     mig.ChainID,
 	}
 
 	err = createMigration(ctx, app.DB, active)

--- a/internal/migrations/migrator.go
+++ b/internal/migrations/migrator.go
@@ -20,7 +20,6 @@ import (
 	"github.com/kwilteam/kwil-db/internal/sql/pg"
 	"github.com/kwilteam/kwil-db/internal/sql/versioning"
 	"github.com/kwilteam/kwil-db/internal/txapp"
-	"github.com/kwilteam/kwil-db/internal/version"
 	"github.com/kwilteam/kwil-db/internal/voting"
 )
 
@@ -378,7 +377,7 @@ func (m *Migrator) GetMigrationMetadata() (*types.MigrationMetadata, error) {
 			MigrationState: types.MigrationState{
 				Status: types.NoActiveMigration,
 			},
-			KwildMinorVersion: string(version.MinorVersionV9),
+			Version: MigrationVersion,
 		}, nil
 	}
 
@@ -390,7 +389,7 @@ func (m *Migrator) GetMigrationMetadata() (*types.MigrationMetadata, error) {
 				StartHeight: m.activeMigration.StartHeight,
 				EndHeight:   m.activeMigration.EndHeight,
 			},
-			KwildMinorVersion: string(version.MinorVersionV9),
+			Version: MigrationVersion,
 		}, nil
 	}
 
@@ -432,9 +431,9 @@ func (m *Migrator) GetMigrationMetadata() (*types.MigrationMetadata, error) {
 			StartHeight: m.activeMigration.StartHeight,
 			EndHeight:   m.activeMigration.EndHeight,
 		},
-		SnapshotMetadata:  snapshotBts,
-		GenesisInfo:       &genesisInfo,
-		KwildMinorVersion: string(version.MinorVersionV9),
+		SnapshotMetadata: snapshotBts,
+		GenesisInfo:      &genesisInfo,
+		Version:          MigrationVersion,
 	}, nil
 }
 

--- a/internal/migrations/sql.go
+++ b/internal/migrations/sql.go
@@ -51,16 +51,15 @@ var (
 	tableMigrationsSQL = `CREATE TABLE IF NOT EXISTS ` + migrationsSchemaName + `.migration (
 		id INT PRIMARY KEY,
 		start_height INT8 NOT NULL,
-		end_height INT8 NOT NULL,
-		chain_id TEXT NOT NULL
+		end_height INT8 NOT NULL
 	)`
 
 	// getMigrationSQL is the sql query used to get the current migration.
-	getMigrationSQL = `SELECT start_height, end_height, chain_id FROM ` + migrationsSchemaName + `.migration;`
+	getMigrationSQL = `SELECT start_height, end_height FROM ` + migrationsSchemaName + `.migration;`
 	// migrationIsActiveSQL is the sql query used  to check if a migration is active.
 	migrationIsActiveSQL = `SELECT EXISTS(SELECT 1 FROM ` + migrationsSchemaName + `.migration);`
 	// createMigrationSQL is the sql query used to create a new migration.
-	createMigrationSQL = `INSERT INTO ` + migrationsSchemaName + `.migration (id, start_height, end_height, chain_id) VALUES ($1, $2, $3, $4);`
+	createMigrationSQL = `INSERT INTO ` + migrationsSchemaName + `.migration (id, start_height, end_height) VALUES ($1, $2, $3, $4);`
 
 	lastStoreChangeset = `last_stored_changeset`
 
@@ -108,11 +107,6 @@ func getMigrationState(ctx context.Context, db sql.Executor) (*activeMigration, 
 		return nil, fmt.Errorf("internal bug: duration is not an int64")
 	}
 
-	md.ChainID, ok = row[2].(string)
-	if !ok {
-		return nil, fmt.Errorf("internal bug: chain ID is not a string")
-	}
-
 	return md, nil
 }
 
@@ -139,7 +133,7 @@ func migrationActive(ctx context.Context, db sql.Executor) (bool, error) {
 
 // createMigration creates a new migration state in the database.
 func createMigration(ctx context.Context, db sql.Executor, md *activeMigration) error {
-	_, err := db.Execute(ctx, createMigrationSQL, 1, md.StartHeight, md.EndHeight, md.ChainID)
+	_, err := db.Execute(ctx, createMigrationSQL, 1, md.StartHeight, md.EndHeight)
 	return err
 }
 

--- a/internal/migrations/sql.go
+++ b/internal/migrations/sql.go
@@ -59,7 +59,7 @@ var (
 	// migrationIsActiveSQL is the sql query used  to check if a migration is active.
 	migrationIsActiveSQL = `SELECT EXISTS(SELECT 1 FROM ` + migrationsSchemaName + `.migration);`
 	// createMigrationSQL is the sql query used to create a new migration.
-	createMigrationSQL = `INSERT INTO ` + migrationsSchemaName + `.migration (id, start_height, end_height) VALUES ($1, $2, $3, $4);`
+	createMigrationSQL = `INSERT INTO ` + migrationsSchemaName + `.migration (id, start_height, end_height) VALUES ($1, $2, $3);`
 
 	lastStoreChangeset = `last_stored_changeset`
 

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -936,7 +936,6 @@ func (svc *Service) ListPendingMigrations(ctx context.Context, req *userjson.Lis
 			ID:               res.ID,
 			ActivationPeriod: (int64)(mig.ActivationPeriod),
 			Duration:         (int64)(mig.Duration),
-			ChainID:          mig.ChainID,
 			Timestamp:        mig.Timestamp,
 		})
 	}

--- a/internal/statesync/snapshot.go
+++ b/internal/statesync/snapshot.go
@@ -5,11 +5,12 @@ import (
 	"os"
 )
 
-// Snapshot is the header of a snapshot file representing the snapshot of the database at a certain height.
-// It contains the height, format, chunk count, hash, size, and name of the snapshot.
-
 const HashLen int = 32
 
+// Snapshot is the header of a snapshot file representing the snapshot of the database at a certain height.
+// It contains the height, format, chunk count, hash, size, and name of the snapshot.
+// WARNING: This struct CAN NOT be changed without breaking functionality,
+// since it is used for communication between nodes.
 type Snapshot struct {
 	Height       uint64          `json:"height"`
 	Format       uint32          `json:"format"`

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,30 +15,19 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0." + MinorVersionV9 + ".0-pre"
-
-// MinorVersion is the minor version of the major version 0.
-type MinorVersion string
-
-// we start with 9 because we only started tracking this in v0.9.0
-const (
-	// MinorVersionV0 is the first minor version of the major version 0.
-	MinorVersionV9 MinorVersion = "9"
-)
+const kwilVersion = "0.9.0-pre"
 
 // KwildVersion may be set at compile time by:
 //
 //	go build -ldflags "-s -w -X github.com/kwilteam/kwil-db/internal/version.KwilVersion=0.6.0+release"
 var (
 	KwilVersion string
-	// KwilMinorVersion is the minor version of the major version 0.
-	KwilMinorVersion MinorVersion = MinorVersionV9
-	Build                         = vcsInfo()
+	Build       = vcsInfo()
 )
 
 func init() {
 	if KwilVersion == "" { // not set via ldflags
-		KwilVersion = string(kwilVersion)
+		KwilVersion = kwilVersion
 		if Build != nil && Build.RevisionShort != "" {
 			// Append VCS revision and workspace dirty flag.
 			sep := "+" // start build metadata

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,19 +15,30 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0.9.0-pre"
+const kwilVersion = "0." + MinorVersionV9 + ".0-pre"
+
+// MinorVersion is the minor version of the major version 0.
+type MinorVersion string
+
+// we start with 9 because we only started tracking this in v0.9.0
+const (
+	// MinorVersionV0 is the first minor version of the major version 0.
+	MinorVersionV9 MinorVersion = "9"
+)
 
 // KwildVersion may be set at compile time by:
 //
 //	go build -ldflags "-s -w -X github.com/kwilteam/kwil-db/internal/version.KwilVersion=0.6.0+release"
 var (
 	KwilVersion string
-	Build       = vcsInfo()
+	// KwilMinorVersion is the minor version of the major version 0.
+	KwilMinorVersion MinorVersion = MinorVersionV9
+	Build                         = vcsInfo()
 )
 
 func init() {
 	if KwilVersion == "" { // not set via ldflags
-		KwilVersion = kwilVersion
+		KwilVersion = string(kwilVersion)
 		if Build != nil && Build.RevisionShort != "" {
 			// Append VCS revision and workspace dirty flag.
 			sep := "+" // start build metadata

--- a/test/driver/operator/cli_driver.go
+++ b/test/driver/operator/cli_driver.go
@@ -185,7 +185,7 @@ type respTxQuery struct {
 
 func (o *OperatorCLIDriver) SubmitMigrationProposal(ctx context.Context, activationHeight, migrationDuration *big.Int) ([]byte, error) {
 	var res display.TxHashResponse
-	err := o.runCommand(ctx, &res, "migrate", "propose", "activation-period", activationHeight.String(), "duration", migrationDuration.String())
+	err := o.runCommand(ctx, &res, "migrate", "propose", "--activation-period", activationHeight.String(), "--duration", migrationDuration.String())
 	if err != nil {
 		return nil, err
 	}

--- a/test/driver/operator/cli_driver.go
+++ b/test/driver/operator/cli_driver.go
@@ -183,9 +183,9 @@ type respTxQuery struct {
 	} `json:"tx_result"`
 }
 
-func (o *OperatorCLIDriver) SubmitMigrationProposal(ctx context.Context, activationHeight, migrationDuration *big.Int, chainID string) ([]byte, error) {
+func (o *OperatorCLIDriver) SubmitMigrationProposal(ctx context.Context, activationHeight, migrationDuration *big.Int) ([]byte, error) {
 	var res display.TxHashResponse
-	err := o.runCommand(ctx, &res, "migrate", "propose", activationHeight.String(), migrationDuration.String(), chainID)
+	err := o.runCommand(ctx, &res, "migrate", "propose", "activation-period", activationHeight.String(), "duration", migrationDuration.String())
 	if err != nil {
 		return nil, err
 	}

--- a/test/driver/operator/client_driver.go
+++ b/test/driver/operator/client_driver.go
@@ -88,7 +88,7 @@ func (a *AdminClientDriver) ConnectedPeers(ctx context.Context) ([]string, error
 	return peers, nil
 }
 
-func (a *AdminClientDriver) SubmitMigrationProposal(ctx context.Context, activationPeriod, migrationDuration *big.Int, chainID string) ([]byte, error) {
+func (a *AdminClientDriver) SubmitMigrationProposal(ctx context.Context, activationPeriod, migrationDuration *big.Int) ([]byte, error) {
 	// return a.Client.SubmitMigrationProposal(ctx, activationHeight, migrationDuration, chainID)
 	activationHeight := activationPeriod.Uint64()
 	dur := migrationDuration.Uint64()
@@ -96,7 +96,6 @@ func (a *AdminClientDriver) SubmitMigrationProposal(ctx context.Context, activat
 	res := migrations.MigrationDeclaration{
 		ActivationPeriod: activationHeight,
 		Duration:         dur,
-		ChainID:          chainID,
 		Timestamp:        time.Now().String(),
 	}
 	proposalBts, err := res.MarshalBinary()

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -979,7 +979,7 @@ func TestLongRunningNetworkMigrations(t *testing.T) {
 		newDir := helper.MigrationSetup(ctx)
 
 		// Trigger a network migration request
-		specifications.SubmitMigrationProposal(ctx, t, node0Driver, integration.MigrationChainID)
+		specifications.SubmitMigrationProposal(ctx, t, node0Driver)
 
 		// node1 approves the migration and verifies that the migration is still pending
 		specifications.ApproveMigration(ctx, t, node1Driver, true)

--- a/test/specifications/dsl.go
+++ b/test/specifications/dsl.go
@@ -158,7 +158,7 @@ type PeersDsl interface {
 
 type MigrationOpsDsl interface {
 	TxQueryDsl
-	SubmitMigrationProposal(ctx context.Context, activationHeight *big.Int, migrationDuration *big.Int, chainID string) ([]byte, error)
+	SubmitMigrationProposal(ctx context.Context, activationHeight *big.Int, migrationDuration *big.Int) ([]byte, error)
 	ApproveMigration(ctx context.Context, migrationResolutionID *types.UUID) ([]byte, error)
 	ListMigrations(ctx context.Context) ([]*types.Migration, error)
 	GenesisState(ctx context.Context) (*types.MigrationMetadata, error)

--- a/test/specifications/migration.go
+++ b/test/specifications/migration.go
@@ -16,11 +16,11 @@ import (
 )
 
 // Trigger migration
-func SubmitMigrationProposal(ctx context.Context, t *testing.T, netops MigrationOpsDsl, chainID string) {
+func SubmitMigrationProposal(ctx context.Context, t *testing.T, netops MigrationOpsDsl) {
 	t.Log("Executing migration trigger specification")
 
 	// Trigger migration"
-	txHash, err := netops.SubmitMigrationProposal(ctx, big.NewInt(1), big.NewInt(100), chainID)
+	txHash, err := netops.SubmitMigrationProposal(ctx, big.NewInt(1), big.NewInt(100))
 	require.NoError(t, err)
 
 	// Ensure that the Tx is mined.


### PR DESCRIPTION
This PR simplifies migration structs. There are three key changes:

1. It removes `chain-id` from the migration proposals, since they are effectively a suggestion anyways.
2. It simplifies the struct that is passed back from the client when querying for migrations. It previously used to return serialized genesis.json, but now returns a much slimmed down struct that only contains necessary info.
3. It adds kwild's minor version to the migration metadata when querying a node. This is because we still send the snapshot metadata serialized, and thus need to maintain compatibility between versions. I thought about moving snapshot metadata into `core/types`, but didn't to keep it simple.