### PR TITLE
abci: workaround for snapshots at initial height having old time

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -490,6 +490,7 @@ func buildAbci(d *coreDependencies, db *pg.DB, txApp abci.TxApp, snapshotter *st
 		GenesisAllocs:      d.genesisCfg.Alloc,
 		GasEnabled:         !d.genesisCfg.ConsensusParams.WithoutGasCosts,
 		ForkHeights:        d.genesisCfg.ForkHeights,
+		InitialHeight:      d.genesisCfg.InitialHeight,
 		ABCIDir:            abciDir,
 	}
 

--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -115,7 +115,7 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 	}
 
 	// Light client verification
-	nodeCfg.StateSync.TrustPeriod = 36000 * time.Second // 10 hours (6s block time)
+	nodeCfg.StateSync.TrustPeriod = 168 * time.Hour // 7 days
 
 	// Standardize the paths.
 	nodeCfg.DBPath = cometbft.DataDir // i.e. "data", we do not allow users to change

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -990,7 +990,7 @@ func (a *AbciApp) Commit(ctx context.Context, _ *abciTypes.RequestCommit) (*abci
 	//   or when the node joins network at any height)
 	snapshotsDue := a.snapshotter != nil &&
 		(a.snapshotter.IsSnapshotDue(uint64(a.height)) || len(a.snapshotter.ListSnapshots()) == 0)
-	snapshotsDue = snapshotsDue && a.height > a.cfg.InitialHeight
+	snapshotsDue = snapshotsDue && a.height > max(1, a.cfg.InitialHeight)
 
 	if a.replayingBlocks != nil && snapshotsDue && !a.replayingBlocks() {
 		// we make a snapshot tx but don't directly use it. This is because under the hood,

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -59,6 +59,7 @@ type AbciConfig struct {
 	GenesisAllocs      map[string]*big.Int
 	GasEnabled         bool
 	ForkHeights        map[string]*uint64
+	InitialHeight      int64
 
 	ABCIDir string
 }
@@ -77,12 +78,6 @@ type AbciApp struct {
 	appHash []byte
 	// height is the current block height
 	height int64
-
-	// initialDone says if this app instances has committed a block yet. This is
-	// a simple way to ensure we don't make a snapshot at the InitialHeight
-	// where it is very possible the first block's header that is stamped with
-	// the genesis time may be quite old and expired for the purpose of statesync.
-	initialDone bool
 
 	cfg   AbciConfig
 	forks forks.Forks
@@ -995,13 +990,7 @@ func (a *AbciApp) Commit(ctx context.Context, _ *abciTypes.RequestCommit) (*abci
 	//   or when the node joins network at any height)
 	snapshotsDue := a.snapshotter != nil &&
 		(a.snapshotter.IsSnapshotDue(uint64(a.height)) || len(a.snapshotter.ListSnapshots()) == 0)
-	// If configured to create snapshots, try to schedule one on the first block
-	// *after* InitialHeight. At this point there should be no other snapshots,
-	// and this is the earliest point we may create a snapshot for which the
-	// block header will not be expired and thus fail validation on a peer
-	// performing statesync. Since we otherwise don't need to store block time
-	// stamps in our meta table, we're checking if we've committed *a* block yet.
-	snapshotsDue = snapshotsDue && a.initialDone
+	snapshotsDue = snapshotsDue && a.height > a.cfg.InitialHeight
 
 	if a.replayingBlocks != nil && snapshotsDue && !a.replayingBlocks() {
 		// we make a snapshot tx but don't directly use it. This is because under the hood,
@@ -1024,8 +1013,6 @@ func (a *AbciApp) Commit(ctx context.Context, _ *abciTypes.RequestCommit) (*abci
 
 	// If a broadcast was accepted during execution of that block, it will be
 	// rechecked and possibly evicted immediately following our commit Response.
-
-	a.initialDone = true
 
 	return &abciTypes.ResponseCommit{}, nil // RetainHeight stays 0 to not prune any blocks
 }


### PR DESCRIPTION
This is a kinda dopey way to avoid making a snapshot at `InitialHeight`, which may or may not be 1, where that block's timestamp is the genesis time set in genesis.json that is often quite a bit older than the next block.  This results in an expired header error on statesync observed:

`"msg":"Can't verify","module":"statesync","module":"light","err":"verify from #1 to #2 failed: old header has expired at 2024-09-20 19:15:21.961570453 +0000 UTC (now: 2024-10-01 16:17:07.80072020`

I wasn't eager to store block time in our meta store to do this the proper way, and we can't simply do this on block 2 since InitialHeight is not always 1.  Did I miss a much simpler way in my pre-lunch fog?  Should I have just injected the initial height at Abci construction?