### PR TITLE
fix banner name

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The database for Web3.
 
-![banner](./kwil-banner.jpeg)
+![banner](./kwil-banner.jpg)
 
 [![Github-License](https://img.shields.io/badge/license-Apache%202.0-green)](./LICENSE.md)
 [![Release](https://img.shields.io/github/v/release/kwilteam/kwil-db)](https://github.com/kwilteam/kwil-db/releases)


### PR DESCRIPTION
I tried to fix the broken banner with https://github.com/kwilteam/kwil-db/pull/1127, but it only fixed the new path. The file also got renamed from `.jpeg` to `.jpg`, which I missed.
