### PR TITLE
update our pg docker image to 16.4, and use in test

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -44,7 +44,7 @@ jobs:
 
     services:
       postgres:
-        image: kwildb/postgres:16.2-1
+        image: kwildb/postgres:16.4-1
         env:
           POSTGRES_PORT: 5432
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -145,7 +145,7 @@ tasks:
       - |
         docker run -p 5432:5432 -v kwil-pg-demo:/var/lib/postgresql/data \
             --shm-size 256m -e "POSTGRES_HOST_AUTH_METHOD=trust" \
-            --name kwil-pg-demo kwildb/postgres:latest
+            --name kwil-pg-demo kwildb/postgres:16.4-1
 
   pg:clean:
     desc: Wipe data from the pg task

--- a/build/package/docker/postgres.dockerfile
+++ b/build/package/docker/postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.2
+FROM postgres:16.4
 
 # Inject the init script that makes the kwild superuser and a kwild database
 # owned by that kwild user, as well as a kwil_test_db database for tests.

--- a/deployments/compose/kwil/docker-compose.yml
+++ b/deployments/compose/kwil/docker-compose.yml
@@ -7,7 +7,7 @@ volumes:
 services:
   pg:
     container_name: postgres-kwild-single
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "15432:5432"
     restart: always
@@ -19,16 +19,8 @@ services:
       # POSTGRES_USER: kwild
       # POSTGRES_PASSWORD: kwild
       # POSTGRES_DB: kwild
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
     volumes:
       - pgkwil:/var/lib/postgresql/data
-      - ./init.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       kwilnet0:
         ipv4_address: 172.5.100.3

--- a/deployments/compose/kwil/init.sql
+++ b/deployments/compose/kwil/init.sql
@@ -1,3 +1,0 @@
--- These commands are run with psql inside the container after postgres starts.
-CREATE USER kwild WITH PASSWORD 'kwild' SUPERUSER REPLICATION;
-CREATE DATABASE kwild OWNER kwild;

--- a/deployments/compose/postgres/docker-compose.yml
+++ b/deployments/compose/postgres/docker-compose.yml
@@ -1,7 +1,7 @@
 services:
   pg:
     container_name: postgres
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432:5432"
     restart: always
@@ -12,16 +12,8 @@ services:
       # POSTGRES_USER: kwild
       # POSTGRES_PASSWORD: kwild
       # POSTGRES_DB: kwild
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
     volumes: 
       - kwildb:/var/lib/postgresql/data
-      - ./init.sql:/docker-entrypoint-initdb.d/create_user.sql
 
 volumes:
   kwildb:

--- a/deployments/compose/postgres/init.sql
+++ b/deployments/compose/postgres/init.sql
@@ -1,5 +1,0 @@
--- These commands are run with psql inside the container after postgres starts.
-CREATE USER kwild WITH PASSWORD 'kwild' SUPERUSER REPLICATION;
-CREATE DATABASE kwild OWNER kwild;
--- the tests db:
-CREATE DATABASE kwil_test_db OWNER kwild;

--- a/test/acceptance/docker-compose-dev.yml
+++ b/test/acceptance/docker-compose-dev.yml
@@ -46,7 +46,7 @@ services:
       retries: 10
 
   pg:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5454:5432"
     restart: always
@@ -54,15 +54,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - kwil-act-testnet
     healthcheck:

--- a/test/acceptance/docker-compose.yml
+++ b/test/acceptance/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       retries: 10
 
   pg:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -52,15 +52,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - kwil-act-testnet
     healthcheck:

--- a/test/acceptance/pginit.sql
+++ b/test/acceptance/pginit.sql
@@ -1,5 +1,0 @@
--- These commands are run with psql inside the container after postgres starts.
-CREATE USER kwild WITH PASSWORD 'kwild' SUPERUSER REPLICATION;
-CREATE DATABASE kwild OWNER kwild;
-\c kwild
-CREATE PUBLICATION kwild_repl FOR ALL TABLES;

--- a/test/integration/docker-compose-dev.yml
+++ b/test/integration/docker-compose-dev.yml
@@ -41,7 +41,7 @@ services:
       retries: 10
 
   pg0:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -49,15 +49,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - ${KWIL_NETWORK:-kwil-int-testnet}
     healthcheck:
@@ -103,7 +94,7 @@ services:
       retries: 10
 
   pg1:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -111,15 +102,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - ${KWIL_NETWORK:-kwil-int-testnet}
     healthcheck:
@@ -166,7 +148,7 @@ services:
       retries: 10
 
   pg2:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -174,15 +156,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - ${KWIL_NETWORK:-kwil-int-testnet}
     healthcheck:
@@ -231,7 +204,7 @@ services:
       retries: 10
 
   pg3:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -239,15 +212,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - ${KWIL_NETWORK:-kwil-int-testnet}
     healthcheck:
@@ -293,7 +257,7 @@ services:
       retries: 10
 
   pg4:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -301,15 +265,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - ${KWIL_NETWORK:-kwil-int-testnet}
     healthcheck:
@@ -355,7 +310,7 @@ services:
       retries: 10
 
   pg5:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -363,15 +318,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - ${KWIL_NETWORK:-kwil-int-testnet}
     healthcheck:

--- a/test/integration/docker-compose-migration.yml.template
+++ b/test/integration/docker-compose-migration.yml.template
@@ -43,7 +43,7 @@ services:
       retries: 10
 
   new-pg0:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -51,15 +51,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -107,7 +98,7 @@ services:
       retries: 10
 
   new-pg1:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -115,15 +106,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -171,7 +153,7 @@ services:
       retries: 10
 
   new-pg2:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -179,15 +161,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -238,7 +211,7 @@ services:
       retries: 10
 
   new-pg3:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -246,15 +219,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:

--- a/test/integration/docker-compose.yml.template
+++ b/test/integration/docker-compose.yml.template
@@ -43,7 +43,7 @@ services:
       retries: 10
 
   pg0:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -51,15 +51,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -107,7 +98,7 @@ services:
       retries: 10
 
   pg1:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -115,15 +106,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -171,7 +153,7 @@ services:
       retries: 10
 
   pg2:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -179,15 +161,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -238,7 +211,7 @@ services:
       retries: 10
 
   pg3:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -246,15 +219,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -302,7 +266,7 @@ services:
       retries: 10
 
   pg4:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -310,15 +274,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:
@@ -366,7 +321,7 @@ services:
       retries: 10
 
   pg5:
-    image: postgres:16.2
+    image: kwildb/postgres:16.4-1
     ports:
       - "5432"
     restart: always
@@ -374,15 +329,6 @@ services:
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust
       POSTGRES_INITDB_ARGS: --data-checksums
-    command: |
-      -c wal_level=logical
-      -c max_wal_senders=10
-      -c max_replication_slots=10
-      -c max_prepared_transactions=2
-      -c track_commit_timestamp=true
-      -c wal_sender_timeout=0
-    volumes:
-      - ./pginit.sql:/docker-entrypoint-initdb.d/create_user.sql
     networks:
       - {{ .Network }}
     healthcheck:

--- a/test/integration/helper.go
+++ b/test/integration/helper.go
@@ -709,7 +709,6 @@ func (r *IntHelper) createLocalNetwork(ctx context.Context) string {
 // It does the following:
 // 1. Create a new network for current test
 // 2. Generate new docker-compose.yml using newly generated network
-// 3. Copy pginit.sql to the same directory as docker-compose.yml
 //
 // NOTE:
 // By default, the subnet pool assigned by docker is too big. Since we create
@@ -780,14 +779,6 @@ func (r *IntHelper) prepareDockerCompose(_ context.Context, tmpDir string) {
 
 	r.t.Logf("generated compose file: %s, network: %s, test: %s",
 		migrationComposeFile, localNetworkName, testName)
-
-	// copy pginit.sql to same directory as docker-compose.yml
-	// so it can be mounted into the pg containers
-	pgInitSQL, err := os.ReadFile("./pginit.sql")
-	require.NoError(r.t, err, "failed to read pginit.sql")
-	pgInitFile := filepath.Join(tmpDir, "pginit.sql")
-	err = os.WriteFile(pgInitFile, pgInitSQL, 0644)
-	require.NoError(r.t, err, "failed to write pginit.sql")
 
 	// copy docker-compose.override.yml if exists
 	if fileExists(dockerComposeOverrideFile) {

--- a/test/integration/pginit.sql
+++ b/test/integration/pginit.sql
@@ -1,5 +1,0 @@
--- These commands are run with psql inside the container after postgres starts.
-CREATE USER kwild WITH PASSWORD 'kwild' SUPERUSER REPLICATION;
-CREATE DATABASE kwild OWNER kwild;
-\c kwild
-CREATE PUBLICATION kwild_repl FOR ALL TABLES;

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -501,7 +501,8 @@ const ContainerName = "kwil-testing-postgres"
 
 // startCommand returns the docker start command
 func startCommand(port string) []string {
-	return []string{"docker", "run", "-d", "-p", fmt.Sprintf("%s:5432", port), "--name", ContainerName, "-e", "POSTGRES_HOST_AUTH_METHOD=trust", "kwildb/postgres:latest"}
+	return []string{"docker", "run", "-d", "-p", fmt.Sprintf("%s:5432", port), "--name", ContainerName,
+		"-e", "POSTGRES_HOST_AUTH_METHOD=trust", "kwildb/postgres:16.4-1"}
 }
 
 // connectWithRetry tries to connect to Postgres, and will retry n times at


### PR DESCRIPTION
This updates our customized `postgres` Docker image in `build/package/docker/postgres.dockerfile` to extend the official `postgres:16.4` image, bumped from 16.2.  I have been using 16.4 since it's release it's release about 2 months ago, and I think it's a good idea to update our official image before 0.9 release.

This PR also starts using *our* postgres image in all of our tests.  It was used for the pg-enabled unit tests, but not in acceptance or integration tests.  We should be testing our image more consistently.  What this means is not of the special startup flags or the injected pginit.sql script need to be part of the docker compose files since they are already part of our extended postgres image.

NOTE: I have already pushed `kwildb/postgres:16.4-1` to Docker Hub, but I have not yet tagged this as `latest`, which still points to `16.2-1`.  If all is well with this PR and subsequent CI runs, we should update the `latest` tag.