### PR TITLE
[v0.9] version: update self-report tag for vanilla builds

### DIFF
--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -15,7 +15,7 @@ import (
 //   - 0.6.0+release
 //   - 0.6.1
 //   - 0.6.2-alpha0+go1.21.nocgo
-const kwilVersion = "0.9.0-pre"
+const kwilVersion = "0.9.3"
 
 // KwildVersion may be set at compile time by:
 //


### PR DESCRIPTION
This updates the hard coded version string that is used for vanilla `go build`s to self report the version.  Official builds set it with an env var.