### PR TITLE
pg: recognize streaming prepared tx msg

### DIFF
--- a/internal/sql/pg/repl.go
+++ b/internal/sql/pg/repl.go
@@ -501,7 +501,7 @@ func decodeWALData(hasher hash.Hash, walData []byte, relations map[uint32]*pglog
 		hasher.Reset()
 		changesetWriter.fail() // discard changeset
 
-	// v2 Stream control messages.  Not expected for kwil
+	// v2 Stream control messages.  Only expected with large transactions.
 	case *pglogrepl.StreamStartMessageV2:
 		*inStream = true
 		logger.Warnf(" [msg] StreamStartMessageV2: xid %d, first segment? %d", logicalMsg.Xid, logicalMsg.FirstSegment)

--- a/internal/sql/pg/repl_msgs.go
+++ b/internal/sql/pg/repl_msgs.go
@@ -14,6 +14,7 @@ const (
 	MessageTypeBeginPrepare     pglogrepl.MessageType = 'b'
 	MessageTypeCommitPrepared   pglogrepl.MessageType = 'K'
 	MessageTypeRollbackPrepared pglogrepl.MessageType = 'r'
+	MessageTypeStreamPrepare    pglogrepl.MessageType = 'p'
 )
 
 // msgTypeToString is helpful for debugging, but normally unused.
@@ -21,6 +22,8 @@ func msgTypeToString(t pglogrepl.MessageType) string { //nolint:unused
 	switch t {
 	case MessageTypePrepare:
 		return "Prepare"
+	case MessageTypeStreamPrepare:
+		return "Stream Prepared"
 	case MessageTypeBeginPrepare:
 		return "Begin Prepared"
 	case MessageTypeCommitPrepared:
@@ -39,7 +42,7 @@ func parseV3(data []byte, inStream bool) (m pglogrepl.Message, err error) {
 	var decoder pglogrepl.MessageDecoder // v1 and v3 have same Decode signature (stream not relevant)
 
 	switch msgType {
-	case MessageTypePrepare:
+	case MessageTypePrepare, MessageTypeStreamPrepare: // same encoding
 		decoder = new(PrepareMessageV3)
 	case MessageTypeBeginPrepare:
 		decoder = new(BeginPrepareMessageV3)


### PR DESCRIPTION
Fixes `Error: decodeWALData failed: parse logical replication message: replication message not supported` preceded by:

```
2024-10-22T10:03:48.805-05:00	error	kwild.cometbft	CONSENSUS FAILURE!!!	{"module": "consensus", "err": "failed to apply block; error failed to precommit transaction: replication stream interrupted", "stack": "goroutine 490 [running]:\nruntime/debug.Stack()\n\t/home/jon/go123/src/runtime/debug/stack.go:26 +0x5e\ngithub.com/cometbft/cometbft/consensus.(*State).receiveRoutine.func2()\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:801 +0x46\npanic({0x15b29c0?, 0xc0089e7720?})\n\t/home/jon/go123/src/runtime/panic.go:785 +0x132\ngithub.com/cometbft/cometbft/consensus.(*State).finalizeCommit(0xc0002df188, 0xd)\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:1781 +0xde5\ngithub.com/cometbft/cometbft/consensus.(*State).tryFinalizeCommit(0xc0002df188, 0xd)\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:1682 +0x2e8\ngithub.com/cometbft/cometbft/consensus.(*State).enterCommit.func1()\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:1617 +0x9c\ngithub.com/cometbft/cometbft/consensus.(*State).enterCommit(0xc0002df188, 0xd, 0x0)\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:1655 +0xc2f\ngithub.com/cometbft/cometbft/consensus.(*State).addVote(0xc0002df188, 0xc00a636820, {0x0, 0x0})\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:2335 +0x1c6d\ngithub.com/cometbft/cometbft/consensus.(*State).tryAddVote(0xc0002df188, 0xc00a636820, {0x0?, 0x49346e?})\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:2067 +0x26\ngithub.com/cometbft/cometbft/consensus.(*State).handleMsg(0xc0002df188, {{0x1bf8600, 0xc0088aaae8}, {0x0, 0x0}})\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:929 +0x38b\ngithub.com/cometbft/cometbft/consensus.(*State).receiveRoutine(0xc0002df188, 0x0)\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:856 +0x4f9\ncreated by github.com/cometbft/cometbft/consensus.(*State).OnStart in goroutine 379\n\t/home/jon/go/pkg/mod/github.com/cometbft/cometbft@v0.38.12/consensus/state.go:398 +0x10c\n", "goversion": "go1.23.2", "mod_version": "(devel)", "revision": "62217d563d787e164ff7ab4f57338348601d609b", "build_time": "2024-10-22T14:25:11Z", "dirty": true}
2024-10-22T10:03:48.805-05:00	info	kwild.cometbft	Saving AddrBook to file	{"module": "p2p", "book": "/home/jon/.kwild-junk3/abci/addrbook.json", "size": 0}
2024-10-22T10:03:48.805-05:00	info	kwild.cometbft	service stop	{"module": "consensus", "wal": "/home/jon/.kwild-junk3/abci/data/cs.wal/wal", "msg": "Stopping baseWAL service", "impl": "baseWAL"}
2024-10-22T10:03:48.805-05:00	info	kwild.cometbft	service stop	{"module": "consensus", "msg": "Stopping State service", "impl": "ConsensusState"}
2024-10-22T10:03:48.805-05:00	info	kwild.cometbft	service stop	{"module": "consensus", "msg": "Stopping TimeoutTicker service", "impl": "TimeoutTicker"}
2024-10-22T10:03:48.808-05:00	info	kwild.cometbft	service stop	{"module": "consensus", "wal": "/home/jon/.kwild-junk3/abci/data/cs.wal/wal", "msg": "Stopping Group service", "impl": "Group"}
2024-10-22T10:03:48.815-05:00	warn	kwild.cometbft	Stopped accept routine, as transport is closed	{"module": "p2p", "numPeers": 0}
2024-10-22T10:03:48.815-05:00	info	kwild.cometbft	Closing rpc listener	{"listener": {"Listener":{}}}
2024-10-22T10:03:48.815-05:00	info	kwild.cometbft	RPC HTTP server stopped	{"module": "rpc-server", "err": "accept tcp 127.0.0.1:26657: use of closed network connection"}
2024-10-22T10:03:48.815-05:00	error	kwild.cometbft	Error serving server	{"err": "accept tcp 127.0.0.1:26657: use of closed network connection", "goversion": "go1.23.2", "mod_version": "(devel)", "revision": "62217d563d787e164ff7ab4f57338348601d609b", "build_time": "2024-10-22T14:25:11Z", "dirty": true}
2024-10-22T10:03:48.815-05:00	info	kwild.cometbft	Closing blockstore
2024-10-22T10:03:48.815-05:00	info	kwild.cometbft	Closing statestore
2024-10-22T10:03:48.815-05:00	info	kwild.cometbft	Closing evidencestore
2024-10-22T10:03:48.815-05:00	info	kwild.server	comet server is stopped
2024-10-22T10:03:48.815-05:00	error	kwild.server	server error	{"error": "decodeWALData failed: parse logical replication message: replication message not supported", "goversion": "go1.23.2", "mod_version": "(devel)", "revision": "62217d563d787e164ff7ab4f57338348601d609b", "build_time": "2024-10-22T14:25:11Z", "dirty": true}
2024-10-22T10:03:48.815-05:00	info	kwild.server	Closing server resources...
2024-10-22T10:03:48.815-05:00	info	kwild	closing signing store
2024-10-22T10:03:48.853-05:00	info	kwild	closing ABCI app
2024-10-22T10:03:48.855-05:00	info	kwild	closing event store
2024-10-22T10:03:48.855-05:00	info	kwild	closing event store
2024-10-22T10:03:48.855-05:00	info	kwild	closing main DB
2024-10-22T10:03:48.855-05:00	info	kwild.server	Server is now shut down.
```