### PR TITLE
feat(rpc): chain RPCs

### DIFF
--- a/app/node/build.go
+++ b/app/node/build.go
@@ -127,7 +127,7 @@ func buildServer(ctx context.Context, d *coreDependencies) *server {
 	}
 
 	chainRpcSvcLogger := d.logger.New("CHAIN")
-	jsonChainSvc := chainsvc.NewService(chainRpcSvcLogger, node, d.genesisCfg)
+	jsonChainSvc := chainsvc.NewService(chainRpcSvcLogger, node, vs, d.genesisCfg)
 	jsonRPCServer.RegisterSvc(jsonChainSvc)
 
 	s := &server{

--- a/app/node/build.go
+++ b/app/node/build.go
@@ -34,6 +34,7 @@ import (
 
 	rpcserver "github.com/kwilteam/kwil-db/node/services/jsonrpc"
 	"github.com/kwilteam/kwil-db/node/services/jsonrpc/adminsvc"
+	"github.com/kwilteam/kwil-db/node/services/jsonrpc/chainsvc"
 	"github.com/kwilteam/kwil-db/node/services/jsonrpc/funcsvc"
 	"github.com/kwilteam/kwil-db/node/services/jsonrpc/usersvc"
 )
@@ -94,7 +95,7 @@ func buildServer(ctx context.Context, d *coreDependencies) *server {
 		usersvc.WithPrivateMode(d.cfg.RPC.Private),
 		usersvc.WithChallengeExpiry(d.cfg.RPC.ChallengeExpiry),
 		usersvc.WithChallengeRateLimit(d.cfg.RPC.ChallengeRateLimit),
-	// usersvc.WithBlockAgeHealth(6*totalConsensusTimeouts.Dur()),
+		// usersvc.WithBlockAgeHealth(6*totalConsensusTimeouts.Dur()),
 	)
 
 	rpcServerLogger := d.logger.New("RPC")
@@ -124,6 +125,10 @@ func buildServer(ctx context.Context, d *coreDependencies) *server {
 		jsonRPCAdminServer.RegisterSvc(jsonRPCTxSvc)
 		jsonRPCAdminServer.RegisterSvc(&funcsvc.Service{})
 	}
+
+	chainRpcSvcLogger := d.logger.New("CHAIN")
+	jsonChainSvc := chainsvc.NewService(chainRpcSvcLogger, node, d.genesisCfg)
+	jsonRPCServer.RegisterSvc(jsonChainSvc)
 
 	s := &server{
 		cfg:                d.cfg,

--- a/config/config.go
+++ b/config/config.go
@@ -6,8 +6,7 @@ import (
 	"time"
 
 	"github.com/kwilteam/kwil-db/core/log"
-	ktypes "github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/node/types"
+	"github.com/kwilteam/kwil-db/core/types"
 
 	"github.com/pelletier/go-toml/v2"
 )
@@ -41,7 +40,7 @@ type GenesisConfig struct {
 	// Leader is the leader's public key.
 	Leader types.HexBytes `json:"leader"`
 	// Validators is the list of genesis validators (including the leader).
-	Validators []*ktypes.Validator `json:"validators"`
+	Validators []*types.Validator `json:"validators"`
 
 	// MaxBlockSize is the maximum size of a block in bytes.
 	MaxBlockSize int64 `json:"max_block_size"`
@@ -89,7 +88,7 @@ func DefaultGenesisConfig() *GenesisConfig {
 		ChainID:          "kwil-test-chain",
 		InitialHeight:    0,
 		Leader:           types.HexBytes{},
-		Validators:       []*ktypes.Validator{},
+		Validators:       []*types.Validator{},
 		DisabledGasCosts: true,
 		JoinExpiry:       14400,
 		VoteExpiry:       108000,

--- a/contrib/docker/compose/postgres/docker-compose.yml
+++ b/contrib/docker/compose/postgres/docker-compose.yml
@@ -12,9 +12,10 @@ services:
       # POSTGRES_USER: kwild
       # POSTGRES_PASSWORD: kwild
       # POSTGRES_DB: kwild
-    volumes: 
+    volumes:
       - kwildb:/var/lib/postgresql/data
 
 volumes:
   kwildb:
     driver: local
+

--- a/core/rpc/client/chain/interface.go
+++ b/core/rpc/client/chain/interface.go
@@ -1,0 +1,21 @@
+package chain
+
+import (
+	"context"
+
+	"github.com/kwilteam/kwil-db/core/types"
+	chaintypes "github.com/kwilteam/kwil-db/core/types/chain"
+)
+
+type Client interface {
+	Version(ctx context.Context) (string, error)
+	BlockByHeight(ctx context.Context, height int64) (*chaintypes.Block, error)
+	BlockByHash(ctx context.Context, hash types.Hash) (*chaintypes.Block, error)
+	BlockResultByHeight(ctx context.Context, height int64) (*chaintypes.BlockResult, error)
+	BlockResultByHash(ctx context.Context, hash types.Hash) (*chaintypes.BlockResult, error)
+	Tx(ctx context.Context, hash types.Hash) (*chaintypes.Tx, error)
+	Genesis(ctx context.Context) (*chaintypes.Genesis, error)
+	ConsensusParams(ctx context.Context) (*types.ConsensusParams, error)
+	Validators(ctx context.Context) (height int64, validators []*types.Validator, err error)
+	UnconfirmedTxs(ctx context.Context) (total int64, tx chaintypes.NamedTx, err error)
+}

--- a/core/rpc/client/chain/interface.go
+++ b/core/rpc/client/chain/interface.go
@@ -17,5 +17,5 @@ type Client interface {
 	Genesis(ctx context.Context) (*chaintypes.Genesis, error)
 	ConsensusParams(ctx context.Context) (*types.ConsensusParams, error)
 	Validators(ctx context.Context) (height int64, validators []*types.Validator, err error)
-	UnconfirmedTxs(ctx context.Context) (total int64, tx chaintypes.NamedTx, err error)
+	UnconfirmedTxs(ctx context.Context) (total int, txs []chaintypes.NamedTx, err error)
 }

--- a/core/rpc/client/chain/jsonrpc/client.go
+++ b/core/rpc/client/chain/jsonrpc/client.go
@@ -1,0 +1,145 @@
+package jsonrpc
+
+import (
+	"context"
+	"net/url"
+
+	rpcclient "github.com/kwilteam/kwil-db/core/rpc/client"
+	"github.com/kwilteam/kwil-db/core/rpc/client/chain"
+	"github.com/kwilteam/kwil-db/core/rpc/client/user"
+	userClient "github.com/kwilteam/kwil-db/core/rpc/client/user/jsonrpc"
+	chainjson "github.com/kwilteam/kwil-db/core/rpc/json/chain"
+	userjson "github.com/kwilteam/kwil-db/core/rpc/json/user"
+	"github.com/kwilteam/kwil-db/core/types"
+	chaintypes "github.com/kwilteam/kwil-db/core/types/chain"
+)
+
+// Client is a chain RPC client. It provides all methods of the user RPC
+// service, plus methods that are specific to the chain service.
+type Client struct {
+	*userClient.Client // expose all user service methods, and methods for chain svc
+}
+
+// Version reports the version of the running node.
+func (c *Client) Version(ctx context.Context) (string, error) {
+	req := &userjson.VersionRequest{}
+	res := &userjson.VersionResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodVersion), req, res)
+	if err != nil {
+		return "", err
+	}
+	return res.KwilVersion, err
+}
+
+func (c *Client) BlockByHeight(ctx context.Context, height int64) (*chaintypes.Block, error) {
+	req := &chainjson.BlockRequest{
+		Height: height,
+	}
+	res := &chainjson.BlockResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodBlock), req, res)
+	if err != nil {
+		return nil, err
+	}
+	return (*chaintypes.Block)(res), nil
+}
+
+func (c *Client) BlockByHash(ctx context.Context, hash types.Hash) (*chaintypes.Block, error) {
+	req := &chainjson.BlockRequest{
+		Hash: hash,
+	}
+	res := &chainjson.BlockResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodBlock), req, res)
+	if err != nil {
+		return nil, err
+	}
+	return (*chaintypes.Block)(res), nil
+}
+
+func (c *Client) BlockResultByHeight(ctx context.Context, height int64) (*chaintypes.BlockResult, error) {
+	req := &chainjson.BlockResultRequest{
+		Height: height,
+	}
+	res := &chainjson.BlockResultResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodBlockResult), req, res)
+	if err != nil {
+		return nil, err
+	}
+	return (*chaintypes.BlockResult)(res), nil
+}
+
+func (c *Client) BlockResultByHash(ctx context.Context, hash types.Hash) (*chaintypes.BlockResult, error) {
+	req := &chainjson.BlockResultRequest{
+		Hash: hash,
+	}
+	res := &chainjson.BlockResultResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodBlockResult), req, res)
+	if err != nil {
+		return nil, err
+	}
+	return (*chaintypes.BlockResult)(res), nil
+}
+
+func (c *Client) Tx(ctx context.Context, hash types.Hash) (*chaintypes.Tx, error) {
+	req := &chainjson.TxRequest{
+		Hash: hash,
+	}
+	res := &chainjson.TxResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodTx), req, res)
+	if err != nil {
+		return nil, err
+	}
+	return (*chaintypes.Tx)(res), err
+}
+
+func (c *Client) Genesis(ctx context.Context) (*chaintypes.Genesis, error) {
+	req := &chainjson.GenesisRequest{}
+	res := &chainjson.GenesisResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodGenesis), req, res)
+	if err != nil {
+		return nil, err
+	}
+	return (*chaintypes.Genesis)(res), err
+}
+
+func (c *Client) ConsensusParams(ctx context.Context) (*types.ConsensusParams, error) {
+	req := &chainjson.ConsensusParamsRequest{}
+	res := &chainjson.ConsensusParamsResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodConsensusParams), req, res)
+	if err != nil {
+		return nil, err
+	}
+	return (*types.ConsensusParams)(res), nil
+}
+
+func (c *Client) Validators(ctx context.Context) (int64, []*types.Validator, error) {
+	req := &chainjson.ValidatorsRequest{}
+	res := &chainjson.ValidatorsResponse{}
+	err := c.CallMethod(ctx, string(chainjson.MethodValidators), req, res)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return res.Height, res.Validators, nil
+}
+
+func (c *Client) UnconfirmedTxs(ctx context.Context) (total int, tx []chaintypes.NamedTx, err error) {
+	req := &chainjson.UnconfirmedTxsRequest{}
+	res := &chainjson.UnconfirmedTxsResponse{}
+	err = c.CallMethod(ctx, string(chainjson.MethodUnconfirmedTxs), req, res)
+	if err != nil {
+		return 0, nil, err
+	}
+
+	return res.Total, res.Txs, nil
+}
+
+// NewClient constructs a new chain Client.
+func NewClient(u *url.URL, opts ...rpcclient.RPCClientOpts) *Client {
+	userClient := userClient.NewClient(u, opts...)
+	return &Client{
+		Client: userClient,
+	}
+}
+
+var _ user.TxSvcClient = (*Client)(nil) // via embedded userClient.Client
+var _ chain.Client = (*Client)(nil)     // with extra methods

