### PR TITLE
jsonrpc/usersvc: use best block height/time in view call

### DIFF
--- a/common/context.go
+++ b/common/context.go
@@ -23,7 +23,7 @@ type BlockContext struct {
 	ChainContext *ChainContext
 	// Height gets the height of the current block.
 	Height int64
-	// Timestamp is a timestamp of the current block.
+	// Timestamp is a timestamp of the current block, in seconds (UNIX epoch).
 	// It is set by the block proposer, and therefore may not be accurate.
 	// It should not be used for time-sensitive operations where incorrect
 	// timestamps could result in security vulnerabilities.


### PR DESCRIPTION
Alternative to https://github.com/kwilteam/kwil-db/pull/1088
Resolves https://github.com/kwilteam/kwil-db/issues/1084

```
action get_post($id) public view {
    SELECT *, @block_timestamp as stamp, @height as height
    FROM posts
    WHERE id = $id;
}
```

```
 $  kwil-cli database call -i xc4503ccf15daada96e36cbbacf641f48ebc6226e28906c8757866b91 -a get_post 'id:3'
| content | height | id |   stamp    | title  | user_id |
+---------+--------+----+------------+--------+---------+
| hihi    |    842 |  3 | 1732569623 | title2 |       1 |

$  kwil-cli database call -i xc4503ccf15daada96e36cbbacf641f48ebc6226e28906c8757866b91 -a get_post 'id:3'
| content | height | id |   stamp    | title  | user_id |
+---------+--------+----+------------+--------+---------+
| hihi    |    843 |  3 | 1732569630 | title2 |       1 |
```