### PR TITLE
Added migrate network-status, proposal-status commands, new status fe…

### DIFF
--- a/cmd/kwil-admin/cmds/migration/approve.go
+++ b/cmd/kwil-admin/cmds/migration/approve.go
@@ -10,9 +10,9 @@ import (
 
 func approveCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "approve <proposal-id>",
+		Use:     "approve <proposal_id>",
 		Short:   "Approve a migration proposal.",
-		Example: "kwil-admin migrate approve <proposal-id>",
+		Example: "kwil-admin migrate approve <proposal_id>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/kwil-admin/cmds/migration/cmd.go
+++ b/cmd/kwil-admin/cmds/migration/cmd.go
@@ -17,8 +17,9 @@ func NewMigrationCmd() *cobra.Command {
 		proposeCmd(),
 		approveCmd(),
 		listCmd(),
-		statusCmd(),
+		proposalStatusCmd(),
 		genesisStateCmd(),
+		networkStatusCmd(),
 	)
 
 	common.BindRPCFlags(migrationCmd)

--- a/cmd/kwil-admin/cmds/migration/genesis.go
+++ b/cmd/kwil-admin/cmds/migration/genesis.go
@@ -60,7 +60,7 @@ func genesisStateCmd() *cobra.Command {
 			// If there is no active migration or if the migration has not started yet, return the migration state
 			// indicating that there is no genesis state to download.
 			if metadata.MigrationState.Status == types.NoActiveMigration ||
-				metadata.MigrationState.Status == types.MigrationNotStarted ||
+				metadata.MigrationState.Status == types.ActivationPeriod ||
 				metadata.GenesisInfo == nil || metadata.SnapshotMetadata == nil {
 				return display.PrintCmd(cmd, &MigrationState{
 					Info: metadata.MigrationState,
@@ -160,7 +160,11 @@ func (m *MigrationState) MarshalText() ([]byte, error) {
 		return []byte("No active migration found."), nil
 	}
 
-	if m.Info.Status == types.MigrationNotStarted {
+	if m.Info.Status == types.GenesisMigration {
+		return []byte("Genesis migration in progress. No genesis state to download."), nil
+	}
+
+	if m.Info.Status == types.ActivationPeriod {
 		return []byte(fmt.Sprintf("No genesis state to download yet. Migration is set to start at block height: %d", m.Info.StartHeight)), nil
 	}
 

--- a/cmd/kwil-admin/cmds/migration/genesis.go
+++ b/cmd/kwil-admin/cmds/migration/genesis.go
@@ -57,6 +57,9 @@ func genesisStateCmd() *cobra.Command {
 				return display.PrintErr(cmd, fmt.Errorf("genesis state download is incompatible. Received version: %d, supported versions: [%d]", metadata.Version, migrations.MigrationVersion))
 			}
 
+			if metadata.MigrationState.Status == types.GenesisMigration {
+				return display.PrintErr(cmd, fmt.Errorf("genesis state command should only be used against the nodes from a network being migrated from"))
+			}
 			// If there is no active migration or if the migration has not started yet, return the migration state
 			// indicating that there is no genesis state to download.
 			if metadata.MigrationState.Status == types.NoActiveMigration ||
@@ -158,10 +161,6 @@ type MigrationState struct {
 func (m *MigrationState) MarshalText() ([]byte, error) {
 	if m.Info.Status == types.NoActiveMigration {
 		return []byte("No active migration found."), nil
-	}
-
-	if m.Info.Status == types.GenesisMigration {
-		return []byte("Genesis migration in progress. No genesis state to download."), nil
 	}
 
 	if m.Info.Status == types.ActivationPeriod {

--- a/cmd/kwil-admin/cmds/migration/list.go
+++ b/cmd/kwil-admin/cmds/migration/list.go
@@ -14,11 +14,11 @@ import (
 
 func listCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "list",
+		Use:   "proposals",
 		Short: "List all the pending migration proposals.",
 		Long:  "List all the pending migration proposals.",
 		Example: `# List all the pending migration proposals.
-kwil-admin migrate list`,
+kwil-admin migrate proposals`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/kwil-admin/cmds/migration/network_status.go
+++ b/cmd/kwil-admin/cmds/migration/network_status.go
@@ -53,7 +53,10 @@ func (m *migrationStatus) MarshalJSON() ([]byte, error) {
 
 func (m *migrationStatus) MarshalText() ([]byte, error) {
 	if m.Status == types.NoActiveMigration {
-		return []byte("No active migration on the network."), nil
+		if m.StartHeight == 0 && m.EndHeight == 0 {
+			return []byte("No active migration on the network."), nil
+		}
+		return []byte("Genesis migration completed. No active migration on the network."), nil
 	}
 
 	if m.Status == types.GenesisMigration {

--- a/cmd/kwil-admin/cmds/migration/network_status.go
+++ b/cmd/kwil-admin/cmds/migration/network_status.go
@@ -33,7 +33,7 @@ func networkStatusCmd() *cobra.Command {
 				Status:        status.Status,
 				StartHeight:   status.StartHeight,
 				EndHeight:     status.EndHeight,
-				CurrentHeight: status.CurrentBlock,
+				CurrentHeight: status.CurrentHeight,
 			})
 		},
 	}

--- a/cmd/kwil-admin/cmds/migration/network_status.go
+++ b/cmd/kwil-admin/cmds/migration/network_status.go
@@ -29,10 +29,6 @@ func networkStatusCmd() *cobra.Command {
 				return display.PrintErr(cmd, err)
 			}
 
-			if status.Status == types.UnknownMigrationStatus {
-				return display.PrintErr(cmd, fmt.Errorf("migration status unknown"))
-			}
-
 			return display.PrintCmd(cmd, &migrationStatus{
 				Status:        status.Status,
 				StartHeight:   status.StartHeight,
@@ -65,8 +61,8 @@ func (m *migrationStatus) MarshalText() ([]byte, error) {
 	}
 
 	return []byte(fmt.Sprintf("Migration Status: %s\n"+
-		"StartHeight: %d\n"+
-		"EndHeight: %d\n"+
-		"CurrentBlock: %d\n",
-		m.Status.String(), m.StartHeight, m.EndHeight, m.CurrentHeight)), nil
+		"Start Height: %d\n"+
+		"End Height: %d\n"+
+		"Current Block: %d\n",
+		m.Status, m.StartHeight, m.EndHeight, m.CurrentHeight)), nil
 }

--- a/cmd/kwil-admin/cmds/migration/network_status.go
+++ b/cmd/kwil-admin/cmds/migration/network_status.go
@@ -12,10 +12,10 @@ import (
 
 func networkStatusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:   "network-status",
+		Use:   "status",
 		Short: "Get the migration status of the network.",
 		Example: `# Get the migration status of the network.
-		kwil-admin migrate network-status`,
+		kwil-admin migrate status`,
 		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()

--- a/cmd/kwil-admin/cmds/migration/network_status.go
+++ b/cmd/kwil-admin/cmds/migration/network_status.go
@@ -1,0 +1,72 @@
+package migration
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/kwilteam/kwil-db/cmd/common/display"
+	"github.com/kwilteam/kwil-db/cmd/kwil-admin/cmds/common"
+	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/spf13/cobra"
+)
+
+func networkStatusCmd() *cobra.Command {
+	return &cobra.Command{
+		Use:   "network-status",
+		Short: "Get the migration status of the network.",
+		Example: `# Get the migration status of the network.
+		kwil-admin migrate network-status`,
+		Args: cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+			clt, err := common.GetAdminSvcClient(ctx, cmd)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			status, err := clt.MigrationStatus(ctx)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			if status.Status == types.UnknownMigrationStatus {
+				return display.PrintErr(cmd, fmt.Errorf("migration status unknown"))
+			}
+
+			return display.PrintCmd(cmd, &migrationStatus{
+				Status:        status.Status,
+				StartHeight:   status.StartHeight,
+				EndHeight:     status.EndHeight,
+				CurrentHeight: status.CurrentBlock,
+			})
+		},
+	}
+}
+
+type migrationStatus struct {
+	Status        types.MigrationStatus `json:"status"`
+	StartHeight   int64                 `json:"start_height"`
+	EndHeight     int64                 `json:"end_height"`
+	CurrentHeight int64                 `json:"current_height"`
+}
+
+func (m *migrationStatus) MarshalJSON() ([]byte, error) {
+	type alias migrationStatus
+	return json.Marshal((*alias)(m)) // slice off methods to avoid recursive call
+}
+
+func (m *migrationStatus) MarshalText() ([]byte, error) {
+	if m.Status == types.NoActiveMigration {
+		return []byte("No active migration on the network."), nil
+	}
+
+	if m.Status == types.GenesisMigration {
+		return []byte("Genesis migration in progress."), nil
+	}
+
+	return []byte(fmt.Sprintf("Migration Status: %s\n"+
+		"StartHeight: %d\n"+
+		"EndHeight: %d\n"+
+		"CurrentBlock: %d\n",
+		m.Status.String(), m.StartHeight, m.EndHeight, m.CurrentHeight)), nil
+}

--- a/cmd/kwil-admin/cmds/migration/proposal_status.go
+++ b/cmd/kwil-admin/cmds/migration/proposal_status.go
@@ -14,12 +14,12 @@ import (
 
 var (
 	statusExample = `# Get the status of the pending migration.
-kwil-admin migrate status <proposalID>`
+kwil-admin migrate proposal-status <proposal_id>`
 )
 
-func statusCmd() *cobra.Command {
+func proposalStatusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "status",
+		Use:     "proposal-status",
 		Short:   "Get the status of the pending migration proposal.",
 		Long:    "Get the status of the pending migration proposal.",
 		Example: statusExample,

--- a/cmd/kwil-admin/cmds/migration/proposal_status.go
+++ b/cmd/kwil-admin/cmds/migration/proposal_status.go
@@ -19,7 +19,7 @@ kwil-admin migrate proposal-status <proposal_id>`
 
 func proposalStatusCmd() *cobra.Command {
 	return &cobra.Command{
-		Use:     "proposal-status",
+		Use:     "proposal-status <proposal_id>",
 		Short:   "Get the status of the pending migration proposal.",
 		Long:    "Get the status of the pending migration proposal.",
 		Example: statusExample,

--- a/cmd/kwil-admin/cmds/migration/proposal_status.go
+++ b/cmd/kwil-admin/cmds/migration/proposal_status.go
@@ -73,7 +73,7 @@ func (m *MigrationStatus) MarshalText() ([]byte, error) {
 	var msg bytes.Buffer
 	msg.WriteString("Migration Status:\n")
 	msg.WriteString(fmt.Sprintf("\tProposal ID: %s\n", m.ProposalID.String()))
-	msg.WriteString(fmt.Sprintf("\tExpiresAt: %d\n", m.ExpiresAt))
+	msg.WriteString(fmt.Sprintf("\tExpires At: %d\n", m.ExpiresAt))
 	msg.WriteString(fmt.Sprintf("\tApprovals Received: %d (needed %d)\n", approved, needed))
 
 	for i := range m.Board {

--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -114,7 +114,7 @@ enable = {{ .MigrationConfig.Enable }}
 # The listening address of the trusted node from the old network. This is used to
 # fetch the genesis state and the block changes from the old network during migration.
 # This is a mandatory field if migration is enabled.
-migrate_from = "{{ .MigrationConfig.MigrateFrom }}"
+from = "{{ .MigrationConfig.MigrateFrom }}"
 
 #######################################################################
 ###                      App Config Options                         ###

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -23,6 +23,21 @@
 # The rest of the files & directories are created by the kwild node on startup
 
 #######################################################################
+###                    Migration Config Options                     ###
+#######################################################################
+
+[migration]
+
+# Enables migration mode
+enable = false
+
+# The listening address of the trusted node from the old network. This is used to
+# fetch the genesis state and the block changes from the old network during migration.
+# This is a mandatory field if migration is enabled.
+# from = "http://localhost:8484"
+from = ""
+
+#######################################################################
 ###                      App Config Options                         ###
 #######################################################################
 

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -29,7 +29,7 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 
 	// Migration flags:
 	flagSet.BoolVar(&cfg.MigrationConfig.Enable, "migration.enable", cfg.MigrationConfig.Enable, "Enable migration")
-	flagSet.StringVar(&cfg.MigrationConfig.MigrateFrom, "migration.from", cfg.MigrationConfig.MigrateFrom, format("%s JSON-RPC listening address of the node to replicate the state from."))
+	flagSet.StringVar(&cfg.MigrationConfig.MigrateFrom, "migration.migrate-from", cfg.MigrationConfig.MigrateFrom, format("%s JSON-RPC listening address of the node to replicate the state from."))
 
 	// General APP flags:
 	flagSet.StringVar(&cfg.AppConfig.PrivateKeyPath, "app.private-key-path", cfg.AppConfig.PrivateKeyPath, "Path to the node private key file")

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -29,7 +29,7 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *config.KwildConfig) {
 
 	// Migration flags:
 	flagSet.BoolVar(&cfg.MigrationConfig.Enable, "migration.enable", cfg.MigrationConfig.Enable, "Enable migration")
-	flagSet.StringVar(&cfg.MigrationConfig.MigrateFrom, "migration.migrate-from", cfg.MigrationConfig.MigrateFrom, format("%s JSON-RPC listening address of the node to replicate the state from."))
+	flagSet.StringVar(&cfg.MigrationConfig.MigrateFrom, "migration.from", cfg.MigrationConfig.MigrateFrom, format("%s JSON-RPC listening address of the node to replicate the state from."))
 
 	// General APP flags:
 	flagSet.StringVar(&cfg.AppConfig.PrivateKeyPath, "app.private-key-path", cfg.AppConfig.PrivateKeyPath, "Path to the node private key file")

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -627,12 +627,34 @@ func isDbInitialized(d *coreDependencies) bool {
 	}
 	defer db.Close()
 
-	// Check if the database is empty or initialized previously
-	// If the database is empty, we need to restore the database from the snapshot
-	vals, _ := voting.GetValidators(d.ctx, db)
-	// ERROR: relation "kwild_voting.voters" does not exist
-	// assumption that error is due to the missing table and schema.
-	return len(vals) > 0
+	// Check if the kwild_voting schema exists
+	exists, err := schemaExists(d.ctx, db, "kwild_voting")
+	if err != nil {
+		failBuild(err, "failed to check if schema exists")
+	}
+
+	// If the schema exists, the database is already initialized
+	// If the schema does not exist, the database is not initialized
+	return exists
+}
+
+// schemaExists checks if the schema with the given name exists in the database
+func schemaExists(ctx context.Context, db sql.Executor, schema string) (bool, error) {
+	query := fmt.Sprintf("SELECT 1 FROM information_schema.schemata WHERE schema_name = '%s'", schema)
+	res, err := db.Execute(ctx, query)
+	if err != nil {
+		return false, err
+	}
+
+	if len(res.Rows) == 0 {
+		return false, nil
+	}
+
+	if len(res.Rows) > 1 {
+		return false, fmt.Errorf("more than one schema found with name %s", schema)
+	}
+
+	return true, nil
 }
 
 func buildEngine(d *coreDependencies, db *pg.DB) *execution.GlobalContext {

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -173,7 +173,7 @@ func buildServer(d *coreDependencies, closers *closeFuncs) *Server {
 
 	// admin service and server
 	signer := buildSigner(d)
-	jsonAdminSvc := adminsvc.NewService(db, wrappedCmtClient, txApp, abciApp, p2p, migrator, signer, d.cfg,
+	jsonAdminSvc := adminsvc.NewService(db, wrappedCmtClient, txApp, abciApp, p2p, signer, d.cfg,
 		d.genesisCfg.ChainID, *d.log.Named("admin-json-svc"))
 	jsonRPCAdminServer := buildJRPCAdminServer(d)
 	jsonRPCAdminServer.RegisterSvc(jsonAdminSvc)

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -463,7 +463,7 @@ func buildMigrator(d *coreDependencies, db *pg.DB, txApp *txapp.TxApp) *migratio
 		failBuild(err, "failed to build snapshot store for migrations")
 	}
 
-	migrator, err := migrations.SetupMigrator(d.ctx, db, ss, txApp, migrationsDir, *d.log.Named("migrator"))
+	migrator, err := migrations.SetupMigrator(d.ctx, db, ss, txApp, migrationsDir, d.genesisCfg.ConsensusParams.Migration, *d.log.Named("migrator"))
 	if err != nil {
 		failBuild(err, "failed to build migrator")
 	}

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -153,7 +153,7 @@ func (m *migrationClient) downloadGenesisState(ctx context.Context) error {
 
 	// Check if the genesis state is ready
 	if metadata.MigrationState.Status == types.NoActiveMigration || metadata.MigrationState.Status == types.ActivationPeriod {
-		return fmt.Errorf("status %s", metadata.MigrationState.Status.String())
+		return fmt.Errorf("status %s", metadata.MigrationState.Status)
 	}
 
 	// Genesis state should ready

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -152,7 +152,7 @@ func (m *migrationClient) downloadGenesisState(ctx context.Context) error {
 	}
 
 	// Check if the genesis state is ready
-	if metadata.MigrationState.Status == types.NoActiveMigration || metadata.MigrationState.Status == types.MigrationNotStarted {
+	if metadata.MigrationState.Status == types.NoActiveMigration || metadata.MigrationState.Status == types.ActivationPeriod {
 		return fmt.Errorf("status %s", metadata.MigrationState.Status.String())
 	}
 

--- a/cmd/kwild/server/migration.go
+++ b/cmd/kwild/server/migration.go
@@ -13,7 +13,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/kwilteam/kwil-db/cmd/kwil-admin/nodecfg"
 	"github.com/kwilteam/kwil-db/cmd/kwild/config"
 	"github.com/kwilteam/kwil-db/common/chain"
 	commonCfg "github.com/kwilteam/kwil-db/common/config"
@@ -220,11 +219,6 @@ func (m *migrationClient) downloadGenesisState(ctx context.Context) error {
 	// Update the kwild config
 	m.kwildCfg.AppConfig.GenesisState = m.snapshotFileName
 
-	// persist the kwild config
-	if err := nodecfg.WriteConfigFile(filepath.Join(m.kwildCfg.RootDir, cometbft.ConfigTOMLName), m.kwildCfg); err != nil {
-		return fmt.Errorf("failed to save kwild config: %w", err)
-	}
-
 	m.logger.Info("Genesis state downloaded successfully", log.String("genesis snapshot", m.snapshotFileName))
 	return nil
 }
@@ -233,6 +227,9 @@ func (m *migrationClient) downloadGenesisState(ctx context.Context) error {
 // It is the caller's responsibility to check if the file exists.
 func validateGenesisState(filename string, appHash []byte) error {
 	// we don't need to check if the file exists since the caller should have already checked it
+	if appHash == nil {
+		return errors.New("genesis file should have app hash set")
+	}
 
 	genesisStateFile, err := os.Open(filename)
 	if err != nil {

--- a/common/common.go
+++ b/common/common.go
@@ -144,11 +144,6 @@ type NetworkParameters struct {
 	DisabledGasCosts bool
 
 	// MigrationStatus determines the status of the migration.
-	// It can be one of the following:
-	// - NoActiveMigration: No active migration is in progress.
-	// - MigrationNotStarted: A migration has been approved but not yet activated.
-	// - MigrationInProgress: A migration is in progress.
-	// - MigrationCompleted: A migration has been completed.
 	MigrationStatus types.MigrationStatus
 
 	// MaxVotesPerTx is the maximum number of votes that can be included in a

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -98,7 +98,7 @@ type AppConfig struct {
 type MigrationConfig struct {
 	Enable bool `mapstructure:"enable"`
 	// MigrateFrom is the JSON-RPC listening address of the node to replicate the state from.
-	MigrateFrom string `mapstructure:"migrate_from"`
+	MigrateFrom string `mapstructure:"from"`
 }
 
 type SnapshotConfig struct {

--- a/core/adminclient/client.go
+++ b/core/adminclient/client.go
@@ -53,6 +53,7 @@ type adminSvcClient interface {
 
 	// migration methods
 	ListMigrations(ctx context.Context) ([]*types.Migration, error)
+	MigrationStatus(ctx context.Context) (*types.MigrationState, error)
 	GenesisState(ctx context.Context) (*types.MigrationMetadata, error)
 	GenesisSnapshotChunk(ctx context.Context, height uint64, chunkIdx uint32) ([]byte, error)
 	LoadChangeset(ctx context.Context, height int64, index int64) ([]byte, error)

--- a/core/rpc/client/admin/jsonrpc/client.go
+++ b/core/rpc/client/admin/jsonrpc/client.go
@@ -150,11 +150,6 @@ func (cl *Client) Status(ctx context.Context) (*adminTypes.Status, error) {
 			PubKey: res.Validator.PubKey,
 			Power:  res.Validator.Power,
 		},
-		Migration: adminTypes.MigrationInfo{
-			Status:      res.Migration.Status.String(),
-			StartHeight: res.Migration.StartHeight,
-			EndHeight:   res.Migration.EndHeight,
-		},
 	}, nil
 }
 

--- a/core/rpc/client/user/jsonrpc/methods.go
+++ b/core/rpc/client/user/jsonrpc/methods.go
@@ -284,6 +284,16 @@ func (cl *Client) GenesisSnapshotChunk(ctx context.Context, height uint64, chunk
 	return res.Chunk, nil
 }
 
+func (cl *Client) MigrationStatus(ctx context.Context) (*types.MigrationState, error) {
+	cmd := &userjson.MigrationStatusRequest{}
+	res := &userjson.MigrationStatusResponse{}
+	err := cl.CallMethod(ctx, string(userjson.MethodMigrationStatus), cmd, res)
+	if err != nil {
+		return nil, err
+	}
+	return res.Status, nil
+}
+
 func (cl *Client) Challenge(ctx context.Context) ([]byte, error) {
 	cmd := &userjson.ChallengeRequest{}
 	res := &userjson.ChallengeResponse{}

--- a/core/rpc/client/user/txsvc.go
+++ b/core/rpc/client/user/txsvc.go
@@ -31,6 +31,7 @@ type TxSvcClient interface {
 	// Active Migration State
 	GenesisState(ctx context.Context) (*types.MigrationMetadata, error)
 	GenesisSnapshotChunk(ctx context.Context, height uint64, chunkIdx uint32) ([]byte, error)
+	MigrationStatus(ctx context.Context) (*types.MigrationState, error)
 
 	// Changesets
 	LoadChangeset(ctx context.Context, height int64, index int64) ([]byte, error)

--- a/core/rpc/json/user/commands.go
+++ b/core/rpc/json/user/commands.go
@@ -116,9 +116,7 @@ type MigrationSnapshotChunkRequest struct {
 type MigrationMetadataRequest struct{}
 type ListMigrationsRequest struct{}
 
-type MigrationStatusRequest struct {
-	Id string `json:"id"` // Id is the migration proposal ID
-}
+type MigrationStatusRequest struct{}
 
 type ChallengeRequest struct{}
 type HealthRequest struct{}

--- a/core/rpc/json/user/responses.go
+++ b/core/rpc/json/user/responses.go
@@ -104,7 +104,7 @@ type ListMigrationsResponse struct {
 }
 
 type MigrationStatusResponse struct {
-	Status *types.PendingResolution `json:"status"`
+	Status *types.MigrationState `json:"status"`
 }
 
 type ChallengeResponse struct {

--- a/core/types/admin/types.go
+++ b/core/types/admin/types.go
@@ -53,7 +53,6 @@ type Status struct {
 	Sync      *SyncInfo      `json:"sync"`
 	Validator *ValidatorInfo `json:"validator"`
 	App       *AppInfo       `json:"app"`
-	Migration MigrationInfo  `json:"migration"`
 }
 
 // PeerInfo describes a connected peer node.
@@ -64,7 +63,8 @@ type PeerInfo struct {
 }
 
 type MigrationInfo struct {
-	Status      string `json:"status"`
-	StartHeight int64  `json:"start_height"`
-	EndHeight   int64  `json:"end_height"`
+	Status        string `json:"status"`
+	StartHeight   int64  `json:"start_height"`
+	EndHeight     int64  `json:"end_height"`
+	CurrentHeight int64  `json:"current_height"`
 }

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -90,47 +90,28 @@ type Migration struct {
 	Timestamp        string `json:"timestamp"`          // Timestamp when the migration was proposed
 }
 
-type MigrationStatus int
+type MigrationStatus string
 
 const (
 	// NoActiveMigration indicates there is currently no migration process happening on the network.
-	NoActiveMigration MigrationStatus = iota
+	NoActiveMigration MigrationStatus = "NoActiveMigration"
 
 	// ActivationPeriod represents the phase after the migration proposal has been approved by the network,
 	// but before the migration begins. During this phase, validators prepare their nodes for migration.
-	ActivationPeriod
+	ActivationPeriod MigrationStatus = "ActivationPeriod"
 
 	// MigrationInProgress is the phase where the migration is actively occurring. The old and new networks
 	// run concurrently, with state changes from the old network being replicated to the new network.
-	MigrationInProgress
+	MigrationInProgress MigrationStatus = "MigrationInProgress"
 
 	// MigrationCompleted indicates the migration process has successfully finished,
 	// and the old network is ready to be decommissioned.
-	MigrationCompleted
+	MigrationCompleted MigrationStatus = "MigrationCompleted"
 
 	// GenesisMigration refers to the phase where the node initializes with the genesis state,
 	// tries to replicate the state changes from the old network.
-	GenesisMigration
-
-	UnknownMigrationStatus
+	GenesisMigration MigrationStatus = "GenesisMigration"
 )
-
-func (status *MigrationStatus) String() string {
-	switch *status {
-	case NoActiveMigration:
-		return "NoActiveMigration"
-	case ActivationPeriod:
-		return "ActivationPeriod"
-	case MigrationInProgress:
-		return "MigrationInProgress"
-	case MigrationCompleted:
-		return "MigrationCompleted"
-	case GenesisMigration:
-		return "GenesisMigration"
-	default:
-		return "Unknown"
-	}
-}
 
 type MigrationState struct {
 	Status       MigrationStatus `json:"status"`       // Status is the current status of the migration

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -93,31 +93,50 @@ type Migration struct {
 type MigrationStatus int
 
 const (
+	// NoActiveMigration indicates there is currently no migration process happening on the network.
 	NoActiveMigration MigrationStatus = iota
-	MigrationNotStarted
+
+	// ActivationPeriod represents the phase after the migration proposal has been approved by the network,
+	// but before the migration begins. During this phase, validators prepare their nodes for migration.
+	ActivationPeriod
+
+	// MigrationInProgress is the phase where the migration is actively occurring. The old and new networks
+	// run concurrently, with state changes from the old network being replicated to the new network.
 	MigrationInProgress
+
+	// MigrationCompleted indicates the migration process has successfully finished,
+	// and the old network is ready to be decommissioned.
 	MigrationCompleted
+
+	// GenesisMigration refers to the phase where the node initializes with the genesis state,
+	// tries to replicate the state changes from the old network.
+	GenesisMigration
+
+	UnknownMigrationStatus
 )
 
 func (status *MigrationStatus) String() string {
 	switch *status {
 	case NoActiveMigration:
 		return "NoActiveMigration"
-	case MigrationNotStarted:
-		return "MigrationNotStarted"
+	case ActivationPeriod:
+		return "ActivationPeriod"
 	case MigrationInProgress:
 		return "MigrationInProgress"
 	case MigrationCompleted:
 		return "MigrationCompleted"
+	case GenesisMigration:
+		return "GenesisMigration"
 	default:
 		return "Unknown"
 	}
 }
 
 type MigrationState struct {
-	Status      MigrationStatus `json:"status"`       // Status is the current status of the migration
-	StartHeight int64           `json:"start_height"` // StartHeight is the block height at which the migration started
-	EndHeight   int64           `json:"end_height"`   // EndHeight is the block height at which the migration ends
+	Status       MigrationStatus `json:"status"`       // Status is the current status of the migration
+	StartHeight  int64           `json:"start_height"` // StartHeight is the block height at which the migration started
+	EndHeight    int64           `json:"end_height"`   // EndHeight is the block height at which the migration ends
+	CurrentBlock int64           `json:"chain_height"` // CurrentBlock is the current block height of the node
 }
 
 // MigrationMetadata holds metadata about a migration, informing

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -115,10 +115,10 @@ const (
 )
 
 type MigrationState struct {
-	Status        MigrationStatus `json:"status"`       // Status is the current status of the migration
-	StartHeight   int64           `json:"start_height"` // StartHeight is the block height at which the migration started
-	EndHeight     int64           `json:"end_height"`   // EndHeight is the block height at which the migration ends
-	CurrentHeight int64           `json:"chain_height"` // CurrentHeight is the current block height of the node
+	Status        MigrationStatus `json:"status"`                 // Status is the current status of the migration
+	StartHeight   int64           `json:"start_height,omitempty"` // StartHeight is the block height at which the migration started on the old chain
+	EndHeight     int64           `json:"end_height,omitempty"`   // EndHeight is the block height at which the migration ends on the old chain
+	CurrentHeight int64           `json:"chain_height,omitempty"` // CurrentHeight is the current block height of the node
 }
 
 // MigrationMetadata holds metadata about a migration, informing

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -90,6 +90,7 @@ type Migration struct {
 	Timestamp        string `json:"timestamp"`          // Timestamp when the migration was proposed
 }
 
+// MigrationStatus represents the status of the nodes in the zero downtime migration process.
 type MigrationStatus string
 
 const (
@@ -100,24 +101,24 @@ const (
 	// but before the migration begins. During this phase, validators prepare their nodes for migration.
 	ActivationPeriod MigrationStatus = "ActivationPeriod"
 
-	// MigrationInProgress is the phase where the migration is actively occurring. The old and new networks
-	// run concurrently, with state changes from the old network being replicated to the new network.
+	// MigrationInProgress indicates that the nodes on the old network are in migration mode and
+	// records the state changes to be replicated on the new network.
 	MigrationInProgress MigrationStatus = "MigrationInProgress"
 
-	// MigrationCompleted indicates the migration process has successfully finished,
-	// and the old network is ready to be decommissioned.
+	// MigrationCompleted indicates that the migration process has successfully finished on the old network,
+	// and the old network is ready to be decommissioned once the new network has caught up.
 	MigrationCompleted MigrationStatus = "MigrationCompleted"
 
-	// GenesisMigration refers to the phase where the node initializes with the genesis state,
-	// tries to replicate the state changes from the old network.
+	// GenesisMigration refers to the phase where the nodes on the new network during migration bootstraps
+	// with the genesis state and replicates the state changes from the old network.
 	GenesisMigration MigrationStatus = "GenesisMigration"
 )
 
 type MigrationState struct {
-	Status       MigrationStatus `json:"status"`       // Status is the current status of the migration
-	StartHeight  int64           `json:"start_height"` // StartHeight is the block height at which the migration started
-	EndHeight    int64           `json:"end_height"`   // EndHeight is the block height at which the migration ends
-	CurrentBlock int64           `json:"chain_height"` // CurrentBlock is the current block height of the node
+	Status        MigrationStatus `json:"status"`       // Status is the current status of the migration
+	StartHeight   int64           `json:"start_height"` // StartHeight is the block height at which the migration started
+	EndHeight     int64           `json:"end_height"`   // EndHeight is the block height at which the migration ends
+	CurrentHeight int64           `json:"chain_height"` // CurrentHeight is the current block height of the node
 }
 
 // MigrationMetadata holds metadata about a migration, informing

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -297,10 +297,7 @@ func NewAbciApp(ctx context.Context, cfg *AbciConfig, snapshotter SnapshotModule
 		}
 	}
 
-	migrationStatus, err := migrator.MigrationStatus(ctx)
-	if err != nil {
-		return nil, fmt.Errorf("failed to get migration status: %w", err)
-	}
+	migrationStatus := migrator.MigrationStatus(ctx)
 	app.log.Infof("Migration status: %s", migrationStatus.String())
 	networkParams.MigrationStatus = migrationStatus
 	app.lastMigrationStatus = migrationStatus

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -94,6 +94,6 @@ type WhitelistPeersModule interface {
 type MigratorModule interface {
 	NotifyHeight(ctx context.Context, block *common.BlockContext, db migrations.Database) error
 	StoreChangesets(height int64, changes <-chan any)
-	MigrationStatus(ctx context.Context) (types.MigrationStatus, error)
+	MigrationStatus(ctx context.Context) types.MigrationStatus
 	PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error
 }

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -93,7 +93,7 @@ type WhitelistPeersModule interface {
 
 type MigratorModule interface {
 	NotifyHeight(ctx context.Context, block *common.BlockContext, db migrations.Database) error
-	StoreChangesets(height int64, changes <-chan any)
-	MigrationStatus(ctx context.Context) types.MigrationStatus
+	StoreChangesets(height int64, changes <-chan any, doneChan chan<- bool, errChan chan<- error)
 	PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error
+	SetMigrationStatus(status types.MigrationStatus)
 }

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -93,7 +93,7 @@ type WhitelistPeersModule interface {
 
 type MigratorModule interface {
 	NotifyHeight(ctx context.Context, block *common.BlockContext, db migrations.Database) error
-	StoreChangesets(height int64, changes <-chan any, errChan chan<- error)
+	StoreChangesets(height int64, changes <-chan any) error
 	PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error
-	SetMigrationStatus(status types.MigrationStatus)
+	GetMigrationMetadata(ctx context.Context, status types.MigrationStatus) (*types.MigrationMetadata, error)
 }

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -94,6 +94,6 @@ type WhitelistPeersModule interface {
 type MigratorModule interface {
 	NotifyHeight(ctx context.Context, block *common.BlockContext, db migrations.Database) error
 	StoreChangesets(height int64, changes <-chan any)
-	MigrationStatus() types.MigrationStatus
+	MigrationStatus(ctx context.Context) (types.MigrationStatus, error)
 	PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error
 }

--- a/internal/abci/interfaces.go
+++ b/internal/abci/interfaces.go
@@ -93,7 +93,7 @@ type WhitelistPeersModule interface {
 
 type MigratorModule interface {
 	NotifyHeight(ctx context.Context, block *common.BlockContext, db migrations.Database) error
-	StoreChangesets(height int64, changes <-chan any, doneChan chan<- bool, errChan chan<- error)
+	StoreChangesets(height int64, changes <-chan any, errChan chan<- error)
 	PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error
 	SetMigrationStatus(status types.MigrationStatus)
 }

--- a/internal/abci/meta/meta.go
+++ b/internal/abci/meta/meta.go
@@ -304,3 +304,21 @@ const (
 	migrationStatus = `migration_status`
 	maxVotesPerTx   = `max_votes_per_tx`
 )
+
+func MigrationStatus(ctx context.Context, db sql.ReadTxMaker) (types.MigrationStatus, error) {
+	tx, err := db.BeginReadTx(ctx)
+	if err != nil {
+		return types.NoActiveMigration, err
+	}
+	defer tx.Rollback(ctx)
+
+	params, err := LoadParams(ctx, tx)
+	if err != nil {
+		if err == ErrParamsNotFound {
+			return types.NoActiveMigration, nil
+		}
+		return types.NoActiveMigration, err
+	}
+
+	return params.MigrationStatus, nil
+}

--- a/internal/abci/meta/meta.go
+++ b/internal/abci/meta/meta.go
@@ -282,6 +282,7 @@ func diff(original, new *common.NetworkParameters) map[string][]byte {
 	}
 
 	if original.MigrationStatus != new.MigrationStatus {
+		fmt.Println("Migration status changed", original.MigrationStatus, new.MigrationStatus)
 		buf := make([]byte, 8)
 		binary.LittleEndian.PutUint64(buf, uint64(new.MigrationStatus))
 		d[migrationStatus] = buf

--- a/internal/abci/meta/meta.go
+++ b/internal/abci/meta/meta.go
@@ -301,21 +301,3 @@ const (
 	migrationStatus = `migration_status`
 	maxVotesPerTx   = `max_votes_per_tx`
 )
-
-func MigrationStatus(ctx context.Context, db sql.ReadTxMaker) (types.MigrationStatus, error) {
-	tx, err := db.BeginReadTx(ctx)
-	if err != nil {
-		return types.NoActiveMigration, err
-	}
-	defer tx.Rollback(ctx)
-
-	params, err := LoadParams(ctx, tx)
-	if err != nil {
-		if err == ErrParamsNotFound {
-			return types.NoActiveMigration, nil
-		}
-		return types.NoActiveMigration, err
-	}
-
-	return params.MigrationStatus, nil
-}

--- a/internal/abci/meta/meta.go
+++ b/internal/abci/meta/meta.go
@@ -157,9 +157,7 @@ func StoreParams(ctx context.Context, db sql.TxMaker, params *common.NetworkPara
 	}
 
 	// migration status
-	buf = make([]byte, 8)
-	binary.LittleEndian.PutUint64(buf, uint64(params.MigrationStatus))
-	_, err = tx.Execute(ctx, upsertParam, migrationStatus, buf)
+	_, err = tx.Execute(ctx, upsertParam, migrationStatus, []byte(params.MigrationStatus))
 	if err != nil {
 		return err
 	}
@@ -241,7 +239,7 @@ func LoadParams(ctx context.Context, db sql.Executor) (*common.NetworkParameters
 		case disabledGasKey:
 			params.DisabledGasCosts = value[0] == 1
 		case migrationStatus:
-			params.MigrationStatus = types.MigrationStatus(binary.LittleEndian.Uint64(value))
+			params.MigrationStatus = types.MigrationStatus(value)
 		case maxVotesPerTx:
 			params.MaxVotesPerTx = int64(binary.LittleEndian.Uint64(value))
 		default:
@@ -283,9 +281,7 @@ func diff(original, new *common.NetworkParameters) map[string][]byte {
 
 	if original.MigrationStatus != new.MigrationStatus {
 		fmt.Println("Migration status changed", original.MigrationStatus, new.MigrationStatus)
-		buf := make([]byte, 8)
-		binary.LittleEndian.PutUint64(buf, uint64(new.MigrationStatus))
-		d[migrationStatus] = buf
+		d[migrationStatus] = []byte(new.MigrationStatus)
 	}
 
 	if original.MaxVotesPerTx != new.MaxVotesPerTx {

--- a/internal/abci/meta/meta_test.go
+++ b/internal/abci/meta/meta_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/internal/abci/meta"
 	"github.com/kwilteam/kwil-db/internal/sql/pg"
 	"github.com/stretchr/testify/require"
@@ -63,7 +64,7 @@ func Test_NetworkParams(t *testing.T) {
 	param2.MaxBlockSize = 2000
 	param2.JoinExpiry = 200
 	param2.DisabledGasCosts = false
-	param2.MigrationStatus = 1
+	param2.MigrationStatus = types.NoActiveMigration
 
 	err = meta.StoreDiff(ctx, tx, param, param2)
 	require.NoError(t, err)

--- a/internal/migrations/changesets.go
+++ b/internal/migrations/changesets.go
@@ -8,6 +8,7 @@ import (
 	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/common/sql"
 	"github.com/kwilteam/kwil-db/core/log"
+	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/serialize"
 	"github.com/kwilteam/kwil-db/extensions/hooks"
 	"github.com/kwilteam/kwil-db/extensions/resolutions"
@@ -129,9 +130,11 @@ func applyChangesets(ctx context.Context, app *common.App, blockCtx *common.Bloc
 	}
 
 	if lastChangeset == endHeight {
+		// migration completed
 		blockCtx.ChainContext.MigrationParams = nil
 		app.Service.Logger.Info(migrationCompleted, log.Int("height", lastChangeset))
-		return nil // migration completed
+		blockCtx.ChainContext.NetworkParameters.MigrationStatus = types.NoActiveMigration
+		return nil
 	}
 
 	if lastChangeset == -1 {
@@ -178,7 +181,9 @@ func applyChangesets(ctx context.Context, app *common.App, blockCtx *common.Bloc
 		lastChangeset = height
 
 		if height == endHeight {
+			// migration completed
 			blockCtx.ChainContext.MigrationParams = nil
+			blockCtx.ChainContext.NetworkParameters.MigrationStatus = types.NoActiveMigration
 			app.Service.Logger.Info(migrationCompleted, log.Int("height", height))
 			break
 		}

--- a/internal/migrations/changesets_test.go
+++ b/internal/migrations/changesets_test.go
@@ -7,6 +7,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/kwilteam/kwil-db/common/chain"
 	"github.com/kwilteam/kwil-db/common/sql"
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/internal/sql/pg"
@@ -49,7 +50,10 @@ func TestChangesetMigration(t *testing.T) {
 	// Split the changeset into chunks of 100 bytes each
 	logger := log.NewStdOut(log.InfoLevel)
 
-	migrator, err = SetupMigrator(ctx, db, nil, nil, "migration_test", logger)
+	migrator, err = SetupMigrator(ctx, db, nil, nil, "migration_test", chain.MigrationParams{
+		StartHeight: 0,
+		EndHeight:   0,
+	}, logger)
 	require.NoError(t, err)
 
 	// Create a changeset migration

--- a/internal/migrations/migrations.go
+++ b/internal/migrations/migrations.go
@@ -121,7 +121,7 @@ func (m *Migrator) startMigration(ctx context.Context, app *common.App, resoluti
 		return err
 	}
 
-	block.ChainContext.NetworkParameters.MigrationStatus = types.MigrationNotStarted
+	block.ChainContext.NetworkParameters.MigrationStatus = types.ActivationPeriod
 	m.activeMigration = active
 	app.Service.Logger.Info("migration started", log.Int("start_height", active.StartHeight), log.Int("end_height", active.EndHeight))
 

--- a/internal/migrations/migrator.go
+++ b/internal/migrations/migrator.go
@@ -54,7 +54,8 @@ const (
 // at the appropriate height, persisting changesets for the migration for each
 // block as it occurs, and making that data available via RPC for the new node.
 // Similarly, if the local process is the new node, it is responsible for reading
-// changesets from the external node and applying them   to the local database.
+// changesets from the external node and applying them to the local database.
+// The changesets are stored from the start height of the migration to the end height (both inclusive).
 type Migrator struct {
 	initialized bool // set to true after the migrator is initialized
 
@@ -614,9 +615,9 @@ func (cw *chunkWriter) SaveMetadata() error {
 }
 
 // storeChangeset persists a changeset to the migrations/changesets directory.
-// doneChan is a channel that is closed when all the block changes have been written to disk.
-// errChan is a channel that receives errors from the changeset storage routine.
-func (m *Migrator) StoreChangesets(height int64, changes <-chan any, doneChan chan<- bool, errChan chan<- error) {
+// errChan is a channel that receives errors from the changeset storage routine and signals
+// abci that the changeset storage has completed or failed.
+func (m *Migrator) StoreChangesets(height int64, changes <-chan any, errChan chan<- error) {
 	if changes == nil {
 		// no changesets to store, not in a migration
 		return
@@ -669,7 +670,7 @@ func (m *Migrator) StoreChangesets(height int64, changes <-chan any, doneChan ch
 	}
 
 	// signals NotifyHeight that all changesets have been written to disk
-	doneChan <- true
+	errChan <- nil
 }
 
 // LoadChangesets loads changesets at a given height from the migration directory.

--- a/internal/migrations/migrator.go
+++ b/internal/migrations/migrator.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/types/serialize"
+	"github.com/kwilteam/kwil-db/internal/abci/meta"
 	"github.com/kwilteam/kwil-db/internal/sql/pg"
 	"github.com/kwilteam/kwil-db/internal/sql/versioning"
 	"github.com/kwilteam/kwil-db/internal/txapp"
@@ -65,13 +66,6 @@ type Migrator struct {
 	// It is nil if there is no plan for a migration.
 	activeMigration *activeMigration
 
-	// Set to true when the migration is in progress.
-	// i.e the block height is between the start and end height of the migration.
-	inProgress bool
-
-	// Set to true when the node is halted after the migration is completed.
-	halted bool
-
 	// snapshotter creates snapshots of the state.
 	snapshotter Snapshotter
 
@@ -104,6 +98,8 @@ type Migrator struct {
 	consensusParamsFn ConsensusParamsGetter
 	// consensusParamsFnChan is a channel that is signals if the consensusParamsFn is set.
 	consensusParamsFnChan chan struct{}
+
+	genesisMigrationParams chain.MigrationParams
 }
 
 // activeMigration is an in-process migration.
@@ -115,12 +111,13 @@ type activeMigration struct {
 }
 
 // SetupMigrator initializes the migrator instance with the necessary dependencies.
-func SetupMigrator(ctx context.Context, db Database, snapshotter Snapshotter, accounts SpendTracker, dir string, logger log.Logger) (*Migrator, error) {
+func SetupMigrator(ctx context.Context, db Database, snapshotter Snapshotter, accounts SpendTracker, dir string, migrationParams chain.MigrationParams, logger log.Logger) (*Migrator, error) {
 	if migrator.initialized {
 		return nil, fmt.Errorf("migrator already initialized")
 	}
 
 	// Set the migrator declared in migrations.go
+	migrator.genesisMigrationParams = migrationParams
 	migrator.snapshotter = snapshotter
 	migrator.Logger = logger
 	migrator.dir = dir
@@ -158,19 +155,6 @@ func SetupMigrator(ctx context.Context, db Database, snapshotter Snapshotter, ac
 	}
 	migrator.lastChangeset = height
 
-	// Check if the migration is in progress or completed
-	if migrator.activeMigration != nil {
-		if migrator.lastChangeset >= migrator.activeMigration.StartHeight {
-			// migration is in progress
-			migrator.inProgress = true
-		}
-
-		if migrator.lastChangeset >= migrator.activeMigration.EndHeight-1 {
-			// migration is completed
-			migrator.halted = true
-		}
-	}
-
 	return migrator, nil
 }
 
@@ -197,7 +181,6 @@ func (m *Migrator) NotifyHeight(ctx context.Context, block *common.BlockContext,
 
 	if block.Height == m.activeMigration.StartHeight-1 {
 		// set the migration in progress, so that we record the changesets starting from the next block
-		m.inProgress = true
 		block.ChainContext.NetworkParameters.MigrationStatus = types.MigrationInProgress
 		return nil
 	}
@@ -264,7 +247,6 @@ func (m *Migrator) NotifyHeight(ctx context.Context, block *common.BlockContext,
 	if block.Height == m.activeMigration.EndHeight {
 		// starting from here, no more transactions of any kind will be accepted or mined.
 		block.ChainContext.NetworkParameters.MigrationStatus = types.MigrationCompleted
-		m.halted = true
 		m.Logger.Info("migration to chain completed, no new transactions will be accepted")
 	}
 
@@ -346,33 +328,47 @@ func (m *Migrator) PersistLastChangesetHeight(ctx context.Context, tx sql.Execut
 	return setLastStoredChangeset(ctx, tx, m.lastChangeset)
 }
 
-func (m *Migrator) MigrationStatus() types.MigrationStatus {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+func (m *Migrator) MigrationStatus(ctx context.Context) (types.MigrationStatus, error) {
+	if m.genesisMigrationParams.EndHeight == 0 {
+		inGenesisMigration, err := InGenesisMigration(ctx, m.DB, m.genesisMigrationParams.EndHeight)
+		if err != nil {
+			return types.NoActiveMigration, fmt.Errorf("failed to check if in genesis migration: %w", err)
+		}
 
-	if m.activeMigration == nil {
-		return types.NoActiveMigration
+		if inGenesisMigration {
+			return types.GenesisMigration, nil
+		}
 	}
 
-	if m.halted {
-		return types.MigrationCompleted
+	status, err := meta.MigrationStatus(ctx, m.DB)
+	if err != nil {
+		return types.NoActiveMigration, fmt.Errorf("failed to get migration status: %w", err)
 	}
-
-	if m.inProgress {
-		return types.MigrationInProgress
-	}
-
-	return types.MigrationNotStarted
+	return status, nil
 }
 
 // GetMigrationMetadata gets the metadata for the genesis snapshot,
 // as well as the available changesets.
-func (m *Migrator) GetMigrationMetadata() (*types.MigrationMetadata, error) {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
+func (m *Migrator) GetMigrationMetadata(ctx context.Context) (*types.MigrationMetadata, error) {
+	status, err := m.MigrationStatus(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	m.Logger.Info("migration status", log.String("status", status.String()))
+
+	if status == types.GenesisMigration {
+		return &types.MigrationMetadata{
+			MigrationState: types.MigrationState{
+				Status:      types.GenesisMigration,
+				StartHeight: m.genesisMigrationParams.StartHeight,
+				EndHeight:   m.genesisMigrationParams.EndHeight,
+			},
+		}, nil
+	}
 
 	// if there is no planned migration, return
-	if m.activeMigration == nil {
+	if status == types.NoActiveMigration {
 		return &types.MigrationMetadata{
 			MigrationState: types.MigrationState{
 				Status: types.NoActiveMigration,
@@ -381,11 +377,14 @@ func (m *Migrator) GetMigrationMetadata() (*types.MigrationMetadata, error) {
 		}, nil
 	}
 
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+
 	// Migration is triggered but not yet started
-	if !m.inProgress {
+	if status == types.ActivationPeriod {
 		return &types.MigrationMetadata{
 			MigrationState: types.MigrationState{
-				Status:      types.MigrationNotStarted,
+				Status:      types.ActivationPeriod,
 				StartHeight: m.activeMigration.StartHeight,
 				EndHeight:   m.activeMigration.EndHeight,
 			},
@@ -418,11 +417,6 @@ func (m *Migrator) GetMigrationMetadata() (*types.MigrationMetadata, error) {
 	var genesisInfo types.GenesisInfo
 	if err := json.Unmarshal(genCfg, &genesisInfo); err != nil {
 		return nil, err
-	}
-
-	status := types.MigrationInProgress
-	if m.halted {
-		status = types.MigrationCompleted
 	}
 
 	return &types.MigrationMetadata{

--- a/internal/migrations/migrator.go
+++ b/internal/migrations/migrator.go
@@ -157,24 +157,6 @@ func SetupMigrator(ctx context.Context, db Database, snapshotter Snapshotter, ac
 	}
 	migrator.lastChangeset = height
 
-	// migration status
-	if migrationParams.EndHeight == 0 {
-		inGenesisMigration, err := InGenesisMigration(ctx, db, migrationParams.EndHeight)
-		if err != nil {
-			return nil, fmt.Errorf("failed to check if in genesis migration: %w", err)
-		}
-
-		if inGenesisMigration {
-			migrator.migrationStatus = types.GenesisMigration
-		}
-	} else {
-		status, err := meta.MigrationStatus(ctx, db)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get migration status: %w", err)
-		}
-		migrator.migrationStatus = status
-	}
-
 	return migrator, nil
 }
 
@@ -270,16 +252,6 @@ func (m *Migrator) NotifyHeight(ctx context.Context, block *common.BlockContext,
 		m.Logger.Info("migration to chain completed, no new transactions will be accepted")
 	}
 
-	// wait for signal on doneChan, indicating that all changesets have been written to disk
-	select {
-	case <-m.doneChan:
-		break
-	case err := <-m.errChan:
-		return err
-	case <-ctx.Done():
-		return nil
-	}
-
 	m.lastChangeset = block.Height
 	return nil
 }
@@ -341,18 +313,17 @@ func (m *Migrator) generateGenesisConfig(ctx context.Context, snapshotHash []byt
 	logger.Info("genesis config generated successfully")
 }
 
+func (m *Migrator) SetMigrationStatus(status types.MigrationStatus) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.migrationStatus = status
+}
+
 func (m *Migrator) PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
 	return setLastStoredChangeset(ctx, tx, m.lastChangeset)
-}
-
-func (m *Migrator) MigrationStatus(ctx context.Context) types.MigrationStatus {
-	m.mu.RLock()
-	defer m.mu.RUnlock()
-
-	return m.migrationStatus
 }
 
 // GetMigrationMetadata gets the metadata for the genesis snapshot,
@@ -645,7 +616,7 @@ func (cw *chunkWriter) SaveMetadata() error {
 }
 
 // storeChangeset persists a changeset to the migrations/changesets directory.
-func (m *Migrator) StoreChangesets(height int64, changes <-chan any) {
+func (m *Migrator) StoreChangesets(height int64, changes <-chan any, doneChan chan<- bool, errChan chan<- error) {
 	if changes == nil {
 		// no changesets to store, not in a migration
 		return
@@ -653,7 +624,7 @@ func (m *Migrator) StoreChangesets(height int64, changes <-chan any) {
 
 	err := ensureChangesetDir(m.dir, height)
 	if err != nil {
-		m.errChan <- err
+		errChan <- err
 		return
 	}
 
@@ -667,7 +638,7 @@ func (m *Migrator) StoreChangesets(height int64, changes <-chan any) {
 			// write the changeset to disk
 			err = pg.StreamElement(chunkWriter, ct)
 			if err != nil {
-				m.errChan <- err
+				errChan <- err
 				return
 			}
 
@@ -675,7 +646,7 @@ func (m *Migrator) StoreChangesets(height int64, changes <-chan any) {
 			// write the relation to disk
 			err = pg.StreamElement(chunkWriter, ct)
 			if err != nil {
-				m.errChan <- err
+				errChan <- err
 				return
 			}
 		}
@@ -687,18 +658,18 @@ func (m *Migrator) StoreChangesets(height int64, changes <-chan any) {
 	}
 	if len(bs.Spends) > 0 {
 		if pg.StreamElement(chunkWriter, bs); err != nil {
-			m.errChan <- err
+			errChan <- err
 			return
 		}
 	}
 
 	if err = chunkWriter.SaveMetadata(); err != nil {
-		m.errChan <- err
+		errChan <- err
 		return
 	}
 
 	// signals NotifyHeight that all changesets have been written to disk
-	m.doneChan <- true
+	doneChan <- true
 }
 
 // LoadChangesets loads changesets at a given height from the migration directory.

--- a/internal/migrations/sql.go
+++ b/internal/migrations/sql.go
@@ -365,25 +365,3 @@ func getChangeset(ctx context.Context, db sql.Executor, height int64, index int6
 
 	return changeset, nil
 }
-
-// InGenesisMigration checks if the node is going through a genesis migration.
-// It returns true if the node is still syncing with the old network.
-func InGenesisMigration(ctx context.Context, db sql.ReadTxMaker, endHeight int64) (bool, error) {
-	if endHeight == 0 {
-		return false, nil
-	}
-
-	tx, err := db.BeginReadTx(ctx)
-	if err != nil {
-		return false, err
-	}
-	defer tx.Rollback(ctx)
-
-	// Check if the migration table exists
-	height, err := getLastChangeset(ctx, tx)
-	if err != nil {
-		return false, err
-	}
-
-	return height < endHeight, nil
-}

--- a/internal/migrations/sql.go
+++ b/internal/migrations/sql.go
@@ -365,3 +365,25 @@ func getChangeset(ctx context.Context, db sql.Executor, height int64, index int6
 
 	return changeset, nil
 }
+
+// InGenesisMigration checks if the node is going through a genesis migration.
+// It returns true if the node is still syncing with the old network.
+func InGenesisMigration(ctx context.Context, db sql.ReadTxMaker, endHeight int64) (bool, error) {
+	if endHeight == 0 {
+		return false, nil
+	}
+
+	tx, err := db.BeginReadTx(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer tx.Rollback(ctx)
+
+	// Check if the migration table exists
+	height, err := getLastChangeset(ctx, tx)
+	if err != nil {
+		return false, err
+	}
+
+	return height < endHeight, nil
+}

--- a/internal/services/jsonrpc/adminsvc/service.go
+++ b/internal/services/jsonrpc/adminsvc/service.go
@@ -57,7 +57,7 @@ type P2P interface {
 type Migrator interface {
 	GetChangesetMetadata(height int64) (*migrations.ChangesetMetadata, error)
 	GetChangeset(height int64, index int64) ([]byte, error)
-	GetMigrationMetadata() (*coretypes.MigrationMetadata, error)
+	GetMigrationMetadata(ctx context.Context) (*coretypes.MigrationMetadata, error)
 	GetGenesisSnapshotChunk(chunkIdx uint32) ([]byte, error)
 }
 
@@ -261,11 +261,6 @@ func (svc *Service) Status(ctx context.Context, req *adminjson.StatusRequest) (*
 		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "node status unavailable", nil)
 	}
 
-	metadata, err := svc.migrator.GetMigrationMetadata()
-	if err != nil || metadata == nil {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "migration state unavailable", nil)
-	}
-
 	return &adminjson.StatusResponse{
 		Node: status.Node,
 		Sync: convertSyncInfo(status.Sync),
@@ -273,7 +268,6 @@ func (svc *Service) Status(ctx context.Context, req *adminjson.StatusRequest) (*
 			PubKey: status.Validator.PubKey,
 			Power:  status.Validator.Power,
 		},
-		Migration: &metadata.MigrationState,
 	}, nil
 }
 

--- a/internal/services/jsonrpc/adminsvc/service.go
+++ b/internal/services/jsonrpc/adminsvc/service.go
@@ -19,7 +19,6 @@ import (
 	types "github.com/kwilteam/kwil-db/core/types/admin"
 	"github.com/kwilteam/kwil-db/core/types/transactions"
 	"github.com/kwilteam/kwil-db/extensions/resolutions"
-	"github.com/kwilteam/kwil-db/internal/migrations"
 	rpcserver "github.com/kwilteam/kwil-db/internal/services/jsonrpc"
 	"github.com/kwilteam/kwil-db/internal/version"
 	"github.com/kwilteam/kwil-db/internal/voting"
@@ -54,13 +53,6 @@ type P2P interface {
 	ListPeers(ctx context.Context) []string
 }
 
-type Migrator interface {
-	GetChangesetMetadata(height int64) (*migrations.ChangesetMetadata, error)
-	GetChangeset(height int64, index int64) ([]byte, error)
-	GetMigrationMetadata(ctx context.Context) (*coretypes.MigrationMetadata, error)
-	GetGenesisSnapshotChunk(chunkIdx uint32) ([]byte, error)
-}
-
 type Service struct {
 	log log.Logger
 
@@ -69,7 +61,6 @@ type Service struct {
 	db         sql.DelayedReadTxMaker
 	pricer     Pricer
 	p2p        P2P
-	migrator   Migrator
 
 	cfg     *config.KwildConfig
 	chainID string
@@ -229,7 +220,7 @@ func (svc *Service) Handlers() map[jsonrpc.Method]rpcserver.MethodHandler {
 
 // NewService constructs a new Service.
 func NewService(db sql.DelayedReadTxMaker, blockchain BlockchainTransactor, txApp TxApp,
-	pricer Pricer, p2p P2P, migrator Migrator, signer auth.Signer, cfg *config.KwildConfig,
+	pricer Pricer, p2p P2P, signer auth.Signer, cfg *config.KwildConfig,
 	chainID string, logger log.Logger) *Service {
 	return &Service{
 		blockchain: blockchain,
@@ -238,7 +229,6 @@ func NewService(db sql.DelayedReadTxMaker, blockchain BlockchainTransactor, txAp
 		chainID:    chainID,
 		pricer:     pricer,
 		p2p:        p2p,
-		migrator:   migrator,
 		cfg:        cfg,
 		log:        logger,
 		db:         db,

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -45,7 +45,7 @@ type Service struct {
 	db          DB              // this should only ever make a read-only tx
 	nodeApp     NodeApplication // so we don't have to do ABCIQuery (indirect)
 	chainClient BlockchainTransactor
-	pricer      Pricer
+	abci        ABCI // handles pricing, migration status etc.
 	migrator    Migrator
 
 	// challenges issued to the clients
@@ -111,7 +111,7 @@ const (
 
 // NewService creates a new instance of the user RPC service.
 func NewService(db DB, engine EngineReader, chainClient BlockchainTransactor,
-	nodeApp NodeApplication, pricer Pricer, migrator Migrator, logger log.Logger, opts ...Opt) *Service {
+	nodeApp NodeApplication, abci ABCI, migrator Migrator, logger log.Logger, opts ...Opt) *Service {
 	cfg := &serviceCfg{
 		readTxTimeout:      defaultReadTxTimeout,
 		challengeExpiry:    defaultChallengeExpiry,
@@ -126,7 +126,7 @@ func NewService(db DB, engine EngineReader, chainClient BlockchainTransactor,
 		readTxTimeout:    cfg.readTxTimeout,
 		engine:           engine,
 		nodeApp:          nodeApp,
-		pricer:           pricer,
+		abci:             abci,
 		chainClient:      chainClient,
 		db:               db,
 		migrator:         migrator,
@@ -387,14 +387,14 @@ type NodeApplication interface {
 	AccountInfo(ctx context.Context, db sql.DB, identifier []byte, getUncommitted bool) (balance *big.Int, nonce int64, err error)
 }
 
-type Pricer interface {
+type ABCI interface {
 	Price(ctx context.Context, db sql.DB, tx *transactions.Transaction) (*big.Int, error)
+	GetMigrationMetadata(ctx context.Context) (*types.MigrationMetadata, error)
 }
 
 type Migrator interface {
 	GetChangesetMetadata(height int64) (*migrations.ChangesetMetadata, error)
 	GetChangeset(height int64, index int64) ([]byte, error)
-	GetMigrationMetadata(ctx context.Context) (*types.MigrationMetadata, error)
 	GetGenesisSnapshotChunk(chunkIdx uint32) ([]byte, error)
 }
 
@@ -505,7 +505,7 @@ func (svc *Service) EstimatePrice(ctx context.Context, req *userjson.EstimatePri
 	readTx := svc.db.BeginDelayedReadTx()
 	defer readTx.Rollback(ctx)
 
-	price, err := svc.pricer.Price(ctx, readTx, req.Tx)
+	price, err := svc.abci.Price(ctx, readTx, req.Tx)
 	if err != nil {
 		svc.log.Error("failed to estimate price", log.Error(err)) // why not tell the client though?
 		return nil, jsonrpc.NewError(jsonrpc.ErrorTxInternal, "failed to estimate price", nil)
@@ -899,7 +899,7 @@ func (svc *Service) LoadChangesetMetadata(ctx context.Context, req *userjson.Cha
 }
 
 func (svc *Service) MigrationMetadata(ctx context.Context, req *userjson.MigrationMetadataRequest) (*userjson.MigrationMetadataResponse, *jsonrpc.Error) {
-	metadata, err := svc.migrator.GetMigrationMetadata(ctx)
+	metadata, err := svc.abci.GetMigrationMetadata(ctx)
 	if err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, err.Error(), nil)
 	}
@@ -950,7 +950,7 @@ func (svc *Service) ListPendingMigrations(ctx context.Context, req *userjson.Lis
 }
 
 func (svc *Service) MigrationStatus(ctx context.Context, req *userjson.MigrationStatusRequest) (*userjson.MigrationStatusResponse, *jsonrpc.Error) {
-	metadata, err := svc.migrator.GetMigrationMetadata(ctx)
+	metadata, err := svc.abci.GetMigrationMetadata(ctx)
 	if err != nil || metadata == nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "migration state unavailable", nil)
 	}

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -328,6 +328,10 @@ func (svc *Service) Methods() map[jsonrpc.Method]rpcserver.MethodDef {
 			"get a genesis snapshot chunk of given idx",
 			"the genesis chunk for the given index",
 		),
+		userjson.MethodMigrationStatus: rpcserver.MakeMethodDef(svc.MigrationStatus,
+			"get the migration status",
+			"the status of the migration",
+		),
 
 		// Challenge method
 		userjson.MethodChallenge: rpcserver.MakeMethodDef(svc.CallChallenge,
@@ -390,7 +394,7 @@ type Pricer interface {
 type Migrator interface {
 	GetChangesetMetadata(height int64) (*migrations.ChangesetMetadata, error)
 	GetChangeset(height int64, index int64) ([]byte, error)
-	GetMigrationMetadata() (*types.MigrationMetadata, error)
+	GetMigrationMetadata(ctx context.Context) (*types.MigrationMetadata, error)
 	GetGenesisSnapshotChunk(chunkIdx uint32) ([]byte, error)
 }
 
@@ -895,7 +899,7 @@ func (svc *Service) LoadChangesetMetadata(ctx context.Context, req *userjson.Cha
 }
 
 func (svc *Service) MigrationMetadata(ctx context.Context, req *userjson.MigrationMetadataRequest) (*userjson.MigrationMetadataResponse, *jsonrpc.Error) {
-	metadata, err := svc.migrator.GetMigrationMetadata()
+	metadata, err := svc.migrator.GetMigrationMetadata(ctx)
 	if err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorInternal, err.Error(), nil)
 	}
@@ -942,6 +946,27 @@ func (svc *Service) ListPendingMigrations(ctx context.Context, req *userjson.Lis
 
 	return &userjson.ListMigrationsResponse{
 		Migrations: pendingMigrations,
+	}, nil
+}
+
+func (svc *Service) MigrationStatus(ctx context.Context, req *userjson.MigrationStatusRequest) (*userjson.MigrationStatusResponse, *jsonrpc.Error) {
+	metadata, err := svc.migrator.GetMigrationMetadata(ctx)
+	if err != nil || metadata == nil {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "migration state unavailable", nil)
+	}
+
+	chainStatus, err := svc.chainClient.Status(ctx)
+	if err != nil {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get chain status", nil)
+	}
+
+	return &userjson.MigrationStatusResponse{
+		Status: &types.MigrationState{
+			Status:       metadata.MigrationState.Status,
+			StartHeight:  metadata.MigrationState.StartHeight,
+			EndHeight:    metadata.MigrationState.EndHeight,
+			CurrentBlock: chainStatus.Sync.BestBlockHeight,
+		},
 	}, nil
 }
 

--- a/internal/services/jsonrpc/usersvc/service.go
+++ b/internal/services/jsonrpc/usersvc/service.go
@@ -962,10 +962,10 @@ func (svc *Service) MigrationStatus(ctx context.Context, req *userjson.Migration
 
 	return &userjson.MigrationStatusResponse{
 		Status: &types.MigrationState{
-			Status:       metadata.MigrationState.Status,
-			StartHeight:  metadata.MigrationState.StartHeight,
-			EndHeight:    metadata.MigrationState.EndHeight,
-			CurrentBlock: chainStatus.Sync.BestBlockHeight,
+			Status:        metadata.MigrationState.Status,
+			StartHeight:   metadata.MigrationState.StartHeight,
+			EndHeight:     metadata.MigrationState.EndHeight,
+			CurrentHeight: chainStatus.Sync.BestBlockHeight,
 		},
 	}, nil
 }

--- a/internal/txapp/mempool.go
+++ b/internal/txapp/mempool.go
@@ -60,6 +60,7 @@ func (m *mempool) applyTransaction(ctx *common.TxContext, tx *transactions.Trans
 	status := ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus
 	inMigration := status == types.MigrationInProgress || status == types.MigrationCompleted
 	activeMigration := status != types.NoActiveMigration
+	genesisMigration := status == types.GenesisMigration
 
 	if inMigration {
 		switch tx.Body.PayloadType {
@@ -90,7 +91,7 @@ func (m *mempool) applyTransaction(ctx *common.TxContext, tx *transactions.Trans
 		if err := res.UnmarshalBinary(tx.Body.Payload); err != nil {
 			return err
 		}
-		if activeMigration && res.Resolution.Type == voting.StartMigrationEventType {
+		if (activeMigration || genesisMigration) && res.Resolution.Type == voting.StartMigrationEventType {
 			return fmt.Errorf(" migration resolutions are not allowed during migration")
 		}
 	}
@@ -107,7 +108,7 @@ func (m *mempool) applyTransaction(ctx *common.TxContext, tx *transactions.Trans
 			return errors.New("migration proposal not found")
 		}
 
-		if activeMigration && resolution.Type == voting.StartMigrationEventType {
+		if (activeMigration || genesisMigration) && resolution.Type == voting.StartMigrationEventType {
 			return fmt.Errorf("approving migration resolutions are not allowed during migration")
 		}
 	}

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -893,7 +893,7 @@ func (d *createResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service
 		return transactions.CodeEncodingError, err
 	}
 
-	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationNotStarted {
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus != types.NoActiveMigration {
 		if res.Resolution.Type == voting.StartMigrationEventType {
 			return transactions.CodeNetworkInMigration, errors.New("migration is about to start, cannot accept new migration proposals")
 		}
@@ -988,7 +988,7 @@ func (d *approveResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx
 		return transactions.CodeUnknownError, fmt.Errorf("resolution with ID %s does not exist", d.resolutionID)
 	}
 
-	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus == types.MigrationNotStarted &&
+	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus != types.NoActiveMigration &&
 		resolution.Type == voting.StartMigrationEventType {
 		return transactions.CodeNetworkInMigration, fmt.Errorf("migration is about to start, cannot accept new migration proposals")
 	}

--- a/test/driver/operator/cli_driver.go
+++ b/test/driver/operator/cli_driver.go
@@ -215,7 +215,7 @@ func (o *OperatorCLIDriver) GenesisState(ctx context.Context) (*types.MigrationM
 
 func (o *OperatorCLIDriver) ListMigrations(ctx context.Context) ([]*types.Migration, error) {
 	var res []*types.Migration
-	err := o.runCommand(ctx, &res, "migrate", "list")
+	err := o.runCommand(ctx, &res, "migrate", "proposals")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This PR includes:
- Renaming the `kwil-admin migrate status` command to `kwil-admin migrate proposal-status` to query the pending proposal status
- Added `kwil-admin migrate network-status` command to retrieve the migration status of the node/chain.
- Introduced new status type to account for genesis migration phase
- Updated mempool and routes to reject migration proposal submissions/approvals during genesis migration (earlier they fail during the resolution processing, now moved it to tx layer)