--- a/core/rpc/json/chain/commands.go
+++ b/core/rpc/json/chain/commands.go
@@ -23,6 +23,7 @@ type TxRequest struct {
 }
 
 type GenesisRequest struct{}
+type ConsensusParamsRequest struct{}
 type ValidatorsRequest struct {
 	Height int64 `json:"height"`
 }

--- a/core/rpc/json/chain/commands.go
+++ b/core/rpc/json/chain/commands.go
@@ -1,0 +1,31 @@
+package chain
+
+import (
+	"github.com/kwilteam/kwil-db/core/types"
+)
+
+type HealthRequest struct{}
+
+type BlockRequest struct {
+	Height int64 `json:"height"`
+	// Hash is the block hash. If both Height and Hash are provided, hash will be used
+	Hash types.Hash `json:"hash"`
+}
+
+type BlockResultRequest struct {
+	Height int64 `json:"height"`
+	// Hash is the block hash. If both Height and Hash are provided, hash will be used
+	Hash types.Hash `json:"hash"`
+}
+
+type TxRequest struct {
+	Hash types.Hash `json:"hash"`
+}
+
+type GenesisRequest struct{}
+type ValidatorsRequest struct {
+	Height int64 `json:"height"`
+}
+type UnconfirmedTxsRequest struct {
+	Limit int `json:"limit"`
+}

--- a/core/rpc/json/chain/methods.go
+++ b/core/rpc/json/chain/methods.go
@@ -5,12 +5,13 @@ import (
 )
 
 const (
-	MethodVersion        jsonrpc.Method = "chain.version"
-	MethodHealth         jsonrpc.Method = "chain.health"
-	MethodBlock          jsonrpc.Method = "chain.block"
-	MethodBlockResult    jsonrpc.Method = "chain.block_result"
-	MethodTx             jsonrpc.Method = "chain.tx"
-	MethodGenesis        jsonrpc.Method = "chain.genesis"
-	MethodValidators     jsonrpc.Method = "chain.validators"
-	MethodUnconfirmedTxs jsonrpc.Method = "chain.unconfirmed_txs"
+	MethodVersion         jsonrpc.Method = "chain.version"
+	MethodHealth          jsonrpc.Method = "chain.health"
+	MethodBlock           jsonrpc.Method = "chain.block"
+	MethodBlockResult     jsonrpc.Method = "chain.block_result"
+	MethodTx              jsonrpc.Method = "chain.tx"
+	MethodGenesis         jsonrpc.Method = "chain.genesis"
+	MethodConsensusParams jsonrpc.Method = "chain.consensus_params"
+	MethodValidators      jsonrpc.Method = "chain.validators"
+	MethodUnconfirmedTxs  jsonrpc.Method = "chain.unconfirmed_txs"
 )

