### PR TITLE
feat(core): support skip health check option

### DIFF
--- a/.github/workflows/kgw-test-reuse.yaml
+++ b/.github/workflows/kgw-test-reuse.yaml
@@ -109,29 +109,35 @@ jobs:
         # if kgw on non-release branches, we want to use go workspace, so that kgw
         # always uses the latest version of kwil-db/core
         run: |
+          echo "KWK_DIR=$(pwd)/.." >> $GITHUB_ENV
           kdbDir=$(pwd)
+          echo "KDB_DIR=$(pwd)" >> $GITHUB_ENV
+          echo "current dir: " $kdbDir
+          cd ..
+          rm -rf ./kgw
           git config --global url."https://${GH_ACCESS_TOKEN}:x-oauth-basic@github.com/kwilteam/".insteadOf "https://github.com/kwilteam/"
-          rm -rf /tmp/kgw
-          git clone -b ${{ inputs.kgw-ref }}  https://github.com/kwilteam/kgw.git /tmp/kgw
+          git clone -b ${{ inputs.kgw-ref }}  https://github.com/kwilteam/kgw.git ./kgw
           rm -rf ~/.gitconfig
-          cd /tmp/kgw
+          cd ./kgw
+          echo "KGW_DIR=$(pwd)" >> $GITHUB_ENV
           if [[ ${{ inputs.kgw-ref }} == release-* ]]; then
             go mod vendor
           else
             # non release branch, use go workspace to always use the latest version of kwil-db/core
-            go work init . $kdbDir/core
+            test -f go.work || go work init . ../kwil-db/core
             go work vendor
           fi
           cd -
+          cd $kdbDir
 
       - name: Build kgw image
         id: docker_build_kgw
         uses: docker/build-push-action@v5
         with:
-          context: /tmp/kgw
+          context: ${{ env.KGW_DIR }}/..
           load: true
           builder: ${{ steps.buildx.outputs.name }}
-          file: /tmp/kgw/Dockerfile
+          file: ${{ env.KGW_DIR }}/Dockerfile.workspace
           push: false
           tags: kgw:latest
           cache-from: type=local,src=/tmp/.buildx-cache-kgw

--- a/core/rpc/client/error.go
+++ b/core/rpc/client/error.go
@@ -11,6 +11,7 @@ var (
 	// It is the equivalent of http status code 401
 	ErrUnauthorized   = errors.New("unauthorized")
 	ErrNotFound       = errors.New("not found")
+	ErrMethodNotFound = errors.New("method not found")
 	ErrInvalidRequest = errors.New("invalid request")
 	ErrNotAllowed     = errors.New("not allowed")
 )

--- a/core/rpc/client/jsonrpc.go
+++ b/core/rpc/client/jsonrpc.go
@@ -208,7 +208,7 @@ func (cl *JSONRPCClient) CallMethod(ctx context.Context, method string, cmd, res
 // clientError joins a jsonrpc.Error with a client.RPCError and any appropriate
 // named error kind like ErrNotFound, ErrUnauthorized, etc. based on the code.
 func clientError(jsonRPCErr *jsonrpc.Error) error {
-	rpcErr := &RPCError{
+	rpcErr := &RPCError{ // @Jon, should we change this to RPCError instead of *RPCError ?
 		Msg:  jsonRPCErr.Message,
 		Code: int32(jsonRPCErr.Code),
 	}
@@ -218,9 +218,7 @@ func clientError(jsonRPCErr *jsonrpc.Error) error {
 	case jsonrpc.ErrorEngineDatasetNotFound, jsonrpc.ErrorTxNotFound, jsonrpc.ErrorValidatorNotFound:
 		return errors.Join(ErrNotFound, err)
 	case jsonrpc.ErrorUnknownMethod:
-		// TODO: change to client.ErrMethodNotFound. This should be different
-		// from other "not found" conditions
-		return errors.Join(ErrNotFound, err)
+		return errors.Join(ErrMethodNotFound, err)
 	// case jsonrpc.ErrorUnauthorized: // not yet used on server
 	// 	return errors.Join(client.ErrUnauthorized, err)
 	// case jsonrpc.ErrorInvalidSignature: // or leave this to core/client.Client to detect and report

--- a/core/types/client/opts.go
+++ b/core/types/client/opts.go
@@ -28,6 +28,9 @@ type Options struct {
 	// This option is only effective when ChainID is set.
 	SkipVerifyChainID bool
 
+	// SkipHealthcheck will skip check remote nodes' health status.
+	SkipHealthcheck bool
+
 	// Silence silences warnings logged from the client.
 	Silence bool
 
@@ -58,6 +61,8 @@ func (c *Options) Apply(opts *Options) {
 	}
 
 	c.SkipVerifyChainID = opts.SkipVerifyChainID
+
+	c.SkipHealthcheck = opts.SkipHealthcheck
 
 	c.Silence = opts.Silence
 }


### PR DESCRIPTION
- a11fe98ce58ccf0ca0bfb61d6cab4cf7cc570d6e supports a new client option `SkipHealthcheck`. If this option is set, errors from calling `user.health` API will be ignored, and fall back to `user.chain_info` to get ChainID.
- a30c0499fcb6d02728b0010e42b3e167db1a300a fix CI to build KGW together with kwil-db in workspace


Note: I push to kwilteam/kwil-db repo so I can manually trigger CI.


kwilteam/kgw#96 depends on this