### PR TITLE
admin: use specified private key with setup init

### DIFF
--- a/cmd/kwil-admin/cmds/setup/init.go
+++ b/cmd/kwil-admin/cmds/setup/init.go
@@ -3,7 +3,6 @@ package setup
 import (
 	"errors"
 	"fmt"
-	"io"
 	"math/big"
 	"os"
 	"path/filepath"
@@ -16,6 +15,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-admin/nodecfg"
 	"github.com/kwilteam/kwil-db/cmd/kwild/config"
 	"github.com/kwilteam/kwil-db/common/chain"
+	"github.com/kwilteam/kwil-db/core/utils"
 	"github.com/kwilteam/kwil-db/internal/abci/cometbft"
 	"github.com/spf13/cobra"
 )
@@ -73,7 +73,7 @@ func initCmd() *cobra.Command {
 				}
 
 				stateFile := config.GenesisStateFileName(expandedDir)
-				if err = copyFile(genesisState, stateFile); err != nil {
+				if err = utils.CopyFile(genesisState, stateFile); err != nil {
 					return display.PrintErr(cmd, err)
 				}
 
@@ -93,7 +93,7 @@ func initCmd() *cobra.Command {
 					return display.PrintErr(cmd, err)
 				}
 
-				if err = copyFile(genesisPath, genFile); err != nil {
+				if err = utils.CopyFile(genesisPath, genFile); err != nil {
 					return display.PrintErr(cmd, err)
 				}
 			} else {
@@ -173,21 +173,4 @@ func (a *AllocsFlag) Set(value string) error {
 
 func (a *AllocsFlag) Type() string {
 	return "allocFlag"
-}
-
-func copyFile(src, dst string) error {
-	out, err := os.Create(dst)
-	if err != nil {
-		return err
-	}
-	defer out.Close()
-
-	in, err := os.Open(src)
-	if err != nil {
-		return err
-	}
-	defer in.Close()
-
-	_, err = io.Copy(out, in)
-	return err
 }

--- a/core/utils/files.go
+++ b/core/utils/files.go
@@ -5,6 +5,8 @@ import (
 	"os"
 )
 
+// CopyFile copies a named file from src to dst. If the destination file exists,
+// it is truncated.
 func CopyFile(src, dst string) error {
 	out, err := os.Create(dst)
 	if err != nil {

--- a/core/utils/files.go
+++ b/core/utils/files.go
@@ -1,0 +1,23 @@
+package utils
+
+import (
+	"io"
+	"os"
+)
+
+func CopyFile(src, dst string) error {
+	out, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer out.Close()
+
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+
+	_, err = io.Copy(out, in)
+	return err
+}

--- a/internal/statesync/snapshotter_test.go
+++ b/internal/statesync/snapshotter_test.go
@@ -2,12 +2,12 @@ package statesync
 
 import (
 	"bufio"
-	"io"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"github.com/kwilteam/kwil-db/core/log"
+	"github.com/kwilteam/kwil-db/core/utils"
 	"github.com/stretchr/testify/require"
 )
 
@@ -30,14 +30,14 @@ func TestSanitizeLogicalDump(t *testing.T) {
 
 	// copy the logical dump file1
 	stage1File := filepath.Join(formatDir, stage1output)
-	err = copyFile(dump1File, stage1File)
+	err = utils.CopyFile(dump1File, stage1File)
 	require.NoError(t, err)
 
 	hash1, err := snapshotter.sanitizeDump(height, 0)
 	require.NoError(t, err)
 
 	// Sanitize the second dump file
-	err = copyFile(dump2File, stage1File)
+	err = utils.CopyFile(dump2File, stage1File)
 	require.NoError(t, err)
 
 	hash2, err := snapshotter.sanitizeDump(height, 0)
@@ -60,25 +60,4 @@ func TestSanitizeLogicalDump(t *testing.T) {
 
 	err = scanner.Err()
 	require.NoError(t, err)
-}
-
-func copyFile(file1 string, file2 string) error {
-	src, err := os.Open(file1)
-	if err != nil {
-		return err
-	}
-	defer src.Close()
-
-	dst, err := os.Create(file2)
-	if err != nil {
-		return err
-	}
-	defer dst.Close()
-
-	_, err = io.Copy(dst, src)
-	if err != nil {
-		return err
-	}
-
-	return nil
 }

--- a/test/specifications/migration.go
+++ b/test/specifications/migration.go
@@ -101,6 +101,7 @@ func CopyFiles(src, dst string) error {
 	if dstFile, err = os.Create(dst); err != nil {
 		return err
 	}
+	defer dstFile.Close()
 
 	// Copy the contents of the source file into the destination file
 	if _, err = io.Copy(dstFile, srcFile); err != nil {


### PR DESCRIPTION
Requires and based on https://github.com/kwilteam/kwil-db/pull/1059

Resolves https://github.com/kwilteam/kwil-db/issues/1057

This change alters how `setup init` handles the `--app.private_key_path` flag.
Recently it was modified to ignore the flag entirely, with the apparent intent of ensuring the generated `config.toml` in the initialized root directory would always be `private_key_path = "private_key"` with the actual private key always being written into the root directory. This behavior is good, however, when the flag is set it is desirable to import the private key file pointed to by this flag, which is what this change does.

This new behavior streamlines the production deployment guide where the workflow for the genesis validator set involves preparing the private keys so that then can be used in the genesis file created with `kwil-admin setup genesis` first.