### PR TITLE
[release-v0.9] expose TrustPeriod flag for snapshots

### DIFF
--- a/cmd/common.go
+++ b/cmd/common.go
@@ -129,6 +129,7 @@ var DefaultConfig = func() *commonConfig.KwildConfig {
 				Enable:              false,
 				DiscoveryTime:       commonConfig.Duration(15 * time.Second),
 				ChunkRequestTimeout: commonConfig.Duration(10 * time.Second),
+				TrustPeriod:         commonConfig.Duration(730 * time.Hour), // 1 month
 			},
 			Consensus: &commonConfig.ConsensusConfig{
 				TimeoutPropose:   commonConfig.Duration(3 * time.Second),

--- a/cmd/kwil-admin/nodecfg/toml.go
+++ b/cmd/kwil-admin/nodecfg/toml.go
@@ -395,4 +395,8 @@ chunk_request_timeout = "{{ .ChainConfig.StateSync.ChunkRequestTimeout }}"
 
 # Note: If the requested chunk is not received for a duration of 2 minutes (hard-coded default), 
 # the state sync process is aborted and the node will fall back to the regular block sync process.
+
+# Trust period is the duration for which the node trusts the state sync snapshots.
+# Snapshots older than the trust period are considered to be expired and are not used for state sync.
+trust_period = "{{ .ChainConfig.StateSync.TrustPeriod }}"
 `

--- a/cmd/kwild/config/config_test.go
+++ b/cmd/kwild/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/kwilteam/kwil-db/cmd"
 	"github.com/kwilteam/kwil-db/common/config"
@@ -45,6 +46,9 @@ func Test_Config_Toml(t *testing.T) {
 	assert.Equal(t, "9.8.7.6:20660", cfg.Instrumentation.PromListenAddr)
 
 	// TODO: Add bunch of other validations for different types
+	// 1h -> 3600s
+	assert.Equal(t, 1*time.Hour, cfg.ChainConfig.StateSync.TrustPeriod.Dur())
+	assert.Equal(t, config.Duration(1*time.Hour), cfg.ChainConfig.StateSync.TrustPeriod)
 }
 
 func Test_cleanListenAddr(t *testing.T) {

--- a/cmd/kwild/config/default_config.toml
+++ b/cmd/kwild/config/default_config.toml
@@ -323,6 +323,10 @@ chunk_request_timeout = "10s"
 # Note: If the requested chunk is not received for a duration of 2 minutes (hard-coded default), 
 # the state sync process is aborted and the node will fall back to the regular block sync process.
 
+# Trust period is the duration for which the node trusts the state sync snapshots.
+# Snapshots older than the trust period are considered to be expired and are not used for state sync.
+trust_period = "36000h"
+
 [instrumentation]
 
 # collect and serve are served under /metrics

--- a/cmd/kwild/config/flags.go
+++ b/cmd/kwild/config/flags.go
@@ -117,6 +117,7 @@ to instead run a dedicated seeder like https://github.com/kwilteam/cometseed.`))
 	flagSet.StringVar(&cfg.ChainConfig.StateSync.RPCServers, "chain.statesync.rpc-servers", cfg.ChainConfig.StateSync.RPCServers, "Chain state sync rpc servers")
 	flagSet.Var(&cfg.ChainConfig.StateSync.DiscoveryTime, "chain.statesync.discovery-time", "Chain state sync discovery time")
 	flagSet.Var(&cfg.ChainConfig.StateSync.ChunkRequestTimeout, "chain.statesync.chunk-request-timeout", "Chain state sync chunk request timeout")
+	flagSet.Var(&cfg.ChainConfig.StateSync.TrustPeriod, "chain.statesync.trust-period", "Duration for which the state sync snapshots are considered trustworthy.")
 
 	// Instrumentation flags
 	flagSet.BoolVar(&cfg.Instrumentation.Prometheus, "instrumentation.prometheus", cfg.Instrumentation.Prometheus, "collect and serve prometheus metrics")

--- a/cmd/kwild/config/test_data/config.toml
+++ b/cmd/kwild/config/test_data/config.toml
@@ -298,6 +298,7 @@ chunk_request_timeout = "10s"
 
 # Note: If the requested chunk is not received for a duration of 2 minutes (hard-coded default), 
 # the state sync process is aborted and the node will fall back to the regular block sync process.
+trust_period = "1h"
 
 [instrumentation]
 

--- a/cmd/kwild/server/cometbft.go
+++ b/cmd/kwild/server/cometbft.go
@@ -115,7 +115,7 @@ func newCometConfig(cfg *config.KwildConfig) *cmtCfg.Config {
 	}
 
 	// Light client verification
-	nodeCfg.StateSync.TrustPeriod = 168 * time.Hour // 7 days
+	nodeCfg.StateSync.TrustPeriod = time.Duration(userChainCfg.StateSync.TrustPeriod)
 
 	// Standardize the paths.
 	nodeCfg.DBPath = cometbft.DataDir // i.e. "data", we do not allow users to change

--- a/common/config/config.go
+++ b/common/config/config.go
@@ -205,6 +205,10 @@ type StateSyncConfig struct {
 	// The timeout duration before re-requesting a chunk, possibly from a different
 	// peer (default: 1 minute).
 	ChunkRequestTimeout Duration `mapstructure:"chunk_request_timeout"`
+
+	// Trust period is the duration for which the node trusts the state sync snapshots.
+	// Snapshots older than the trust period are considered to be expired and are not used for state sync.
+	TrustPeriod Duration `mapstructure:"trust_period"`
 }
 
 type ChainConfig struct {


### PR DESCRIPTION
Backport of cb0f6f6c19644f9ec405078b54c615eb4c6e8d35 for `release-v0.9`
It was only on `preview` afait, but it seems desirable if we are doing a v0.9.2