### PR TITLE
rpc,txapp,voting: disable delete resolution route

### DIFF
--- a/core/rpc/client/admin/admin.go
+++ b/core/rpc/client/admin/admin.go
@@ -31,6 +31,6 @@ type AdminClient interface {
 	// Resolutions
 	CreateResolution(ctx context.Context, resolution []byte, resolutionType string) ([]byte, error)
 	ApproveResolution(ctx context.Context, resolutionID *types.UUID) ([]byte, error)
-	DeleteResolution(ctx context.Context, resolutionID *types.UUID) ([]byte, error)
+	// DeleteResolution(ctx context.Context, resolutionID *types.UUID) ([]byte, error)
 	ResolutionStatus(ctx context.Context, resolutionID *types.UUID) (*types.PendingResolution, error)
 }

--- a/core/rpc/client/admin/jsonrpc/client.go
+++ b/core/rpc/client/admin/jsonrpc/client.go
@@ -256,7 +256,7 @@ func (cl *Client) ApproveResolution(ctx context.Context, resolutionID *types.UUI
 	return res.TxHash, nil
 }
 
-// DeleteResolution deletes a resolution.
+/* DeleteResolution deletes a resolution. This is disabled until the tx route is tested.
 func (cl *Client) DeleteResolution(ctx context.Context, resolutionID *types.UUID) ([]byte, error) {
 	cmd := &adminjson.DeleteResolutionRequest{
 		ResolutionID: resolutionID,
@@ -267,7 +267,7 @@ func (cl *Client) DeleteResolution(ctx context.Context, resolutionID *types.UUID
 		return nil, err
 	}
 	return res.TxHash, nil
-}
+}*/
 
 func (cl *Client) ResolutionStatus(ctx context.Context, resolutionID *types.UUID) (*types.PendingResolution, error) {
 	cmd := &adminjson.ResolutionStatusRequest{

--- a/core/rpc/json/admin/commands.go
+++ b/core/rpc/json/admin/commands.go
@@ -36,9 +36,9 @@ type ApproveResolutionRequest struct {
 	ResolutionID *types.UUID `json:"resolution_id"` // Id is the resolution ID
 }
 
-type DeleteResolutionRequest struct {
-	ResolutionID *types.UUID `json:"resolution_id"` // Id is the resolution ID
-}
+// type DeleteResolutionRequest struct {
+// 	ResolutionID *types.UUID `json:"resolution_id"` // Id is the resolution ID
+// }
 
 type ResolutionStatusRequest struct {
 	ResolutionID *types.UUID `json:"resolution_id"` // Id is the resolution ID

--- a/core/rpc/json/admin/methods.go
+++ b/core/rpc/json/admin/methods.go
@@ -22,6 +22,6 @@ const (
 	MethodListPeers         jsonrpc.Method = "admin.list_peers"
 	MethodCreateResolution  jsonrpc.Method = "admin.create_resolution"
 	MethodApproveResolution jsonrpc.Method = "admin.approve_resolution"
-	MethodDeleteResolution  jsonrpc.Method = "admin.delete_resolution"
 	MethodResolutionStatus  jsonrpc.Method = "admin.resolution_status"
+	// MethodDeleteResolution  jsonrpc.Method = "admin.delete_resolution"
 )

--- a/core/types/transactions/payloads.go
+++ b/core/types/transactions/payloads.go
@@ -34,7 +34,7 @@ const (
 	PayloadTypeValidatorVoteBodies PayloadType = "validator_vote_bodies"
 	PayloadTypeCreateResolution    PayloadType = "create_resolution"
 	PayloadTypeApproveResolution   PayloadType = "approve_resolution"
-	PayloadTypeDeleteResolution    PayloadType = "delete_resolution"
+	// PayloadTypeDeleteResolution    PayloadType = "delete_resolution"
 )
 
 // payloadConcreteTypes associates a payload type with the concrete type of
@@ -52,7 +52,7 @@ var payloadConcreteTypes = map[PayloadType]Payload{
 	PayloadTypeValidatorVoteBodies: &ValidatorVoteBodies{},
 	PayloadTypeCreateResolution:    &CreateResolution{},
 	PayloadTypeApproveResolution:   &ApproveResolution{},
-	PayloadTypeDeleteResolution:    &DeleteResolution{},
+	// PayloadTypeDeleteResolution:    &DeleteResolution{},
 }
 
 // UnmarshalPayload unmarshals a serialized transaction payload into an instance
@@ -93,7 +93,7 @@ func (p PayloadType) Valid() bool {
 		PayloadTypeTransfer,
 		PayloadTypeCreateResolution,
 		PayloadTypeApproveResolution,
-		PayloadTypeDeleteResolution,
+		// PayloadTypeDeleteResolution,
 		// These should not come in user transactions, but they are not invalid
 		// payload types in general.
 		PayloadTypeValidatorVoteIDs,
@@ -119,7 +119,7 @@ var payloadTypes = map[PayloadType]bool{
 	PayloadTypeValidatorVoteBodies: true,
 	PayloadTypeCreateResolution:    true,
 	PayloadTypeApproveResolution:   true,
-	PayloadTypeDeleteResolution:    true,
+	// PayloadTypeDeleteResolution:    true,
 }
 
 // RegisterPayload registers a new payload type. This should be done on
@@ -666,6 +666,8 @@ func (v *ApproveResolution) UnmarshalBinary(p0 serialize.SerializedData) error {
 	return serialize.Decode(p0, v)
 }
 
+/* no delete resolution for now since it has never been tested and has no immediate use
+
 // DeleteResolution is a payload for deleting a resolution.
 type DeleteResolution struct {
 	ResolutionID *types.UUID
@@ -684,3 +686,4 @@ func (d *DeleteResolution) Type() PayloadType {
 func (d *DeleteResolution) UnmarshalBinary(p0 serialize.SerializedData) error {
 	return serialize.Decode(p0, d)
 }
+*/

--- a/internal/services/jsonrpc/adminsvc/service.go
+++ b/internal/services/jsonrpc/adminsvc/service.go
@@ -196,10 +196,10 @@ func (svc *Service) Methods() map[jsonrpc.Method]rpcserver.MethodDef {
 			"approve a resolution",
 			"the hash of the broadcasted approve resolution transaction",
 		),
-		adminjson.MethodDeleteResolution: rpcserver.MakeMethodDef(svc.DeleteResolution,
-			"delete a resolution",
-			"the hash of the broadcasted delete resolution transaction",
-		),
+		// adminjson.MethodDeleteResolution: rpcserver.MakeMethodDef(svc.DeleteResolution,
+		// 	"delete a resolution",
+		// 	"the hash of the broadcasted delete resolution transaction",
+		// ),
 		adminjson.MethodResolutionStatus: rpcserver.MakeMethodDef(svc.ResolutionStatus,
 			"get the status of a resolution",
 			"the status of the resolution"),
@@ -510,6 +510,7 @@ func (svc *Service) ApproveResolution(ctx context.Context, req *adminjson.Approv
 	return svc.sendTx(ctx, res)
 }
 
+/* disabled until the tx route is tested
 func (svc *Service) DeleteResolution(ctx context.Context, req *adminjson.DeleteResolutionRequest) (*userjson.BroadcastResponse, *jsonrpc.Error) {
 	res := &transactions.DeleteResolution{
 		ResolutionID: req.ResolutionID,
@@ -517,6 +518,7 @@ func (svc *Service) DeleteResolution(ctx context.Context, req *adminjson.DeleteR
 
 	return svc.sendTx(ctx, res)
 }
+*/
 
 func (svc *Service) ResolutionStatus(ctx context.Context, req *adminjson.ResolutionStatusRequest) (*adminjson.ResolutionStatusResponse, *jsonrpc.Error) {
 	readTx := svc.db.BeginDelayedReadTx()

--- a/internal/txapp/interfaces.go
+++ b/internal/txapp/interfaces.go
@@ -58,7 +58,7 @@ var (
 	getVoterPower                    = voting.GetValidatorPower
 	resolutionExists                 = voting.ResolutionExists
 	resolutionByID                   = voting.GetResolutionInfo
-	deleteResolution                 = voting.DeleteResolution
+	// deleteResolution                 = voting.DeleteResolution
 
 	// account functions
 	getAccount = accounts.GetAccount

--- a/internal/txapp/routes.go
+++ b/internal/txapp/routes.go
@@ -985,7 +985,7 @@ func (d *approveResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx
 		return transactions.CodeUnknownError, err
 	}
 	if resolution == nil {
-		return transactions.CodeUnknownError, fmt.Errorf("resolution with ID %s does not exist", d.resolutionID)
+		return transactions.CodeInvalidResolutionType, fmt.Errorf("resolution with ID %s does not exist", d.resolutionID)
 	}
 
 	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus != types.NoActiveMigration &&
@@ -1001,6 +1001,8 @@ func (d *approveResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx
 
 	return 0, nil
 }
+
+/* enable and test this in the future
 
 type deleteResolutionRoute struct {
 	resolutionID *types.UUID
@@ -1061,3 +1063,4 @@ func (d *deleteResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx 
 
 	return 0, nil
 }
+*/

--- a/test/driver/operator/client_driver.go
+++ b/test/driver/operator/client_driver.go
@@ -110,9 +110,9 @@ func (a *AdminClientDriver) ApproveMigration(ctx context.Context, migrationResol
 	return a.Client.ApproveResolution(ctx, migrationResolutionID)
 }
 
-func (a *AdminClientDriver) DeleteMigration(ctx context.Context, migrationResolutionID *types.UUID) ([]byte, error) {
-	return a.Client.DeleteResolution(ctx, migrationResolutionID)
-}
+// func (a *AdminClientDriver) DeleteMigration(ctx context.Context, migrationResolutionID *types.UUID) ([]byte, error) {
+// 	return a.Client.DeleteResolution(ctx, migrationResolutionID)
+// }
 
 func (a *AdminClientDriver) GenesisState(ctx context.Context) (*types.MigrationMetadata, error) {
 	return a.Client.GenesisState(ctx)


### PR DESCRIPTION
The delete resolution route was not registered with the tx app's router, nor was it tested, so this removes the client methods and the RPC service handler until we've properly tested the tx route (and motivated it).