--- a/core/rpc/json/chain/methods.go
+++ b/core/rpc/json/chain/methods.go
@@ -1,0 +1,16 @@
+package chain
+
+import (
+	jsonrpc "github.com/kwilteam/kwil-db/core/rpc/json"
+)
+
+const (
+	MethodVersion        jsonrpc.Method = "chain.version"
+	MethodHealth         jsonrpc.Method = "chain.health"
+	MethodBlock          jsonrpc.Method = "chain.block"
+	MethodBlockResult    jsonrpc.Method = "chain.block_result"
+	MethodTx             jsonrpc.Method = "chain.tx"
+	MethodGenesis        jsonrpc.Method = "chain.genesis"
+	MethodValidators     jsonrpc.Method = "chain.validators"
+	MethodUnconfirmedTxs jsonrpc.Method = "chain.unconfirmed_txs"
+)

--- a/core/rpc/json/chain/responses.go
+++ b/core/rpc/json/chain/responses.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 
 	"github.com/kwilteam/kwil-db/core/types"
+	chaintypes "github.com/kwilteam/kwil-db/core/types/chain"
 )
 
 // HealthResponse is the health check response.
@@ -13,66 +14,15 @@ type HealthResponse struct {
 	Healthy bool   `json:"healthy"`
 }
 
-type BlockHeader types.BlockHeader
-
-func (b BlockHeader) MarshalJSON() ([]byte, error) {
-	return json.Marshal(&struct {
-		Version     uint16     `json:"version"`
-		Height      int64      `json:"height"`
-		NumTxns     uint32     `json:"num_txns"`
-		PrevHash    types.Hash `json:"prev_hash"`
-		PrevAppHash types.Hash `json:"prev_app_hash"`
-		// Timestamp is the unix millisecond timestamp
-		Timestamp        int64      `json:"timestamp"`
-		MerkleRoot       types.Hash `json:"merkle_root"`
-		ValidatorSetHash types.Hash `json:"validator_set_hash"`
-	}{
-		Version:          b.Version,
-		Height:           b.Height,
-		NumTxns:          b.NumTxns,
-		PrevHash:         b.PrevHash,
-		PrevAppHash:      b.PrevAppHash,
-		Timestamp:        b.Timestamp.UnixMilli(),
-		MerkleRoot:       b.MerkleRoot,
-		ValidatorSetHash: b.ValidatorSetHash,
-	})
-}
-
 // BlockResponse is the block information
-type BlockResponse struct {
-	Header    *BlockHeader `json:"header"`
-	Txns      [][]byte     `json:"txns"`
-	Signature []byte       `json:"signature"`
-	Hash      types.Hash   `json:"hash"`
-	AppHash   types.Hash   `json:"app_hash"`
-}
+type BlockResponse chaintypes.Block
 
-type BlockResultResponse struct {
-	Height    int64            `json:"height"`
-	TxResults []types.TxResult `json:"tx_results"`
-}
+type BlockResultResponse chaintypes.BlockResult
+
+type TxResponse chaintypes.Tx
 
 // GenesisResponse is the same as kwil-db/config.GenesisConfig, with JSON tags.
-type GenesisResponse struct {
-	ChainID string `json:"chain_id"`
-	// Leader is the leader's public key.
-	Leader types.HexBytes `json:"leader"`
-	// Validators is the list of genesis validators (including the leader).
-	Validators []*types.Validator `json:"validators"`
-	// MaxBlockSize is the maximum size of a block in bytes.
-	MaxBlockSize int64 `json:"max_block_size"`
-	// JoinExpiry is the number of blocks after which the validators
-	// join request expires if not approved.
-	JoinExpiry int64 `json:"join_expiry"`
-	// VoteExpiry is the default number of blocks after which the validators
-	// vote expires if not approved.
-	VoteExpiry int64 `json:"vote_expiry"`
-	// DisabledGasCosts dictates whether gas costs are disabled.
-	DisabledGasCosts bool `json:"disabled_gas_costs"`
-	// MaxVotesPerTx is the maximum number of votes that can be included in a
-	// single transaction.
-	MaxVotesPerTx int64 `json:"max_votes_per_tx"`
-}
+type GenesisResponse chaintypes.Genesis
 
 type ConsensusParamsResponse types.ConsensusParams
 
@@ -110,12 +60,7 @@ type ValidatorsResponse struct {
 	Validators []*types.Validator `json:"validators"`
 }
 
-type NamedTx struct {
-	Hash types.Hash `json:"hash"`
-	Tx   []byte     `json:"tx"`
-}
-
 type UnconfirmedTxsResponse struct {
-	Total int       `json:"total"`
-	Txs   []NamedTx `json:"txs"`
+	Total int                  `json:"total"`
+	Txs   []chaintypes.NamedTx `json:"txs"`
 }

--- a/core/rpc/json/chain/responses.go
+++ b/core/rpc/json/chain/responses.go
@@ -2,6 +2,7 @@ package chain
 
 import (
 	"encoding/json"
+
 	"github.com/kwilteam/kwil-db/core/types"
 )
 
@@ -51,6 +52,7 @@ type BlockResultResponse struct {
 	TxResults []types.TxResult `json:"tx_results"`
 }
 
