### PR TITLE
Rollback support to preemptively cancel and rollback current block ex…

### DIFF
--- a/core/types/messages.go
+++ b/core/types/messages.go
@@ -1,5 +1,7 @@
 package types
 
+import "time"
+
 // This file contains the messages exchanged between the consensus engine and the block processor.
 
 type BlockExecRequest struct {
@@ -39,4 +41,12 @@ type ConsensusParams struct {
 	// MaxVotesPerTx is the maximum number of votes that can be included in a
 	// single transaction.
 	MaxVotesPerTx int64
+}
+
+type BlockExecutionStatus struct {
+	StartTime time.Time
+	EndTime   time.Time
+	Height    int64
+	TxIDs     []Hash
+	TxStatus  map[string]bool
 }

--- a/node/accounts/accounts.go
+++ b/node/accounts/accounts.go
@@ -303,3 +303,10 @@ func (a *Accounts) updateAccount(ctx context.Context, tx sql.Executor, account [
 	}
 	return nil
 }
+
+func (a *Accounts) Rollback() {
+	a.mtx.Lock()
+	defer a.mtx.Unlock()
+
+	a.updates = make(map[string]*types.Account)
+}

--- a/node/block_processor/interfaces.go
+++ b/node/block_processor/interfaces.go
@@ -36,6 +36,7 @@ type TxApp interface {
 	Execute(ctx *common.TxContext, db sql.DB, tx *ktypes.Transaction) *txapp.TxResponse
 	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (finalValidators []*ktypes.Validator, err error)
 	Commit() error
+	Rollback()
 	GenesisInit(ctx context.Context, db sql.DB, validators []*ktypes.Validator, genesisAccounts []*ktypes.Account, initialHeight int64, chain *common.ChainContext) error
 	ApplyMempool(ctx *common.TxContext, db sql.DB, tx *types.Transaction) error
 

--- a/node/block_processor/status.go
+++ b/node/block_processor/status.go
@@ -1,0 +1,81 @@
+package blockprocessor
+
+import (
+	"slices"
+	"time"
+
+	ktypes "github.com/kwilteam/kwil-db/core/types"
+)
+
+type blockExecStatus struct {
+	startTime, endTime time.Time
+	height             int64
+	txIDs              []ktypes.Hash
+	txStatus           map[string]bool
+}
+
+// Used by the rpc server to get the execution status of the block being processed.
+// end_time is not set if the block is still being processed.
+func (bp *BlockProcessor) BlockExecutionStatus() ktypes.BlockExecutionStatus {
+	bp.statusMu.RLock()
+	defer bp.statusMu.RUnlock()
+
+	if bp.status == nil {
+		return ktypes.BlockExecutionStatus{}
+	}
+
+	status := &ktypes.BlockExecutionStatus{
+		StartTime: bp.status.startTime,
+		EndTime:   bp.status.endTime,
+		Height:    bp.status.height,
+		TxIDs:     slices.Clone(bp.status.txIDs),
+		TxStatus:  make(map[string]bool),
+	}
+
+	for k, v := range bp.status.txStatus {
+		status.TxStatus[k] = v
+	}
+
+	return *status
+}
+
+func (bp *BlockProcessor) initBlockExecutionStatus(blk *ktypes.Block) {
+	bp.statusMu.Lock()
+	defer bp.statusMu.Unlock()
+
+	status := &blockExecStatus{
+		startTime: time.Now(),
+		height:    blk.Header.Height,
+		txStatus:  make(map[string]bool),
+		txIDs:     make([]ktypes.Hash, len(blk.Txns)),
+	}
+
+	for i, tx := range blk.Txns {
+		txID := ktypes.HashBytes(tx)
+		status.txIDs[i] = txID
+		status.txStatus[txID.String()] = false // not needed, just for clarity
+	}
+
+	bp.status = status
+}
+
+func (bp *BlockProcessor) clearBlockExecutionStatus() {
+	bp.statusMu.Lock()
+	defer bp.statusMu.Unlock()
+
+	bp.status = nil
+}
+
+func (bp *BlockProcessor) updateBlockExecutionStatus(txID ktypes.Hash) {
+	bp.statusMu.Lock()
+	defer bp.statusMu.Unlock()
+
+	bp.status.txStatus[txID.String()] = true
+}
+
+func (bp *BlockProcessor) recordBlockExecEndTime() {
+	bp.statusMu.Lock()
+	defer bp.statusMu.Unlock()
+
+	bp.status.endTime = time.Now()
+}

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -779,6 +779,9 @@ func (d *dummyTxApp) Price(ctx context.Context, dbTx sql.DB, tx *ktypes.Transact
 func (d *dummyTxApp) Commit() error {
 	return nil
 }
+
+func (d *dummyTxApp) Rollback() {}
+
 func (d *dummyTxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*ktypes.Validator, genesisAccounts []*ktypes.Account, initialHeight int64, chain *common.ChainContext) error {
 	return nil
 }

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -275,7 +275,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp2.blk)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -553,8 +553,10 @@ func TestValidatorStateMachine(t *testing.T) {
 			val := New(ceConfigs[1])
 			blkProp1, err = leader.createBlockProposal()
 			assert.NoError(t, err)
+			time.Sleep(300 * time.Millisecond) // just to ensure that the block hashes are different due to start time
 			blkProp2, err = leader.createBlockProposal()
 			assert.NoError(t, err)
+			t.Logf("blkProp1: %s, blkProp2: %s", blkProp1.blkHash.String(), blkProp2.blkHash.String())
 
 			ctx, cancel := context.WithCancel(context.Background())
 			var wg sync.WaitGroup

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	ktypes "github.com/kwilteam/kwil-db/core/types"
+	"github.com/kwilteam/kwil-db/node/mempool"
 	"github.com/kwilteam/kwil-db/node/types"
 	"github.com/kwilteam/kwil-db/node/types/sql"
 )
@@ -21,6 +22,7 @@ type DB interface {
 type Mempool interface {
 	PeekN(maxSize int) []types.NamedTx
 	Remove(txid types.Hash)
+	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
 }
 
 // BlockStore includes both txns and blocks

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -35,6 +35,7 @@ type BlockStore interface {
 	GetByHeight(height int64) (types.Hash, *ktypes.Block, types.Hash, error)
 	StoreResults(hash types.Hash, results []ktypes.TxResult) error
 	// Results(hash types.Hash) ([]types.TxResult, error)
+
 }
 
 type BlockProcessor interface {
@@ -47,4 +48,6 @@ type BlockProcessor interface {
 	CheckTx(ctx context.Context, tx *ktypes.Transaction, recheck bool) error
 
 	GetValidators() []*ktypes.Validator
+
+	BlockExecutionStatus() ktypes.BlockExecutionStatus
 }

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -365,6 +365,8 @@ func (d *dummyTxApp) Commit() error {
 	return nil
 }
 
+func (d *dummyTxApp) Rollback() {}
+
 func (d *dummyTxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*ktypes.Validator, genesisAccounts []*ktypes.Account, initialHeight int64, chain *common.ChainContext) error {
 	return nil
 }

--- a/node/txapp/interfaces.go
+++ b/node/txapp/interfaces.go
@@ -17,6 +17,7 @@ type Accounts interface {
 	GetAccount(ctx context.Context, tx sql.Executor, acctID []byte) (*types.Account, error)
 	ApplySpend(ctx context.Context, tx sql.Executor, acctID []byte, amount *big.Int, nonce int64) error
 	Commit() error
+	Rollback()
 }
 
 type Validators interface {
@@ -24,6 +25,7 @@ type Validators interface {
 	GetValidatorPower(ctx context.Context, tx sql.Executor, pubKey []byte) (int64, error)
 	GetValidators() []*types.Validator
 	Commit() error
+	Rollback()
 }
 
 // Rebroadcaster is a service that marks events for rebroadcasting.

--- a/node/txapp/routes_test.go
+++ b/node/txapp/routes_test.go
@@ -327,6 +327,8 @@ func (a *mockAccount) Commit() error {
 	return nil
 }
 
+func (a *mockAccount) Rollback() {}
+
 type mockValidator struct {
 	getVoterFn getVoterPowerFunc
 }
@@ -346,6 +348,8 @@ func (v *mockValidator) SetValidatorPower(_ context.Context, _ sql.Executor, pub
 func (v *mockValidator) Commit() error {
 	return nil
 }
+
+func (v *mockValidator) Rollback() {}
 
 func getSigner(hexPrivKey string) auth.Signer {
 	bts, err := hex.DecodeString(hexPrivKey)

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -169,6 +169,13 @@ func (r *TxApp) Commit() error {
 	return nil
 }
 
+func (r *TxApp) Rollback() {
+	r.Accounts.Rollback()
+	r.Validators.Rollback()
+
+	r.mempool.reset() // will issue recheck before next block
+}
+
 // processVotes confirms resolutions that have been approved by the network,
 // expires resolutions that have expired, and properly credits proposers and voters.
 func (r *TxApp) processVotes(ctx context.Context, db sql.DB, block *common.BlockContext) error {

--- a/node/voting/voting.go
+++ b/node/voting/voting.go
@@ -672,3 +672,10 @@ func (v *VoteStore) ValidatorUpdates() map[string]*types.Validator {
 
 	return v.valUpdates
 }
+
+func (v *VoteStore) Rollback() {
+	v.mtx.Lock()
+	defer v.mtx.Unlock()
+
+	v.valUpdates = make(map[string]*types.Validator)
+}


### PR DESCRIPTION
…ecution
yet to add `kwil-admin` command to issue cancellation request and block execution status request. But rest is good.  

Added support for leader to manually trigger block cancellation and also provide a list of long running transactions to be purged from the mempool and re-propose a block for the same height. 
Leader upon receiving this cancellation request will broadcast the resetState messages to all the validators, who upon receiving the resetMsg will stop the block execution and rollback the state. 

If leader has already executed the transactions by the time we receive the cancellation request, should we still reject the current block and propose a new block or should it just ignore the request? Right now I am ignoring, but can be changed.