### PR TITLE
cli: reorder config priority

### DIFF
--- a/cmd/kwil-cli/cmds/configure/configure.go
+++ b/cmd/kwil-cli/cmds/configure/configure.go
@@ -34,7 +34,8 @@ func NewCmdConfigure() *cobra.Command {
 				return display.PrintErr(cmd, errors.New("cannot configure run in silence mode"))
 			}
 
-			conf, err := config.LoadPersistedConfig()
+			// config.LoadPersistedConfig() => just the config file
+			conf, err := config.ActiveConfig() // considering merged config including flags and env
 			if err != nil {
 				return display.PrintErr(cmd, err)
 			}

--- a/cmd/kwil-cli/cmds/root.go
+++ b/cmd/kwil-cli/cmds/root.go
@@ -38,7 +38,8 @@ func NewRootCmd() *cobra.Command {
 		SilenceUsage:      true,
 		DisableAutoGenTag: true,
 		PersistentPreRunE: bind.ChainPreRuns(bind.MaybeEnableCLIDebug,
-			config.PreRunBindFlags, config.PreRunBindConfigFile,
+			// Config priority, highest to lowest: env, flags, config.json
+			config.PreRunBindConfigFile, config.PreRunBindFlags, config.PreRunBindEnv,
 			config.PreRunPrintEffectiveConfig),
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
@@ -53,7 +54,7 @@ func NewRootCmd() *cobra.Command {
 	config.BindConfigPath(rootCmd)
 
 	// Automatically define flags for all of the fields of the config struct.
-	config.SetFlags(rootCmd.Flags())
+	config.SetFlags(rootCmd.PersistentFlags()) // share configs with all subcommands
 
 	helpers.BindAssumeYesFlag(rootCmd) // --assume-yes/-Y
 

--- a/cmd/kwil-cli/cmds/utils/ping.go
+++ b/cmd/kwil-cli/cmds/utils/ping.go
@@ -18,14 +18,16 @@ func pingCmd() *cobra.Command {
 		Long:  "Ping the kwil provider endpoint.  If successful, returns 'pong'.",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			return client.DialClient(cmd.Context(), cmd, client.WithoutPrivateKey, func(ctx context.Context, client clientType.Client, cfg *config.KwilCliConfig) error {
-				res, err := client.Ping(ctx)
-				if err != nil {
-					return display.PrintErr(cmd, err)
-				}
+			return client.DialClient(cmd.Context(), cmd, client.WithoutPrivateKey,
+				func(ctx context.Context, client clientType.Client, cfg *config.KwilCliConfig) error {
+					res, err := client.Ping(ctx)
+					if err != nil {
+						return display.PrintErr(cmd, err)
+					}
 
-				return display.PrintCmd(cmd, display.RespString(res))
-			})
+					return display.PrintCmd(cmd, display.RespString(res))
+				},
+			)
 		},
 	}
 

--- a/cmd/kwil-cli/main.go
+++ b/cmd/kwil-cli/main.go
@@ -1,7 +1,6 @@
 package main
 
 import (
-	"fmt"
 	"os"
 
 	// NOTE: if extensions are used to build a kwild with new transaction
@@ -12,12 +11,13 @@ import (
 	// introduced by the consensus extensions.
 
 	root "github.com/kwilteam/kwil-db/cmd/kwil-cli/cmds"
+	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
 )
 
 func main() {
 	root := root.NewRootCmd()
 	if err := root.Execute(); err != nil {
-		fmt.Println(err)
+		config.PreRunPrintEffectiveConfig(root, nil) // only when --debug is set
 		os.Exit(-1)
 	}
 	os.Exit(0)


### PR DESCRIPTION
Neglected to push this yesterday.

For `kwil-cli`, this reorders the priority of config:

1. env
2. flags
3. config file (config.json)

This PR also makes it an error condition if the config file was specified (`--config/-c`) but it does not exists.  It is only not an error if it was not specified.