+// GenesisResponse is the same as kwil-db/config.GenesisConfig, with JSON tags.
 type GenesisResponse struct {
 	ChainID string `json:"chain_id"`
 	// Leader is the leader's public key.
@@ -71,6 +73,38 @@ type GenesisResponse struct {
 	// single transaction.
 	MaxVotesPerTx int64 `json:"max_votes_per_tx"`
 }
+
+type ConsensusParamsResponse types.ConsensusParams
+
+func (r ConsensusParamsResponse) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		// MaxBlockSize is the maximum size of a block in bytes.
+		MaxBlockSize int64 `json:"max_block_size"`
+		// JoinExpiry is the number of blocks after which the validators
+		// join request expires if not approved.
+		JoinExpiry int64 `json:"join_expiry"`
+		// VoteExpiry is the default number of blocks after which the validators
+		// vote expires if not approved.
+		VoteExpiry int64 `json:"vote_expiry"`
+		// DisabledGasCosts dictates whether gas costs are disabled.
+		DisabledGasCosts bool `json:"disabled_gas_costs"`
+
+		// MigrationStatus determines the status of the migration.
+		MigrationStatus string `json:"migration_status"`
+
+		// MaxVotesPerTx is the maximum number of votes that can be included in a
+		// single transaction.
+		MaxVotesPerTx int64 `json:"max_votes_per_tx"`
+	}{
+		MaxBlockSize:     r.MaxBlockSize,
+		JoinExpiry:       r.JoinExpiry,
+		VoteExpiry:       r.VoteExpiry,
+		DisabledGasCosts: r.DisabledGasCosts,
+		MigrationStatus:  string(r.MigrationStatus),
+		MaxVotesPerTx:    r.MaxVotesPerTx,
+	})
+}
+
 type ValidatorsResponse struct {
 	Height     int64              `json:"height"`
 	Validators []*types.Validator `json:"validators"`

--- a/core/rpc/json/chain/responses.go
+++ b/core/rpc/json/chain/responses.go
@@ -1,0 +1,87 @@
+package chain
+
+import (
+	"encoding/json"
+	"github.com/kwilteam/kwil-db/core/types"
+)
+
+// HealthResponse is the health check response.
+type HealthResponse struct {
+	ChainID string `json:"chain_id"`
+	Height  int64  `json:"height"`
+	Healthy bool   `json:"healthy"`
+}
+
+type BlockHeader types.BlockHeader
+
+func (b BlockHeader) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Version     uint16     `json:"version"`
+		Height      int64      `json:"height"`
+		NumTxns     uint32     `json:"num_txns"`
+		PrevHash    types.Hash `json:"prev_hash"`
+		PrevAppHash types.Hash `json:"prev_app_hash"`
+		// Timestamp is the unix millisecond timestamp
+		Timestamp        int64      `json:"timestamp"`
+		MerkleRoot       types.Hash `json:"merkle_root"`
+		ValidatorSetHash types.Hash `json:"validator_set_hash"`
+	}{
+		Version:          b.Version,
+		Height:           b.Height,
+		NumTxns:          b.NumTxns,
+		PrevHash:         b.PrevHash,
+		PrevAppHash:      b.PrevAppHash,
+		Timestamp:        b.Timestamp.UnixMilli(),
+		MerkleRoot:       b.MerkleRoot,
+		ValidatorSetHash: b.ValidatorSetHash,
+	})
+}
+
+// BlockResponse is the block information
+type BlockResponse struct {
+	Header    *BlockHeader `json:"header"`
+	Txns      [][]byte     `json:"txns"`
+	Signature []byte       `json:"signature"`
+	Hash      types.Hash   `json:"hash"`
+	AppHash   types.Hash   `json:"app_hash"`
+}
+
+type BlockResultResponse struct {
+	Height    int64            `json:"height"`
+	TxResults []types.TxResult `json:"tx_results"`
+}
+
+type GenesisResponse struct {
+	ChainID string `json:"chain_id"`
+	// Leader is the leader's public key.
+	Leader types.HexBytes `json:"leader"`
+	// Validators is the list of genesis validators (including the leader).
+	Validators []*types.Validator `json:"validators"`
+	// MaxBlockSize is the maximum size of a block in bytes.
+	MaxBlockSize int64 `json:"max_block_size"`
+	// JoinExpiry is the number of blocks after which the validators
+	// join request expires if not approved.
+	JoinExpiry int64 `json:"join_expiry"`
+	// VoteExpiry is the default number of blocks after which the validators
+	// vote expires if not approved.
+	VoteExpiry int64 `json:"vote_expiry"`
+	// DisabledGasCosts dictates whether gas costs are disabled.
+	DisabledGasCosts bool `json:"disabled_gas_costs"`
+	// MaxVotesPerTx is the maximum number of votes that can be included in a
+	// single transaction.
+	MaxVotesPerTx int64 `json:"max_votes_per_tx"`
+}
+type ValidatorsResponse struct {
+	Height     int64              `json:"height"`
+	Validators []*types.Validator `json:"validators"`
+}
+
+type NamedTx struct {
+	Hash types.Hash `json:"hash"`
+	Tx   []byte     `json:"tx"`
+}
+
+type UnconfirmedTxsResponse struct {
+	Total int       `json:"total"`
+	Txs   []NamedTx `json:"txs"`
+}

--- a/core/types/chain/types.go
+++ b/core/types/chain/types.go
@@ -3,6 +3,7 @@ package types
 
 import (
 	"encoding/json"
+
 	"github.com/kwilteam/kwil-db/core/types"
 )
 

--- a/core/types/chain/types.go
+++ b/core/types/chain/types.go
@@ -1,0 +1,12 @@
+// Package types contains the type used by the chain stat RPC client and servers.
+package types
+
+import "github.com/kwilteam/kwil-db/core/types"
+
+type ChainTx struct {
+	Hash     types.Hash      `json:"hash"`
+	Height   int64           `json:"height"`
+	Index    uint32          `json:"index"`
+	Tx       []byte          `json:"tx"`
+	TxResult *types.TxResult `json:"tx_result"`
+}

--- a/core/types/chain/types.go
+++ b/core/types/chain/types.go
@@ -1,12 +1,80 @@
-// Package types contains the type used by the chain stat RPC client and servers.
+// Package types contains the type used by the chain RPC client and server.
 package types
 
-import "github.com/kwilteam/kwil-db/core/types"
+import (
+	"encoding/json"
+	"github.com/kwilteam/kwil-db/core/types"
+)
 
