### PR TITLE
fix: deprecated extension config map not set properly

### DIFF
--- a/cmd/kwild/server/build.go
+++ b/cmd/kwild/server/build.go
@@ -272,7 +272,7 @@ func (c *coreDependencies) service(loggerName string) *common.Service {
 		GenesisConfig:    c.genesisCfg,
 		LocalConfig:      c.cfg,
 		Identity:         c.privKey.PubKey().Bytes(),
-		ExtensionConfigs: make(map[string]map[string]string),
+		ExtensionConfigs: c.cfg.AppConfig.Extensions,
 	}
 }
 


### PR DESCRIPTION
This fixes a bug where a deprecated field was not being set properly, causing it to be a breaking change within the deprecation period.

