### PR TITLE
sql,pg: catch db backend failure

### DIFF
--- a/build/package/docker/postgres.dockerfile
+++ b/build/package/docker/postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.4
+FROM postgres:16.5
 
 # Inject the init script that makes the kwild superuser and a kwild database
 # owned by that kwild user, as well as a kwil_test_db database for tests.
@@ -14,4 +14,5 @@ COPY ./pginit.sql /docker-entrypoint-initdb.d/init.sql
 
 # Override the default entrypoint/command to include the additional configuration
 CMD ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=10", "-c", "max_replication_slots=10", \
-	"-c", "track_commit_timestamp=true", "-c", "wal_sender_timeout=0", "-c", "max_prepared_transactions=2"]
+	"-c", "track_commit_timestamp=true", "-c", "wal_sender_timeout=0", "-c", "max_prepared_transactions=2", \
+	"-c", "max_locks_per_transaction=256", "-c", "max_connections=128"]

--- a/common/sql/sql_test.go
+++ b/common/sql/sql_test.go
@@ -1,0 +1,65 @@
+package sql
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestIsFatalDBError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{
+			name: "nil error",
+			err:  nil,
+			want: false,
+		},
+		{
+			name: "ErrDBFailure",
+			err:  ErrDBFailure,
+			want: true,
+		},
+		{
+			name: "wrapped ErrDBFailure",
+			err:  errors.Join(errors.New("wrapped"), ErrDBFailure),
+			want: true,
+		},
+		{
+			name: "insufficient resources error",
+			err:  &pgconn.PgError{Code: "53100"},
+			want: true,
+		},
+		{
+			name: "system error",
+			err:  &pgconn.PgError{Code: "58000"},
+			want: true,
+		},
+		{
+			name: "internal error",
+			err:  &pgconn.PgError{Code: "XX000"},
+			want: true,
+		},
+		{
+			name: "non-fatal pg error",
+			err:  &pgconn.PgError{Code: "23505"},
+			want: false,
+		},
+		{
+			name: "generic error",
+			err:  errors.New("some error"),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsFatalDBError(tt.err); got != tt.want {
+				t.Errorf("IsFatalDBError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/abci/abci.go
+++ b/internal/abci/abci.go
@@ -676,6 +676,13 @@ func (a *AbciApp) FinalizeBlock(ctx context.Context, req *abciTypes.RequestFinal
 
 		abciRes := &abciTypes.ExecTxResult{}
 		if txRes.Error != nil {
+			// Ensure the node halt if a fatal DB error occurs (e.g. out of memory/disk,
+			// corruption, etc.), rather than allowing non-determinism with a failed txn.
+			if sql.IsFatalDBError(txRes.Error) {
+				return nil, txRes.Error
+			}
+
+			// If the transaction failed for user reasons, we still want to include it in the block.
 			abciRes.Log = txRes.Error.Error()
 			a.log.Debug("failed to execute transaction", zap.Error(txRes.Error))
 		} else {

--- a/internal/sql/pg/tx.go
+++ b/internal/sql/pg/tx.go
@@ -4,6 +4,7 @@ package pg
 
 import (
 	"context"
+	"errors"
 
 	"github.com/jackc/pgx/v5"
 	common "github.com/kwilteam/kwil-db/common/sql"
@@ -44,13 +45,21 @@ func (tx *nestedTx) BeginTx(ctx context.Context) (common.Tx, error) {
 }
 
 func (tx *nestedTx) Query(ctx context.Context, stmt string, args ...any) (*common.ResultSet, error) {
-	return query(ctx, tx.oidTypes, tx.Tx, stmt, args...)
+	resSet, err := query(ctx, tx.oidTypes, tx.Tx, stmt, args...)
+	if errors.Is(err, common.ErrDBFailure) {
+		tx.Tx.Conn().Close(ctx) // do not allow the outer txn to commit!
+	}
+	return resSet, err
 }
 
 // Execute is now literally identical to Query in both semantics and syntax. We
 // might remove one or the other in this context (transaction methods).
 func (tx *nestedTx) Execute(ctx context.Context, stmt string, args ...any) (*common.ResultSet, error) {
-	return query(ctx, tx.oidTypes, tx.Tx, stmt, args...)
+	resSet, err := query(ctx, tx.oidTypes, tx.Tx, stmt, args...)
+	if errors.Is(err, common.ErrDBFailure) {
+		tx.Tx.Conn().Close(ctx) // do not allow the outer txn to commit!
+	}
+	return resSet, err
 }
 
 // QueryScanFn satisfies sql.QueryScanner.
@@ -58,7 +67,11 @@ func (tx *nestedTx) QueryScanFn(ctx context.Context, sql string,
 	scans []any, fn func() error, args ...any) error {
 
 	conn := tx.Conn()
-	return queryRowFunc(ctx, conn, sql, scans, fn, args...)
+	err := queryRowFunc(ctx, conn, sql, scans, fn, args...)
+	if errors.Is(err, common.ErrDBFailure) {
+		tx.Tx.Conn().Close(ctx) // do not allow the outer txn to commit!
+	}
+	return err
 }
 
 // AccessMode returns the access mode of the transaction.


### PR DESCRIPTION
There are certain errors from the database that indicate failures of the DB backend itself, such as out of memory/disk or corruption etc.

Unfortunately, these were not halting the node, only resulting in failed blockchain transactions, thus non-determinism since it would still compute an apphash (likely incorrect) and commit the block:

```
2024-11-14T15:25:16.331Z	warn	kwild.pg	pg/conn.go:137	ERROR [53200]: out of shared memory
2024-11-14T15:25:16.332Z	warn	kwild.abci	abci/abci.go:371	failed to execute transaction	{"error": "ERROR: out of shared memory (SQLSTATE 53200)\ninternal database error"}
2024-11-14T15:25:16.336Z	warn	kwild.abci	abci/abci.go:371	failed to execute transaction	{"error": "ERROR: out of shared memory (SQLSTATE 53200)\ninternal database error"}
2024-11-14T15:25:16.34Z	warn	kwild.abci	abci/abci.go:371	failed to execute transaction	{"error": "ERROR: out of shared memory (SQLSTATE 53200)\ninternal database error"}
2024-11-14T15:25:16.343Z	warn	kwild.abci	abci/abci.go:371	failed to execute transaction	{"error": "ERROR: out of shared memory (SQLSTATE 53200)\ninternal database error"}
2024-11-14T15:25:16.347Z	warn	kwild.abci	abci/abci.go:371	failed to execute transaction	{"error": "ERROR: out of shared memory (SQLSTATE 53200)\ninternal database error"}
2024-11-14T15:25:16.35Z	warn	kwild.abci	abci/abci.go:371	failed to execute transaction	{"error": "ERROR: out of shared memory (SQLSTATE 53200)\ninternal database error"}
2024-11-14T15:25:17.434Z	info	kwild.cometbft	state/execution.go:230	finalized block	{"module": "state", "height": 1095421, "num_txs_res": 501, "num_val_updates": 0, "block_app_hash": "0A4B186AD57C28DE4EBF694293800C25572267F0258FA694B52F42B7FD55B813"}
```

This PR fixes that by:
- catching error codes in class 53, 58, or XX (https://www.postgresql.org/docs/current/errcodes-appendix.html)
- closing the current db connection when the `pg` package detects this error
- when detected, join the error with the common `sql.ErrDBFailure` error type
- in abci's `FinalizeBlock`, detect this error type and cause the node to halt instead of just labeling the transaction as failed in the block result
