### PR TITLE
accountsHash determinism, and global types.Hash use

### DIFF
--- a/app/shared/display/message.go
+++ b/app/shared/display/message.go
@@ -1,7 +1,6 @@
 package display
 
 import (
-	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
@@ -112,9 +111,9 @@ func (r *RespTxQuery) MarshalJSON() ([]byte, error) {
 			out.Warn = "ERROR encoding transaction: " + err.Error()
 		} else if r.WithRaw {
 			out.Raw = hex.EncodeToString(raw)
-			hash := sha256.Sum256(raw)
+			hash := types.HashBytes(raw)
 			if hash != r.Msg.Hash {
-				out.Warn = fmt.Sprintf("HASH MISMATCH: requested %s; received %x",
+				out.Warn = fmt.Sprintf("HASH MISMATCH: requested %s; received %s",
 					r.Msg.Hash, hash)
 			}
 		}
@@ -155,9 +154,9 @@ Log: %s`,
 		if r.WithRaw {
 			msg += "\nRaw: " + hex.EncodeToString(raw)
 		}
-		hash := sha256.Sum256(raw)
+		hash := types.HashBytes(raw)
 		if hash != r.Msg.Hash {
-			msg += fmt.Sprintf("\nWARNING! HASH MISMATCH:\n\tRequested %s\n\tReceived  %x",
+			msg += fmt.Sprintf("\nWARNING! HASH MISMATCH:\n\tRequested %s\n\tReceived  %s",
 				r.Msg.Hash, hash)
 		}
 	}

--- a/cmd/kwil-cli/cmds/utils/message.go
+++ b/cmd/kwil-cli/cmds/utils/message.go
@@ -2,9 +2,7 @@ package utils
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/base64"
-	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -57,8 +55,8 @@ func (t *transaction) MarshalJSON() ([]byte, error) {
 }
 
 func (t *transaction) MarshalText() ([]byte, error) {
-	txHash := sha256.Sum256(t.Raw) // tmhash is sha256
-	msg := fmt.Sprintf(`Transaction ID: %x
+	txHash := types.HashBytes(t.Raw)
+	msg := fmt.Sprintf(`Transaction ID: %s
 Sender: %s
 Description: %s
 Payload type: %s
@@ -69,7 +67,7 @@ Signature type: %s
 Signature: %s
 `,
 		txHash,
-		hex.EncodeToString(t.Tx.Sender), // hex because it's an address or pubkey, probably address
+		t.Tx.Sender.String(),
 		t.Tx.Body.Description,
 		t.Tx.Body.PayloadType,
 		t.Tx.Body.ChainID,

--- a/core/types/hash.go
+++ b/core/types/hash.go
@@ -22,7 +22,7 @@ func HashBytes(b []byte) Hash {
 }
 
 // Hasher is like the standard library's hash.Hash, but with fewer methods and
-// returning a Hash instead of a byte slice. Use [NewHasher] to get a Hasher.
+// returning a [Hash] instead of a byte slice. Use [NewHasher] to get a Hasher.
 type Hasher interface {
 	// Write more data to the running hash. It never returns an error.
 	io.Writer

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"bytes"
+	"encoding"
 	"encoding/binary"
 	"encoding/json"
 	"errors"
@@ -43,7 +44,7 @@ type Transaction struct {
 	Serialization SignedMsgSerializationType `json:"serialization"`
 
 	// Sender is the user identifier, which is generally an address but may be
-	// a public key of the sender.
+	// a public key of the sender, hence bytes that encode as hexadecimal.
 	Sender HexBytes `json:"sender"`
 
 	strictUnmarshal bool
@@ -258,6 +259,8 @@ func (t *TransactionBody) SerializeMsg(mst SignedMsgSerializationType) ([]byte, 
 	return nil, errors.New("invalid serialization type")
 }
 
+var _ encoding.BinaryMarshaler = (*Transaction)(nil)
+
 // MarshalBinary produces the full binary serialization of the transaction,
 // which is the form used in p2p messaging and blockchain storage.
 func (t *Transaction) MarshalBinary() ([]byte, error) {
@@ -278,6 +281,8 @@ func (t *Transaction) ReadFrom(r io.Reader) (int64, error) {
 	return int64(n), nil
 }
 
+var _ encoding.BinaryUnmarshaler = (*Transaction)(nil)
+
 func (t *Transaction) UnmarshalBinary(data []byte) error {
 	r := bytes.NewReader(data)
 	n, err := t.deserialize(r)
@@ -295,6 +300,8 @@ func (t *Transaction) UnmarshalBinary(data []byte) error {
 	}
 	return nil
 }
+
+var _ encoding.BinaryMarshaler = (*TransactionBody)(nil)
 
 func (tb *TransactionBody) MarshalBinary() ([]byte, error) {
 	buf := new(bytes.Buffer)
@@ -385,6 +392,8 @@ func (tb *TransactionBody) ReadFrom(r io.Reader) (int64, error) {
 
 	return int64(n), nil
 }
+
+var _ encoding.BinaryUnmarshaler = (*TransactionBody)(nil)
 
 func (tb *TransactionBody) UnmarshalBinary(data []byte) error {
 	buf := bytes.NewReader(data)

--- a/node/types/block.go
+++ b/node/types/block.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"io"
@@ -208,9 +207,9 @@ func EncodeBlockHeader(hdr *BlockHeader) []byte {
 }
 
 func (bh *BlockHeader) Hash() Hash {
-	hasher := sha256.New()
+	hasher := types.NewHasher()
 	bh.writeBlockHeader(hasher)
-	return Hash(hasher.Sum(nil))
+	return hasher.Sum(nil)
 }
 
 /*func encodeBlockHeaderOneAlloc(hdr *BlockHeader) []byte {
@@ -296,7 +295,7 @@ func CalcMerkleRoot(leaves []Hash) Hash {
 		for i := range len(leaves) / 2 {
 			copy(left, leaves[i*2][:])
 			copy(right, leaves[i*2+1][:])
-			leaves[i] = sha256.Sum256(both)
+			leaves[i] = types.HashBytes(both)
 		}
 		leaves = leaves[:len(leaves)/2]
 	}

--- a/node/types/block_test.go
+++ b/node/types/block_test.go
@@ -2,12 +2,12 @@ package types
 
 import (
 	"bytes"
-	"crypto/sha256"
 	"encoding/binary"
 	"testing"
 	"time"
 
 	"github.com/kwilteam/kwil-db/core/crypto"
+	"github.com/kwilteam/kwil-db/core/types"
 
 	"github.com/stretchr/testify/require"
 )
@@ -120,7 +120,7 @@ func TestCalcMerkleRoot(t *testing.T) {
 		var buf [HashLen * 2]byte
 		copy(buf[:HashLen], leaf1[:])
 		copy(buf[HashLen:], leaf2[:])
-		expected := sha256.Sum256(buf[:])
+		expected := types.HashBytes(buf[:])
 
 		if root != expected {
 			t.Errorf("got root %x, want %x", root, expected)


### PR DESCRIPTION
I came across what looks like some non-determinism in the computation of `accountsHash` while converting some uses of `sha256.Sum256` to our `types.Hash`/`types.Hasher`/`types.HashBytes`.

@charithabandi pls correct me if I'm wrong, but `ce.accounts.Updates()` code seems to range over a map, but even if it sorted internally I think it's right to have CE do a sort its way, as the other hashes do.