### PR TITLE
use structured transaction in store and mempool

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -62,8 +62,8 @@ type BlockHeader struct {
 
 type Block struct {
 	Header    *BlockHeader
-	Txns      [][]byte
-	Signature []byte // Signature is the block producer's signature (leader in our model)
+	Txns      [][]byte // TODO: convert to []*Transaction
+	Signature []byte   // Signature is the block producer's signature (leader in our model)
 }
 
 func (b *Block) Hash() Hash {

--- a/core/types/transaction.go
+++ b/core/types/transaction.go
@@ -259,6 +259,25 @@ func (t *TransactionBody) SerializeMsg(mst SignedMsgSerializationType) ([]byte, 
 	return nil, errors.New("invalid serialization type")
 }
 
+type countingWriter struct {
+	w io.Writer
+	c int64
+}
+
+func (cw *countingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.c += int64(n)
+	return n, err
+}
+
+var _ io.WriterTo = (*Transaction)(nil)
+
+func (t *Transaction) WriteTo(w io.Writer) (int64, error) {
+	cw := &countingWriter{w: w}
+	err := t.serialize(cw)
+	return cw.c, err
+}
+
 var _ encoding.BinaryMarshaler = (*Transaction)(nil)
 
 // MarshalBinary produces the full binary serialization of the transaction,

--- a/core/utils/rw.go
+++ b/core/utils/rw.go
@@ -23,3 +23,25 @@ func (cw *CountingWriter) Write(p []byte) (int, error) {
 func (cw *CountingWriter) Written() int64 {
 	return cw.c
 }
+
+// CountingReader wraps an io.Reader, adding a ReadCount method to get the total
+// bytes read over multiple calls to Read. This is helpful if the Reader passes
+// through other functions that do not return the bytes read.
+type CountingReader struct {
+	r io.Reader
+	c int64
+}
+
+func NewCountingReader(r io.Reader) *CountingReader {
+	return &CountingReader{r: r}
+}
+
+func (cr *CountingReader) Read(p []byte) (int, error) {
+	n, err := cr.r.Read(p)
+	cr.c += int64(n)
+	return n, err
+}
+
+func (cr *CountingReader) ReadCount() int64 {
+	return cr.c
+}

--- a/core/utils/writer.go
+++ b/core/utils/writer.go
@@ -1,0 +1,25 @@
+package utils
+
+import "io"
+
+// CountingWriter wraps an io.Writer, adding a Written method to get the total
+// bytes written over multiple calls to Write. This is helpful if the Writer
+// passes through other functions that do not return the bytes written.
+type CountingWriter struct {
+	w io.Writer
+	c int64
+}
+
+func NewCountingWriter(w io.Writer) *CountingWriter {
+	return &CountingWriter{w: w}
+}
+
+func (cw *CountingWriter) Write(p []byte) (int, error) {
+	n, err := cw.w.Write(p)
+	cw.c += int64(n)
+	return n, err
+}
+
+func (cw *CountingWriter) Written() int64 {
+	return cw.c
+}

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -41,7 +41,7 @@ func (ce *ConsensusEngine) validateBlock(blk *ktypes.Block) error {
 	return nil
 }
 
-func (ce *ConsensusEngine) CheckTx(ctx context.Context, tx []byte) error {
+func (ce *ConsensusEngine) CheckTx(ctx context.Context, tx *ktypes.Transaction) error {
 	ce.mempoolMtx.Lock()
 	defer ce.mempoolMtx.Unlock()
 
@@ -107,7 +107,7 @@ func (ce *ConsensusEngine) commit(ctx context.Context) error {
 	// remove transactions from the mempool
 	for _, txn := range blkProp.blk.Txns {
 		txHash := types.HashBytes(txn) // TODO: can this be saved instead of recalculating?
-		ce.mempool.Store(txHash, nil)
+		ce.mempool.Remove(txHash)
 	}
 
 	// TODO: reapply existing transaction  (checkTX)

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -20,7 +20,7 @@ type DB interface {
 
 type Mempool interface {
 	PeekN(maxSize int) []types.NamedTx
-	Store(txid types.Hash, tx []byte)
+	Remove(txid types.Hash)
 }
 
 // BlockStore includes both txns and blocks
@@ -42,7 +42,7 @@ type BlockProcessor interface {
 	Rollback(ctx context.Context, height int64, appHash ktypes.Hash) error
 	Close() error
 
-	CheckTx(ctx context.Context, tx []byte, recheck bool) error
+	CheckTx(ctx context.Context, tx *ktypes.Transaction, recheck bool) error
 
 	GetValidators() []*ktypes.Validator
 }

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -29,7 +29,7 @@ type ConsensusEngine interface {
 		blkAnnouncer consensus.BlkAnnouncer, ackBroadcaster consensus.AckBroadcaster,
 		blkRequester consensus.BlkRequester, stateResetter consensus.ResetStateBroadcaster, discoveryBroadcaster consensus.DiscoveryReqBroadcaster) error
 
-	CheckTx(ctx context.Context, tx []byte) error
+	CheckTx(ctx context.Context, tx *ktypes.Transaction) error
 }
 
 type SnapshotStore interface {

--- a/node/mempool/mempool.go
+++ b/node/mempool/mempool.go
@@ -99,6 +99,7 @@ func (mp *Mempool) ReapN(n int) []types.NamedTx {
 	defer mp.mtx.Unlock()
 	n = min(n, len(mp.txQ))
 	txns := slices.Clone(mp.txQ[:n])
+	mp.txQ = mp.txQ[n:]
 	for _, tx := range txns {
 		delete(mp.txns, tx.Hash)
 	}

--- a/node/mempool/mempool_test.go
+++ b/node/mempool/mempool_test.go
@@ -60,3 +60,63 @@ func Test_MempoolRemove(t *testing.T) {
 	assert.Empty(t, m.txQ)
 	assert.Empty(t, m.txns)
 }
+
+func Test_MempoolReapN(t *testing.T) {
+	m := New()
+
+	// Setup test transactions
+	tx1 := types.NamedTx{
+		Hash: types.Hash{1, 2, 3},
+		Tx:   newTx(1, "A"),
+	}
+	tx2 := types.NamedTx{
+		Hash: types.Hash{4, 5, 6},
+		Tx:   newTx(2, "B"),
+	}
+	tx3 := types.NamedTx{
+		Hash: types.Hash{7, 8, 9},
+		Tx:   newTx(3, "C"),
+	}
+
+	// Test reaping from empty mempool
+	emptyReap := m.ReapN(1)
+	assert.Empty(t, emptyReap)
+
+	// Add transactions to mempool
+	m.Store(tx1.Hash, tx1.Tx)
+	m.Store(tx2.Hash, tx2.Tx)
+	m.Store(tx3.Hash, tx3.Tx)
+
+	// Test reaping more transactions than available
+	overReap := m.ReapN(5)
+	assert.Len(t, overReap, 3)
+	assert.Equal(t, overReap[0].Hash, tx1.Hash)
+	assert.Equal(t, overReap[1].Hash, tx2.Hash)
+	assert.Equal(t, overReap[2].Hash, tx3.Hash)
+	assert.Empty(t, m.txQ)
+	assert.Empty(t, m.txns)
+
+	// Refill mempool
+	m.Store(tx1.Hash, tx1.Tx)
+	m.Store(tx2.Hash, tx2.Tx)
+	m.Store(tx3.Hash, tx3.Tx)
+
+	// Test partial reaping
+	partialReap := m.ReapN(2)
+	assert.Len(t, partialReap, 2)
+	assert.Equal(t, partialReap[0].Hash, tx1.Hash)
+	assert.Equal(t, partialReap[1].Hash, tx2.Hash)
+	assert.Len(t, m.txQ, 1)
+	assert.Len(t, m.txns, 1)
+
+	// Test reaping remaining transaction
+	finalReap := m.ReapN(1)
+	assert.Len(t, finalReap, 1)
+	assert.Equal(t, finalReap[0].Hash, tx3.Hash)
+	assert.Empty(t, m.txQ)
+	assert.Empty(t, m.txns)
+
+	// Test reaping with zero count
+	zeroReap := m.ReapN(0)
+	assert.Empty(t, zeroReap)
+}

--- a/node/mempool/mempool_test.go
+++ b/node/mempool/mempool_test.go
@@ -1,0 +1,62 @@
+package mempool
+
+import (
+	"math/big"
+	"testing"
+
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	ktypes "github.com/kwilteam/kwil-db/core/types"
+	"github.com/kwilteam/kwil-db/node/types"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTx(nonce uint64, sender string) *ktypes.Transaction {
+	return &ktypes.Transaction{
+		Signature: &auth.Signature{},
+		Body: &ktypes.TransactionBody{
+			Description: "test",
+			Payload:     []byte(`random payload`),
+			Fee:         big.NewInt(0),
+			Nonce:       nonce,
+		},
+		Sender: []byte(sender),
+	}
+}
+
+func Test_MempoolRemove(t *testing.T) {
+	m := New()
+
+	// Setup test transactions
+	tx1 := types.NamedTx{
+		Hash: types.Hash{1, 2, 3},
+		Tx:   newTx(1, "A"),
+	}
+	tx2 := types.NamedTx{
+		Hash: types.Hash{4, 5, 6},
+		Tx:   newTx(2, "B"),
+	}
+
+	// Add transactions to mempool
+	m.Store(tx1.Hash, tx1.Tx)
+	m.Store(tx2.Hash, tx2.Tx)
+
+	// Test removing existing transaction
+	m.Remove(tx1.Hash)
+	assert.Len(t, m.txQ, 1)
+	assert.Len(t, m.txns, 1)
+	assert.Equal(t, m.txQ[0].Hash, tx2.Hash)
+	_, exists := m.txns[tx1.Hash]
+	assert.False(t, exists)
+
+	// Test removing non-existent transaction
+	nonExistentHash := types.Hash{9}
+	m.Remove(nonExistentHash)
+	assert.Len(t, m.txQ, 1)
+	assert.Len(t, m.txns, 1)
+	assert.Equal(t, m.txQ[0].Hash, tx2.Hash)
+
+	// Test removing last transaction
+	m.Remove(tx2.Hash)
+	assert.Empty(t, m.txQ)
+	assert.Empty(t, m.txns)
+}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -188,7 +188,7 @@ func (ce *dummyCE) Role() types.Role {
 	return types.RoleLeader
 }
 
-func (ce *dummyCE) CheckTx(ctx context.Context, tx []byte) error {
+func (ce *dummyCE) CheckTx(ctx context.Context, tx *ktypes.Transaction) error {
 	return nil
 }
 

--- a/node/store/store.go
+++ b/node/store/store.go
@@ -469,7 +469,8 @@ func (bki *BlockStore) HaveTx(txHash types.Hash) bool {
 
 // GetTx returns the raw bytes of the transaction, and information on the block
 // containing the transaction.
-func (bki *BlockStore) GetTx(txHash types.Hash) (raw []byte, height int64, blkHash types.Hash, blkIdx uint32, err error) {
+func (bki *BlockStore) GetTx(txHash types.Hash) (tx *ktypes.Transaction, height int64, blkHash types.Hash, blkIdx uint32, err error) {
+	var raw []byte
 	err = bki.db.View(func(txn *badger.Txn) error {
 		// Get block info from the tx index
 		key := slices.Concat(nsTxn, txHash[:]) // tdb["t:txHash"] => blk info
@@ -515,5 +516,13 @@ func (bki *BlockStore) GetTx(txHash types.Hash) (raw []byte, height int64, blkHa
 	if errors.Is(err, badger.ErrKeyNotFound) {
 		err = types.ErrNotFound
 	}
+
+	if len(raw) == 0 {
+		return
+	}
+
+	tx = new(ktypes.Transaction)
+	err = tx.UnmarshalBinary(raw)
+
 	return
 }

--- a/node/tx.go
+++ b/node/tx.go
@@ -103,23 +103,23 @@ func (n *Node) txGetStreamHandler(s network.Stream) {
 	}
 
 	// first check mempool
-	rawTx := n.mp.Get(req.Hash)
-	if rawTx != nil {
-		s.Write(rawTx)
+	tx := n.mp.Get(req.Hash)
+	if tx != nil {
+		tx.WriteTo(s)
 		return
 	}
 
 	// this is racy, and should be different in product
 
 	// then confirmed tx index
-	rawTx, _, _, _, err := n.bki.GetTx(req.Hash)
+	tx, _, _, _, err := n.bki.GetTx(req.Hash)
 	if err != nil {
 		if !errors.Is(err, types.ErrNotFound) {
 			n.log.Errorf("unexpected GetTx error: %v", err)
 		}
 		s.Write(noData) // don't have it
 	} else {
-		s.Write(rawTx)
+		tx.WriteTo(s)
 	}
 
 	// NOTE: response could also include conf/unconf or block height (-1 or N)

--- a/node/types/interfaces.go
+++ b/node/types/interfaces.go
@@ -48,15 +48,16 @@ type BlockResultsStorer interface {
 }
 
 type TxGetter interface {
-	GetTx(txHash types.Hash) (raw []byte, height int64, blkHash types.Hash, blkIdx uint32, err error)
+	GetTx(txHash types.Hash) (raw *types.Transaction, height int64, blkHash types.Hash, blkIdx uint32, err error)
 	HaveTx(Hash) bool
 }
 
 type MemPool interface {
 	Size() int
-	ReapN(int) ([]Hash, [][]byte) // Reap(n int, maxBts int) ([]Hash, [][]byte)
-	Get(Hash) []byte
-	Store(Hash, []byte)
+	ReapN(int) []NamedTx
+	Get(Hash) *types.Transaction
+	Remove(Hash)
+	Store(Hash, *types.Transaction)
 	PeekN(n int) []NamedTx
 	// Check([]byte)
 	PreFetch(txid Hash) bool // should be app level instead
@@ -75,5 +76,5 @@ type Execution interface {
 
 type NamedTx struct {
 	Hash Hash
-	Tx   []byte
+	Tx   *types.Transaction
 }

--- a/node/types/interfaces.go
+++ b/node/types/interfaces.go
@@ -1,8 +1,6 @@
 package types
 
 import (
-	"context"
-
 	"github.com/kwilteam/kwil-db/core/types"
 )
 
@@ -68,10 +66,6 @@ type QualifiedBlock struct { // basically just caches the hash
 	Hash     Hash
 	Proposed bool
 	AppHash  *Hash
-}
-
-type Execution interface {
-	ExecBlock(blk *types.Block) (commit func(context.Context, bool) error, appHash Hash, res []types.TxResult, err error)
 }
 
 type NamedTx struct {


### PR DESCRIPTION
Both the block store and mempool types were still using opaque transctions (`[]byte`) from the early version of the p2p demo.  This updates both to use `*types.Transaction`.

This change stops short of updating the `Block` type to have a `Txns []*Transaction`  field instead of `Txns [][]byte`, but that change should also be made.  This can wait until the block data / chain RPCs are complete.  It will also require updating the block serialization code, although the effective binary serialization will be identical.

This also updates the mempool implementation and interface:
- internally there is a FIFO queue so that `PeekN` will return those at the front of the queue.  The maps still remain there for fast indexing and existence checks.
- add a `Remove` method that is the same as `Store(txid, nil)`