### PR TITLE
clean up prepared transactions in (*DB).Close

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -238,7 +238,7 @@ tasks:
     cmds:
       - go test ./core/... -tags=ext_test -count=1 -race
       - CGO_ENABLED=1 go test ./parse/... -tags=ext_test -count=1 -race
-      - CGO_ENABLED=1 go test ./... -tags=ext_test -count=1 -race
+      - CGO_ENABLED=1 go test ./... -tags=ext_test,pglive -count=1 -race
 
   # test:it:
   #   desc: Run integration tests ('short' mode)

--- a/app/node/build.go
+++ b/app/node/build.go
@@ -152,6 +152,8 @@ func (mt *mysteryThing) Price(ctx context.Context, db sql.DB, tx *types.Transact
 }
 
 func buildDB(ctx context.Context, d *coreDependencies, closers *closeFuncs) *pg.DB {
+	pg.UseLogger(d.logger.New("PG"))
+
 	// TODO: restore from snapshots
 
 	db, err := d.dbOpener(ctx, d.cfg.DB.DBName, d.cfg.DB.MaxConns)

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -176,7 +176,7 @@ func verifyStatus(_ *testing.T, val *ConsensusEngine, status Status, height int6
 }
 
 func TestMain(m *testing.M) {
-	pg.UseLogger(log.New(log.WithName("DBS")))
+	pg.UseLogger(log.New(log.WithName("DBS"), log.WithFormat(log.FormatUnstructured)))
 	m.Run()
 }
 

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -175,6 +175,11 @@ func verifyStatus(_ *testing.T, val *ConsensusEngine, status Status, height int6
 	return nil
 }
 
+func TestMain(m *testing.M) {
+	pg.UseLogger(log.New(log.WithName("DBS")))
+	m.Run()
+}
+
 func TestValidatorStateMachine(t *testing.T) {
 	// t.Parallel()
 	type action struct {

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -42,7 +42,7 @@ var defaultGenesisParams = &consensus.GenesisParams{
 }
 
 func TestMain(m *testing.M) {
-	pg.UseLogger(log.New(log.WithName("DBS")))
+	pg.UseLogger(log.New(log.WithName("DBS"), log.WithFormat(log.FormatUnstructured)))
 	m.Run()
 }
 

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -41,6 +41,11 @@ var defaultGenesisParams = &consensus.GenesisParams{
 	},
 }
 
+func TestMain(m *testing.M) {
+	pg.UseLogger(log.New(log.WithName("DBS")))
+	m.Run()
+}
+
 func TestSingleNodeMocknet(t *testing.T) {
 	if testing.Short() {
 		t.Skip()
@@ -53,8 +58,6 @@ func TestSingleNodeMocknet(t *testing.T) {
 	}
 	bs1 := memstore.NewMemBS()
 	mp1 := mempool.New()
-
-	pg.UseLogger(log.New(log.WithName("DBS")))
 
 	db1 := initDB(t, "5432", "kwil_test_db")
 
@@ -154,8 +157,6 @@ func TestDualNodeMocknet(t *testing.T) {
 	}
 	bs1 := memstore.NewMemBS()
 	mp1 := mempool.New()
-
-	pg.UseLogger(log.New(log.WithName("DBS")))
 
 	db1 := initDB(t, "5432", "kwil_test_db")
 	func() {
@@ -332,10 +333,9 @@ func initDB(t *testing.T, port, dbName string) *pg.DB {
 }
 
 func cleanupDB(db *pg.DB) {
-	ctx := context.Background()
-	db.AutoCommit(true)
-	defer db.AutoCommit(false)
 	defer db.Close()
+	db.AutoCommit(true)
+	ctx := context.Background()
 	db.Execute(ctx, `DROP SCHEMA IF EXISTS kwild_chain CASCADE;`)
 	db.Execute(ctx, `DROP SCHEMA IF EXISTS kwild_internal CASCADE;`)
 }


### PR DESCRIPTION
Not just regular transactions.  This avoids annoying orphaned prepared transactions in the case where a bug results in closing the DB when there is an active transaction.