### PR TITLE
Preview max db conns

### DIFF
--- a/cmd/kwild/config/config.go
+++ b/cmd/kwild/config/config.go
@@ -79,6 +79,7 @@ type AppConfig struct {
 	RPCTimeout         Duration                     `mapstructure:"rpc_timeout"`
 	RPCMaxReqSize      int                          `mapstructure:"rpc_req_limit"`
 	ReadTxTimeout      Duration                     `mapstructure:"db_read_timeout"`
+	MaxDBConnections   uint32                       `mapstructure:"db_max_connections"`
 	ExtensionEndpoints []string                     `mapstructure:"extension_endpoints"`
 	AdminRPCPass       string                       `mapstructure:"admin_pass"`
 	NoTLS              bool                         `mapstructure:"admin_notls"`
@@ -566,6 +567,7 @@ func DefaultConfig() *KwildConfig {
 			RPCTimeout:           Duration(45 * time.Second),
 			RPCMaxReqSize:        4_200_000,
 			ReadTxTimeout:        Duration(5 * time.Second),
+			MaxDBConnections:     24,
 			Extensions:           make(map[string]map[string]string),
 			Snapshots: SnapshotConfig{
 				Enabled:         false,

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -38,6 +38,7 @@ func AddConfigFlags(flagSet *pflag.FlagSet, cfg *KwildConfig) {
 	flagSet.Var(&cfg.AppCfg.RPCTimeout, "app.rpc-timeout", "timeout for RPC requests (through reading the request, handling the request, and sending the response)")
 	flagSet.IntVar(&cfg.AppCfg.RPCMaxReqSize, "app.rpc-req-limit", cfg.AppCfg.RPCMaxReqSize, "RPC request size limit")
 	flagSet.Var(&cfg.AppCfg.ReadTxTimeout, "app.db-read-timeout", "timeout for database reads initiated by RPC requests")
+	flagSet.Uint32Var(&cfg.AppCfg.MaxDBConnections, "app.db-max-connections", cfg.AppCfg.MaxDBConnections, "maximum number of database connections")
 
 	// Extension endpoints flags
 	flagSet.StringSliceVar(&cfg.AppCfg.ExtensionEndpoints, "app.extension-endpoints", cfg.AppCfg.ExtensionEndpoints, "kwild extension endpoints")

--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -426,7 +426,7 @@ func buildDB(d *coreDependencies, closer *closeFuncs) *pg.DB {
 	// If yes, restore the database from the snapshot
 	restoreDB(d)
 
-	db, err := d.dbOpener(d.ctx, d.cfg.AppCfg.DBName, 24)
+	db, err := d.dbOpener(d.ctx, d.cfg.AppCfg.DBName, uint32(d.cfg.AppCfg.MaxDBConnections))
 	if err != nil {
 		failBuild(err, "kwild database open failed")
 	}


### PR DESCRIPTION
From @outerlook via Slack:

> Frontend team from time to time still crashes the server batching requests. Is that option to reduce requests concurrency available?
https://github.com/kwilteam/kwil-db/blob/cb0f6f6c19644f9ec405078b54c615eb4c6e8d35/cmd/kwild/server/build.go#L429
how much effort would it take to make this 24 configurable? Also it's expected that with this lower value, a queue system will kick in to manage requests, or would them fail?


This PR adds a `app.db-max-connections` flag which specifies the maximum number of connections the engine will hold to Postgres. The default is still 24, but it is now configurable. The minimum is 2, and kwild will fail quickly if the user configures 1.

I did some local testing to ensure that this applies backpressure properly, and can confirm it does. A the number of long-running concurrent reads repeatedly execute against a database, the average time per query increases. I tested it with both reads from the same table (which actually get backpressure from Postgres's lock contention before the max connections are an issue), as well as with separate tables (which obviously did not have issues with lock contention).