-type ChainTx struct {
-	Hash     types.Hash      `json:"hash"`
-	Height   int64           `json:"height"`
-	Index    uint32          `json:"index"`
-	Tx       []byte          `json:"tx"`
-	TxResult *types.TxResult `json:"tx_result"`
+type Tx struct {
+	Hash     types.Hash         `json:"hash"`
+	Height   int64              `json:"height"`
+	Index    uint32             `json:"index"`
+	Tx       *types.Transaction `json:"tx"`
+	TxResult *types.TxResult    `json:"tx_result"`
+}
+
+type BlockHeader types.BlockHeader
+
+func (b BlockHeader) MarshalJSON() ([]byte, error) {
+	return json.Marshal(&struct {
+		Version     uint16     `json:"version"`
+		Height      int64      `json:"height"`
+		NumTxns     uint32     `json:"num_txns"`
+		PrevHash    types.Hash `json:"prev_hash"`
+		PrevAppHash types.Hash `json:"prev_app_hash"`
+		// Timestamp is the unix millisecond timestamp
+		Timestamp        int64      `json:"timestamp"`
+		MerkleRoot       types.Hash `json:"merkle_root"`
+		ValidatorSetHash types.Hash `json:"validator_set_hash"`
+	}{
+		Version:          b.Version,
+		Height:           b.Height,
+		NumTxns:          b.NumTxns,
+		PrevHash:         b.PrevHash,
+		PrevAppHash:      b.PrevAppHash,
+		Timestamp:        b.Timestamp.UnixMilli(),
+		MerkleRoot:       b.MerkleRoot,
+		ValidatorSetHash: b.ValidatorSetHash,
+	})
+}
+
+type Block struct {
+	Header    *BlockHeader `json:"header"`
+	Txns      [][]byte     `json:"txns"`
+	Signature []byte       `json:"signature"`
+	Hash      types.Hash   `json:"hash"`
+	AppHash   types.Hash   `json:"app_hash"`
+}
+
+type BlockResult struct {
+	Height    int64            `json:"height"`
+	Hash      types.Hash       `json:"hash"`
+	TxResults []types.TxResult `json:"tx_results"`
+}
+
+type Genesis struct {
+	ChainID string `json:"chain_id"`
+	// Leader is the leader's public key.
+	Leader types.HexBytes `json:"leader"`
+	// Validators is the list of genesis validators (including the leader).
+	Validators []*types.Validator `json:"validators"`
+	// MaxBlockSize is the maximum size of a block in bytes.
+	MaxBlockSize int64 `json:"max_block_size"`
+	// JoinExpiry is the number of blocks after which the validators
+	// join request expires if not approved.
+	JoinExpiry int64 `json:"join_expiry"`
+	// VoteExpiry is the default number of blocks after which the validators
+	// vote expires if not approved.
+	VoteExpiry int64 `json:"vote_expiry"`
+	// DisabledGasCosts dictates whether gas costs are disabled.
+	DisabledGasCosts bool `json:"disabled_gas_costs"`
+	// MaxVotesPerTx is the maximum number of votes that can be included in a
+	// single transaction.
+	MaxVotesPerTx int64 `json:"max_votes_per_tx"`
+}
+
+type NamedTx struct {
+	Hash types.Hash         `json:"hash"`
+	Tx   *types.Transaction `json:"tx"`
 }

--- a/node/block.go
+++ b/node/block.go
@@ -302,7 +302,7 @@ func (n *Node) getBlkHeight(ctx context.Context, height int64) (types.Hash, type
 
 // BlockByHeight returns the block by height. If height <= 0, the latest block
 // will be returned.
-func (n *Node) BlockByHeight(_ context.Context, height int64) (types.Hash, *ktypes.Block, types.Hash, error) {
+func (n *Node) BlockByHeight(height int64) (types.Hash, *ktypes.Block, types.Hash, error) {
 	if height <= 0 { // I think this is correct since block height starts from 1
 		height, _, _ = n.bki.Best()
 	}
@@ -310,11 +310,11 @@ func (n *Node) BlockByHeight(_ context.Context, height int64) (types.Hash, *ktyp
 }
 
 // BlockByHash returns the block by block hash.
-func (n *Node) BlockByHash(_ context.Context, hash types.Hash) (*ktypes.Block, types.Hash, error) {
+func (n *Node) BlockByHash(hash types.Hash) (*ktypes.Block, types.Hash, error) {
 	return n.bki.Get(hash)
 }
 
 // BlockResultByHash returns the block result by block hash.
-func (n *Node) BlockResultByHash(_ context.Context, hash types.Hash) ([]ktypes.TxResult, error) {
+func (n *Node) BlockResultByHash(hash types.Hash) ([]ktypes.TxResult, error) {
 	return n.bki.Results(hash)
 }

--- a/node/block.go
+++ b/node/block.go
@@ -299,3 +299,22 @@ func (n *Node) getBlkHeight(ctx context.Context, height int64) (types.Hash, type
 	}
 	return types.Hash{}, types.Hash{}, nil, ErrBlkNotFound
 }
+
+// BlockByHeight returns the block by height. If height <= 0, the latest block
+// will be returned.
+func (n *Node) BlockByHeight(_ context.Context, height int64) (types.Hash, *ktypes.Block, types.Hash, error) {
+	if height <= 0 { // I think this is correct since block height starts from 1
+		height, _, _ = n.bki.Best()
+	}
+	return n.bki.GetByHeight(height)
+}
+
+// BlockByHash returns the block by block hash.
+func (n *Node) BlockByHash(_ context.Context, hash types.Hash) (*ktypes.Block, types.Hash, error) {
+	return n.bki.Get(hash)
+}
+
+// BlockResultByHash returns the block result by block hash.
+func (n *Node) BlockResultByHash(_ context.Context, hash types.Hash) ([]ktypes.TxResult, error) {
+	return n.bki.Results(hash)
+}

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -48,6 +48,10 @@ func (ce *ConsensusEngine) CheckTx(ctx context.Context, tx *ktypes.Transaction) 
 	return ce.blockProcessor.CheckTx(ctx, tx, false)
 }
 
+func (ce *ConsensusEngine) ConsensusParams() *ktypes.ConsensusParams {
+	return ce.blockProcessor.ConsensusParams()
+}
+
 func (ce *ConsensusEngine) executeBlock(ctx context.Context, blkProp *blockProposal) error {
 	defer func() {
 		ce.stateInfo.mtx.Lock()

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	ktypes "github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/node/mempool"
 	"github.com/kwilteam/kwil-db/node/types"
 	"github.com/kwilteam/kwil-db/node/types/sql"
 )
@@ -22,7 +21,6 @@ type DB interface {
 type Mempool interface {
 	PeekN(maxSize int) []types.NamedTx
 	Remove(txid types.Hash)
-	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
 }
 
 // BlockStore includes both txns and blocks
@@ -35,7 +33,6 @@ type BlockStore interface {
 	GetByHeight(height int64) (types.Hash, *ktypes.Block, types.Hash, error)
 	StoreResults(hash types.Hash, results []ktypes.TxResult) error
 	// Results(hash types.Hash) ([]types.TxResult, error)
-
 }
 
 type BlockProcessor interface {
@@ -48,6 +45,7 @@ type BlockProcessor interface {
 	CheckTx(ctx context.Context, tx *ktypes.Transaction, recheck bool) error
 
 	GetValidators() []*ktypes.Validator
+	ConsensusParams() *ktypes.ConsensusParams
 
 	BlockExecutionStatus() ktypes.BlockExecutionStatus
 }

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -3,6 +3,8 @@ package consensus
 import (
 	"context"
 
+	"github.com/kwilteam/kwil-db/node/mempool"
+
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/types"
 	"github.com/kwilteam/kwil-db/node/types/sql"
@@ -21,6 +23,7 @@ type DB interface {
 type Mempool interface {
 	PeekN(maxSize int) []types.NamedTx
 	Remove(txid types.Hash)
+	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
 }
 
 // BlockStore includes both txns and blocks

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -30,6 +30,8 @@ type ConsensusEngine interface {
 		blkRequester consensus.BlkRequester, stateResetter consensus.ResetStateBroadcaster, discoveryBroadcaster consensus.DiscoveryReqBroadcaster) error
 
 	CheckTx(ctx context.Context, tx *ktypes.Transaction) error
+
+	ConsensusParams() *ktypes.ConsensusParams
 }
 
 type SnapshotStore interface {

--- a/node/node.go
+++ b/node/node.go
@@ -512,7 +512,7 @@ func (n *Node) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, _ /*sync
 }
 
 // ChainTx return tx info that is used in Chain rpc.
-func (n *Node) ChainTx(_ context.Context, hash types.Hash) (*chainTypes.ChainTx, error) {
+func (n *Node) ChainTx(hash types.Hash) (*chainTypes.ChainTx, error) {
 	raw, height, blkHash, blkIdx, err := n.bki.GetTx(hash)
 	if err != nil {
 		return nil, err
@@ -535,7 +535,7 @@ func (n *Node) ChainTx(_ context.Context, hash types.Hash) (*chainTypes.ChainTx,
 }
 
 // ChainUnconfirmedTx return unconfirmed tx info that is used in Chain rpc.
-func (n *Node) ChainUnconfirmedTx(_ context.Context, limit int) (int, []types.NamedTx) {
+func (n *Node) ChainUnconfirmedTx(limit int) (int, []types.NamedTx) {
 	total := n.mp.Size()
 	if limit <= 0 {
 		return total, nil
@@ -543,9 +543,13 @@ func (n *Node) ChainUnconfirmedTx(_ context.Context, limit int) (int, []types.Na
 	return n.mp.Size(), n.mp.PeekN(limit)
 }
 
-func (n *Node) BlockHeight(ctx context.Context) int64 {
+func (n *Node) BlockHeight() int64 {
 	height, _, _ := n.bki.Best()
 	return height
+}
+
+func (n *Node) ConsensusParams() *ktypes.ConsensusParams {
+	return n.ce.ConsensusParams()
 }
 
 var RequiredStreamProtocols = []protocol.ID{

--- a/node/node.go
+++ b/node/node.go
@@ -512,8 +512,8 @@ func (n *Node) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, _ /*sync
 }
 
 // ChainTx return tx info that is used in Chain rpc.
-func (n *Node) ChainTx(hash types.Hash) (*chainTypes.ChainTx, error) {
-	raw, height, blkHash, blkIdx, err := n.bki.GetTx(hash)
+func (n *Node) ChainTx(hash types.Hash) (*chainTypes.Tx, error) {
+	tx, height, blkHash, blkIdx, err := n.bki.GetTx(hash)
 	if err != nil {
 		return nil, err
 	}
@@ -525,11 +525,11 @@ func (n *Node) ChainTx(hash types.Hash) (*chainTypes.ChainTx, error) {
 		return nil, errors.New("invalid block index")
 	}
 	res := blkResults[blkIdx]
-	return &chainTypes.ChainTx{
+	return &chainTypes.Tx{
 		Hash:     hash,
 		Height:   height,
 		Index:    blkIdx,
-		Tx:       raw,
+		Tx:       tx,
 		TxResult: &res,
 	}, nil
 }

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -192,6 +192,10 @@ func (ce *dummyCE) CheckTx(ctx context.Context, tx *ktypes.Transaction) error {
 	return nil
 }
 
+func (ce *dummyCE) ConsensusParams() *ktypes.ConsensusParams {
+	return nil
+}
+
 func (ce *dummyCE) Start(ctx context.Context, proposerBroadcaster consensus.ProposalBroadcaster,
 	blkAnnouncer consensus.BlkAnnouncer, ackBroadcaster consensus.AckBroadcaster,
 	blkRequester consensus.BlkRequester, stateResetter consensus.ResetStateBroadcaster, discReqBroadcaster consensus.DiscoveryReqBroadcaster) error {

--- a/node/services/jsonrpc/chainsvc/service.go
+++ b/node/services/jsonrpc/chainsvc/service.go
@@ -247,21 +247,21 @@ func (svc *Service) Genesis(ctx context.Context, req *chainjson.GenesisRequest) 
 func (svc *Service) Validators(ctx context.Context, req *chainjson.ValidatorsRequest) (*chainjson.ValidatorsResponse, *jsonrpc.Error) {
 	panic("Plz inject voting dependency")
 	// should be able to get validator set at req.Height
-	vals := svc.voting.GetValidators()
-
-	pbValidators := make([]*ktypes.Validator, len(vals))
-	for i, vi := range vals {
-		pbValidators[i] = &ktypes.Validator{
-			Role:   vi.Role,
-			PubKey: vi.PubKey,
-			Power:  vi.Power,
-		}
-	}
-
-	return &chainjson.ValidatorsResponse{
-		Height:     svc.blockchain.BlockHeight(ctx),
-		Validators: nil,
-	}, nil
+	//vals := svc.voting.GetValidators()
+	//
+	//pbValidators := make([]*ktypes.Validator, len(vals))
+	//for i, vi := range vals {
+	//	pbValidators[i] = &ktypes.Validator{
+	//		Role:   vi.Role,
+	//		PubKey: vi.PubKey,
+	//		Power:  vi.Power,
+	//	}
+	//}
+	//
+	//return &chainjson.ValidatorsResponse{
+	//	Height:     svc.blockchain.BlockHeight(ctx),
+	//	Validators: nil,
+	//}, nil
 }
 
 // UnconfirmedTxs returns the unconfirmed txs. Default return 10 txs, max return 50 txs.

--- a/node/services/jsonrpc/chainsvc/service.go
+++ b/node/services/jsonrpc/chainsvc/service.go
@@ -1,0 +1,297 @@
+package chainsvc
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/kwilteam/kwil-db/config"
+	"github.com/kwilteam/kwil-db/core/log"
+	jsonrpc "github.com/kwilteam/kwil-db/core/rpc/json"
+	chainjson "github.com/kwilteam/kwil-db/core/rpc/json/chain"
+	userjson "github.com/kwilteam/kwil-db/core/rpc/json/user"
+	ktypes "github.com/kwilteam/kwil-db/core/types"
+	chaintypes "github.com/kwilteam/kwil-db/core/types/chain"
+	rpcserver "github.com/kwilteam/kwil-db/node/services/jsonrpc"
+	nodetypes "github.com/kwilteam/kwil-db/node/types"
+	"github.com/kwilteam/kwil-db/version"
+)
+
+const (
+	apiVerMajor = 0
+	apiVerMinor = 1 // should it be 2 ?
+	apiVerPatch = 0
+
+	serviceName = "chain"
+)
+
+// API version log
+//
+// apiVerMinor = 1 initial api
+
+var (
+	apiSemver = fmt.Sprintf("%d.%d.%d", apiVerMajor, apiVerMinor, apiVerPatch)
+)
+
+// Node specifies the methods required for chain service to interact with the blockchain.
+type Node interface {
+	// BlockByHeight returns block info at height. If height=0, the latest block will be returned.
+	BlockByHeight(ctx context.Context, height int64) (ktypes.Hash, *ktypes.Block, ktypes.Hash, error)
+	BlockByHash(ctx context.Context, hash ktypes.Hash) (*ktypes.Block, ktypes.Hash, error)
+	BlockResultByHash(ctx context.Context, hash ktypes.Hash) ([]ktypes.TxResult, error)
+	ChainTx(ctx context.Context, hash ktypes.Hash) (*chaintypes.ChainTx, error)
+	BlockHeight(ctx context.Context) int64
+	ChainUnconfirmedTx(ctx context.Context, limit int) (int, []nodetypes.NamedTx)
+}
+
+type Validators interface {
+	GetValidators() []*ktypes.Validator
+}
+
+type Service struct {
+	log        log.Logger
+	genesisCfg *config.GenesisConfig
+	voting     Validators
+	blockchain Node // node is the local node that can accept transactions.
+}
+
+func NewService(log log.Logger, blockchain Node, genesisCfg *config.GenesisConfig) *Service {
+	return &Service{
+		log:        log,
+		genesisCfg: genesisCfg,
+		//voting:     voting, // TODO
+		blockchain: blockchain,
+	}
+}
+
+func (svc *Service) Name() string {
+	return serviceName
+}
+
+func (svc *Service) Health(ctx context.Context) (detail json.RawMessage, happy bool) {
+	healthResp, jsonErr := svc.HealthMethod(ctx, &chainjson.HealthRequest{})
+	if jsonErr != nil { // unable to even perform the health check
+		// This is not for a JSON-RPC client.
+		svc.log.Error("health check failure", "error", jsonErr)
+		resp, _ := json.Marshal(struct {
+			Healthy bool `json:"healthy"`
+		}{}) // omit everything else since
+		return resp, false
+	}
+
+	resp, _ := json.Marshal(healthResp)
+
+	return resp, healthResp.Healthy
+}
+
+func (svc *Service) Methods() map[jsonrpc.Method]rpcserver.MethodDef {
+	return map[jsonrpc.Method]rpcserver.MethodDef{
+		chainjson.MethodVersion: rpcserver.MakeMethodDef(verHandler,
+			"retrieve the API version of the chain service",
+			"service info including semver and kwild version"),
+		chainjson.MethodHealth: rpcserver.MakeMethodDef(svc.HealthMethod,
+			"retrieve the health status of the chain service",
+			"health status of the service"),
+		chainjson.MethodBlock: rpcserver.MakeMethodDef(svc.Block,
+			"retrieve certain block info",
+			"block information at a certain height"),
+		chainjson.MethodBlockResult: rpcserver.MakeMethodDef(svc.BlockResult,
+			"retrieve certain block result info",
+			"block result information at a certain height"),
+		chainjson.MethodTx: rpcserver.MakeMethodDef(svc.Tx,
+			"retrieve certain transaction info",
+			"transaction information at a certain hash"),
+		chainjson.MethodGenesis: rpcserver.MakeMethodDef(svc.Genesis,
+			"retrieve the genesis info",
+			"genesis information"),
+		chainjson.MethodValidators: rpcserver.MakeMethodDef(svc.Validators,
+			"retrieve validator info at certain height",
+			"validator information at certain height"),
+		chainjson.MethodUnconfirmedTxs: rpcserver.MakeMethodDef(svc.UnconfirmedTxs,
+			"retrieve unconfirmed txs",
+			"unconfirmed txs"),
+	}
+}
+
+func (svc *Service) HealthMethod(ctx context.Context, _ *chainjson.HealthRequest) (*chainjson.HealthResponse, *jsonrpc.Error) {
+	return &chainjson.HealthResponse{
+		ChainID: svc.genesisCfg.ChainID,
+		Height:  svc.blockchain.BlockHeight(ctx),
+		Healthy: true,
+	}, nil
+}
+
+func verHandler(context.Context, *userjson.VersionRequest) (*userjson.VersionResponse, *jsonrpc.Error) {
+	return &userjson.VersionResponse{
+		Service:     serviceName,
+		Version:     apiSemver,
+		Major:       apiVerMajor,
+		Minor:       apiVerMinor,
+		Patch:       apiVerPatch,
+		KwilVersion: version.KwilVersion,
+	}, nil
+}
+
+// Block returns block information either by block height or block hash.
+// If both provided, block hash will be used.
+func (svc *Service) Block(ctx context.Context, req *chainjson.BlockRequest) (*chainjson.BlockResponse, *jsonrpc.Error) {
+	if req.Height < 0 {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "height cannot be negative", nil)
+	}
+
+	// prioritize req.Hash over req.Height
+	if !req.Hash.IsZero() {
+		block, appHash, err := svc.blockchain.BlockByHash(ctx, req.Hash)
+		if err != nil {
+			svc.log.Error("block by hash", "hash", req.Hash, "error", err)
+			return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get block", nil)
+		}
+
+		return &chainjson.BlockResponse{
+			Header:    (*chainjson.BlockHeader)(block.Header),
+			Txns:      block.Txns,
+			Signature: block.Signature,
+			Hash:      req.Hash,
+			AppHash:   appHash,
+		}, nil
+	}
+
+	blockHash, block, appHash, err := svc.blockchain.BlockByHeight(ctx, req.Height)
+	svc.log.Error("block by height", "height", req.Height, "hash", req.Hash, "error", err)
+	if err != nil {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get block", nil)
+	}
+
+	return &chainjson.BlockResponse{
+		Header:    (*chainjson.BlockHeader)(block.Header),
+		Txns:      block.Txns,
+		Signature: block.Signature,
+		Hash:      blockHash,
+		AppHash:   appHash,
+	}, nil
+}
+
+// BlockResult returns block result either by block height or bloch hash.
+// If both provided, block hash will be used.
+func (svc *Service) BlockResult(ctx context.Context, req *chainjson.BlockResultRequest) (*chainjson.BlockResultResponse, *jsonrpc.Error) {
+	if req.Height < 0 {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "height cannot be negative", nil)
+	}
+
+	if !req.Hash.IsZero() {
+		block, _, err := svc.blockchain.BlockByHash(ctx, req.Hash)
+		if err != nil {
+			svc.log.Error("block by hash", "hash", req.Hash, "error", err)
+			return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get block: "+err.Error(), nil)
+		}
+
+		txResults, err := svc.blockchain.BlockResultByHash(ctx, req.Hash)
+		if err != nil {
+			svc.log.Error("block result by hash", "hash", req.Hash, "error", err)
+			return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get block result: "+err.Error(), nil)
+		}
+
+		return &chainjson.BlockResultResponse{
+			Height:    block.Header.Height,
+			TxResults: txResults,
+		}, nil
+	}
+
+	blockHash, block, _, err := svc.blockchain.BlockByHeight(ctx, req.Height)
+	svc.log.Error("block by height", "height", req.Height, "hash", req.Hash, "error", err)
+	if err != nil {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get block", nil)
+	}
+
+	txResults, err := svc.blockchain.BlockResultByHash(ctx, blockHash)
+	if err != nil {
+		svc.log.Error("block result by hash", "hash", req.Hash, "error", err)
+		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get block result: "+err.Error(), nil)
+	}
+
+	return &chainjson.BlockResultResponse{
+		Height:    block.Header.Height,
+		TxResults: txResults,
+	}, nil
+}
+
+// Tx returns a transaction by hash.
+func (svc *Service) Tx(ctx context.Context, req *chainjson.TxRequest) (*chaintypes.ChainTx, *jsonrpc.Error) {
+	if req.Hash.IsZero() {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "hash is required", nil)
+	}
+
+	tx, err := svc.blockchain.ChainTx(ctx, req.Hash)
+	if err != nil {
+		svc.log.Error("tx by hash", "hash", req.Hash, "error", err)
+		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get tx: "+err.Error(), nil)
+	}
+
+	return tx, nil
+}
+
+func (svc *Service) Genesis(ctx context.Context, req *chainjson.GenesisRequest) (*chainjson.GenesisResponse, *jsonrpc.Error) {
+	return &chainjson.GenesisResponse{
+		ChainID:          svc.genesisCfg.ChainID,
+		Leader:           svc.genesisCfg.Leader,
+		Validators:       svc.genesisCfg.Validators,
+		MaxBlockSize:     svc.genesisCfg.MaxBlockSize,
+		JoinExpiry:       svc.genesisCfg.JoinExpiry,
+		VoteExpiry:       svc.genesisCfg.VoteExpiry,
+		DisabledGasCosts: svc.genesisCfg.DisabledGasCosts,
+		MaxVotesPerTx:    svc.genesisCfg.MaxVotesPerTx,
+	}, nil
+}
+
+// Validators returns validator set at certain height. Default to latest height.
+func (svc *Service) Validators(ctx context.Context, req *chainjson.ValidatorsRequest) (*chainjson.ValidatorsResponse, *jsonrpc.Error) {
+	panic("Plz inject voting dependency")
+	// should be able to get validator set at req.Height
+	vals := svc.voting.GetValidators()
+
+	pbValidators := make([]*ktypes.Validator, len(vals))
+	for i, vi := range vals {
+		pbValidators[i] = &ktypes.Validator{
+			Role:   vi.Role,
+			PubKey: vi.PubKey,
+			Power:  vi.Power,
+		}
+	}
+
+	return &chainjson.ValidatorsResponse{
+		Height:     svc.blockchain.BlockHeight(ctx),
+		Validators: nil,
+	}, nil
+}
+
+// UnconfirmedTxs returns the unconfirmed txs. Default return 10 txs, max return 50 txs.
+func (svc *Service) UnconfirmedTxs(ctx context.Context, req *chainjson.UnconfirmedTxsRequest) (*chainjson.UnconfirmedTxsResponse, *jsonrpc.Error) {
+	if req.Limit < 0 {
+		return nil, jsonrpc.NewError(jsonrpc.ErrorInvalidParams, "invalid limit", nil)
+	}
+	if req.Limit > 50 {
+		req.Limit = 50
+	}
+	if req.Limit == 0 {
+		req.Limit = 10
+	}
+	total, txs := svc.blockchain.ChainUnconfirmedTx(ctx, req.Limit)
+	return &chainjson.UnconfirmedTxsResponse{
+		Total: total,
+		Txs:   convertNamedTxs(txs),
+	}, nil
+}
+
+// The admin Service must be usable as a Svc registered with a JSON-RPC Server.
+var _ rpcserver.Svc = (*Service)(nil)
+
+func convertNamedTxs(txs []nodetypes.NamedTx) []chainjson.NamedTx {
+	res := make([]chainjson.NamedTx, len(txs))
+	for i, tx := range txs {
+		res[i] = chainjson.NamedTx{
+			Hash: tx.Hash,
+			Tx:   tx.Tx,
+		}
+	}
+	return res
+}

--- a/node/services/jsonrpc/chainsvc/spec.go
+++ b/node/services/jsonrpc/chainsvc/spec.go
@@ -1,0 +1,17 @@
+package chainsvc
+
+import (
+	"github.com/kwilteam/kwil-db/node/services/jsonrpc/openrpc"
+)
+
+var (
+	SpecInfo = openrpc.Info{
+		Title:       "Kwil DB Chain service",
+		Description: `The JSON-RPC chain service for Kwil DB.`,
+		License: &openrpc.License{ // the spec file's license
+			Name: "CC0-1.0",
+			URL:  "https://creativecommons.org/publicdomain/zero/1.0/legalcode",
+		},
+		Version: "0.1.0",
+	}
+)

--- a/node/services/jsonrpc/funcsvc/service.go
+++ b/node/services/jsonrpc/funcsvc/service.go
@@ -68,14 +68,6 @@ func (svc *Service) Methods() map[jsonrpc.Method]rpcserver.MethodDef {
 	}
 }
 
-func (svc *Service) Handlers() map[jsonrpc.Method]rpcserver.MethodHandler {
-	handlers := make(map[jsonrpc.Method]rpcserver.MethodHandler)
-	for method, def := range svc.Methods() {
-		handlers[method] = def.Handler
-	}
-	return handlers
-}
-
 // VerifySignature checks the signature with the given public key and message.
 // This only verifies the signature against known kwil-db singing schema, which
 // is determined by the signature's type.


### PR DESCRIPTION
This resolves #1121

All APIs listed in the issue are implemented under `chain` rpc namespace.

These APIs are not implemented:
- `/num_unconfirmed_txs`,  `chain.unconfirmed_txs` returned the total txs
- `/tx_search`, it's more useful for tx subscription, we don't have the needs yet
- `/block_search`, it's more useful for block subscription
- `/check_tx`
- `/commit`, I don't think we have this kind of info
