### PR TITLE
structured tx in block

### DIFF
--- a/app/shared/display/message.go
+++ b/app/shared/display/message.go
@@ -106,16 +106,14 @@ func (r *RespTxQuery) MarshalJSON() ([]byte, error) {
 	}
 	// Always try to serialize to verify hash, but only show raw if requested.
 	if r.Msg.Tx != nil {
-		raw, err := r.Msg.Tx.MarshalBinary()
-		if err != nil {
-			out.Warn = "ERROR encoding transaction: " + err.Error()
-		} else if r.WithRaw {
+		raw := r.Msg.Tx.Bytes()
+		if r.WithRaw {
 			out.Raw = hex.EncodeToString(raw)
-			hash := types.HashBytes(raw)
-			if hash != r.Msg.Hash {
-				out.Warn = fmt.Sprintf("HASH MISMATCH: requested %s; received %s",
-					r.Msg.Hash, hash)
-			}
+		}
+		hash := types.HashBytes(raw)
+		if hash != r.Msg.Hash {
+			out.Warn = fmt.Sprintf("HASH MISMATCH: requested %s; received %s",
+				r.Msg.Hash, hash)
 		}
 	}
 	return json.Marshal(out)
@@ -147,18 +145,15 @@ Log: %s`,
 		return []byte(msg), nil
 	}
 
-	raw, err := r.Msg.Tx.MarshalBinary()
-	if err != nil {
-		msg += "\nERROR encoding transaction: " + err.Error()
-	} else {
-		if r.WithRaw {
-			msg += "\nRaw: " + hex.EncodeToString(raw)
-		}
-		hash := types.HashBytes(raw)
-		if hash != r.Msg.Hash {
-			msg += fmt.Sprintf("\nWARNING! HASH MISMATCH:\n\tRequested %s\n\tReceived  %s",
-				r.Msg.Hash, hash)
-		}
+	raw := r.Msg.Tx.Bytes()
+
+	if r.WithRaw {
+		msg += "\nRaw: " + hex.EncodeToString(raw)
+	}
+	hash := types.HashBytes(raw)
+	if hash != r.Msg.Hash {
+		msg += fmt.Sprintf("\nWARNING! HASH MISMATCH:\n\tRequested %s\n\tReceived  %s",
+			r.Msg.Hash, hash)
 	}
 
 	return []byte(msg), nil

--- a/app/shared/display/message_test.go
+++ b/app/shared/display/message_test.go
@@ -172,7 +172,8 @@ func Example_respTxQuery_json() {
 	//       "gas": 10,
 	//       "log": "This is log",
 	//       "events": null
-	//     }
+	//     },
+	//     "warning": "HASH MISMATCH: requested 0102030400000000000000000000000000000000000000000000000000000000; received a9e1f559c5ec1246078f5b9f362ee59ee4113946305d41448f917cdd96a0c883"
 	//   },
 	//   "error": ""
 	// }
@@ -207,8 +208,8 @@ func Example_respTxQuery_WithRaw_json() {
 	//       "log": "This is log",
 	//       "events": null
 	//     },
-	//     "raw": "5500000041000000cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e2534758000c000000736563703235366b315f6570220000005468697320697320612074657374207472616e73616374696f6e20666f7220636c695d0000000001f859b8397866363137616631636137373465626264366432336538666531326335366434316432356132326438316538386636376336633665653064348b6372656174655f75736572d1d0cfc9847465787480c28080c483666f6f070000006578656375746501030000003130300a00000000000000040000006173646606000000636f6e63617400000000",
-	//     "warning": "HASH MISMATCH: requested 0102030400000000000000000000000000000000000000000000000000000000; received ab8465bfd9a09828c348ea32801927598c1632ad37d248d7e945279f6d1b6480"
+	//     "raw": "00005500000041000000cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e2534758000c000000736563703235366b315f6570aa000000220000005468697320697320612074657374207472616e73616374696f6e20666f7220636c695d0000000001f859b8397866363137616631636137373465626264366432336538666531326335366434316432356132326438316538386636376336633665653064348b6372656174655f75736572d1d0cfc9847465787480c28080c483666f6f070000006578656375746501030000003130300a00000000000000040000006173646606000000636f6e63617400000000",
+	//     "warning": "HASH MISMATCH: requested 0102030400000000000000000000000000000000000000000000000000000000; received a9e1f559c5ec1246078f5b9f362ee59ee4113946305d41448f917cdd96a0c883"
 	//   },
 	//   "error": ""
 	// }
@@ -222,7 +223,7 @@ func Test_TxHashAndExecResponse(t *testing.T) {
 		Hash:      RespTxHash(hash),
 		QueryResp: &RespTxQuery{Msg: qr},
 	}
-	expectJSON := `{"tx_hash":"0102030405000000000000000000000000000000000000000000000000000000","exec_result":{"hash":"0102030405000000000000000000000000000000000000000000000000000000","height":10,"tx":{"signature":{"sig":"yz/tf2/zblkFTASoMbIV5RQFJ1PuNT5v4x1LTvc2rNYVUSfbVV0wBroU/LTHm7rVbI5juBqYljGbsFOp4lNHWAA=","type":"secp256k1_ep"},"body":{"desc":"This is a test transaction for cli","payload":"AAH4Wbg5eGY2MTdhZjFjYTc3NGViYmQ2ZDIzZThmZTEyYzU2ZDQxZDI1YTIyZDgxZTg4ZjY3YzZjNmVlMGQ0i2NyZWF0ZV91c2Vy0dDPyYR0ZXh0gMKAgMSDZm9v","type":"execute","fee":"100","nonce":10,"chain_id":"asdf"},"serialization":"concat","sender":""},"result":{"code":0,"gas":10,"log":"This is log","events":null}}}`
+	expectJSON := `{"tx_hash":"0102030405000000000000000000000000000000000000000000000000000000","exec_result":{"hash":"0102030405000000000000000000000000000000000000000000000000000000","height":10,"tx":{"signature":{"sig":"yz/tf2/zblkFTASoMbIV5RQFJ1PuNT5v4x1LTvc2rNYVUSfbVV0wBroU/LTHm7rVbI5juBqYljGbsFOp4lNHWAA=","type":"secp256k1_ep"},"body":{"desc":"This is a test transaction for cli","payload":"AAH4Wbg5eGY2MTdhZjFjYTc3NGViYmQ2ZDIzZThmZTEyYzU2ZDQxZDI1YTIyZDgxZTg4ZjY3YzZjNmVlMGQ0i2NyZWF0ZV91c2Vy0dDPyYR0ZXh0gMKAgMSDZm9v","type":"execute","fee":"100","nonce":10,"chain_id":"asdf"},"serialization":"concat","sender":""},"result":{"code":0,"gas":10,"log":"This is log","events":null},"warning":"HASH MISMATCH: requested 0102030405000000000000000000000000000000000000000000000000000000; received a9e1f559c5ec1246078f5b9f362ee59ee4113946305d41448f917cdd96a0c883"}}`
 	expectText := "TxHash: 0102030405000000000000000000000000000000000000000000000000000000\nStatus: success\nHeight: 10\nLog: This is log"
 
 	outText, err := resp.MarshalText()
@@ -287,7 +288,7 @@ func TestRespTxQuery_MarshalText(t *testing.T) {
 			name: "pending status",
 			input: &RespTxQuery{
 				Msg: &types.TxQueryResponse{
-					Hash:   mustUnmarshalHash("ff42fabfe6e73e0c566cb2462cc0bf69de0e050c7a90fa9d5a708ace51243589"),
+					Hash:   mustUnmarshalHash("8d741508a6849f9d11c8f478584b5067a6bcfc1114300feff53454b0e064c0a0"),
 					Height: -1, // -1 height indicates pending
 					Tx: &types.Transaction{
 						Body: &types.TransactionBody{
@@ -305,7 +306,7 @@ func TestRespTxQuery_MarshalText(t *testing.T) {
 					},
 				},
 			},
-			expected: "Transaction ID: ff42fabfe6e73e0c566cb2462cc0bf69de0e050c7a90fa9d5a708ace51243589\nStatus: pending\nHeight: -1\nLog: transaction pending",
+			expected: "Transaction ID: 8d741508a6849f9d11c8f478584b5067a6bcfc1114300feff53454b0e064c0a0\nStatus: pending\nHeight: -1\nLog: transaction pending",
 		},
 	}
 

--- a/core/types/chain/types.go
+++ b/core/types/chain/types.go
@@ -41,11 +41,11 @@ func (b BlockHeader) MarshalJSON() ([]byte, error) {
 }
 
 type Block struct {
-	Header    *BlockHeader `json:"header"`
-	Txns      [][]byte     `json:"txns"`
-	Signature []byte       `json:"signature"`
-	Hash      types.Hash   `json:"hash"`
-	AppHash   types.Hash   `json:"app_hash"`
+	Header    *BlockHeader         `json:"header"`
+	Txns      []*types.Transaction `json:"txns"`
+	Signature []byte               `json:"signature"`
+	Hash      types.Hash           `json:"hash"`
+	AppHash   types.Hash           `json:"app_hash"`
 }
 
 type BlockResult struct {

--- a/core/types/messages.go
+++ b/core/types/messages.go
@@ -48,5 +48,5 @@ type BlockExecutionStatus struct {
 	EndTime   time.Time
 	Height    int64
 	TxIDs     []Hash
-	TxStatus  map[string]bool
+	TxStatus  map[Hash]bool
 }

--- a/core/types/transaction_test.go
+++ b/core/types/transaction_test.go
@@ -319,15 +319,13 @@ func TestTransactionMarshalUnmarshal(t *testing.T) {
 	require.NoError(t, err)
 
 	testcases := []struct {
-		name        string
-		signer      auth.Signer
-		expectError bool
-		fn          func(t *testing.T) *Transaction
+		name   string
+		signer auth.Signer
+		fn     func(t *testing.T) *Transaction
 	}{
 		{
-			name:        "valid transaction",
-			signer:      secp256k1Signer(t),
-			expectError: false,
+			name:   "valid transaction",
+			signer: secp256k1Signer(t),
 			fn: func(t *testing.T) *Transaction {
 				// sign tx
 				tx := &Transaction{
@@ -368,7 +366,6 @@ func TestTransactionMarshalUnmarshal(t *testing.T) {
 
 				return tx
 			},
-			expectError: false,
 		},
 		{
 			name:   "empty signature type",
@@ -392,7 +389,6 @@ func TestTransactionMarshalUnmarshal(t *testing.T) {
 
 				return tx
 			},
-			expectError: false,
 		},
 		{
 			name: "empty signature data",
@@ -415,10 +411,9 @@ func TestTransactionMarshalUnmarshal(t *testing.T) {
 
 				return tx
 			},
-			expectError: false,
 		},
 		{
-			name: "empty body",
+			name: "empty body (allowed now)",
 			fn: func(t *testing.T) *Transaction {
 				return &Transaction{
 					Body: nil,
@@ -430,7 +425,6 @@ func TestTransactionMarshalUnmarshal(t *testing.T) {
 					Serialization: DefaultSignedMsgSerType,
 				}
 			},
-			expectError: true,
 		},
 		{
 			name: "empty sender",
@@ -480,18 +474,13 @@ func TestTransactionMarshalUnmarshal(t *testing.T) {
 			tx := tt.fn(t)
 
 			data, err := tx.MarshalBinary()
-			if tt.expectError {
-				require.Error(t, err)
-				return
-			} else {
-				require.NoError(t, err)
-			}
+			require.NoError(t, err)
 
 			newTx := &Transaction{}
 			err = newTx.UnmarshalBinary(data)
 			require.NoError(t, err)
 
-			require.Equal(t, tx, newTx)
+			require.EqualExportedValues(t, tx, newTx)
 
 			newData, err := newTx.MarshalBinary()
 			require.NoError(t, err)

--- a/node/block.go
+++ b/node/block.go
@@ -25,7 +25,7 @@ func (n *Node) blkGetStreamHandler(s network.Stream) {
 
 	var req blockHashReq
 	if _, err := req.ReadFrom(s); err != nil {
-		n.log.Warn("Bad get block (hash) request", "error", err) // Debug when we ship
+		n.log.Debug("Bad get block (hash) request", "error", err)
 		return
 	}
 	n.log.Debug("Peer requested block", "hash", req.Hash)

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 
 	ktypes "github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/node/types"
 )
 
 // TODO: should include consensus params hash
@@ -116,7 +115,7 @@ func (ce *ConsensusEngine) commit(ctx context.Context) error {
 
 	// remove transactions from the mempool
 	for _, txn := range blkProp.blk.Txns {
-		txHash := types.HashBytes(txn) // TODO: can this be saved instead of recalculating?
+		txHash := txn.Hash()
 		ce.mempool.Remove(txHash)
 	}
 

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -43,7 +43,7 @@ type BlockProcessor interface {
 	InitChain(ctx context.Context) (int64, []byte, error)
 	SetBroadcastTxFn(fn blockprocessor.BroadcastTxFn)
 
-	PrepareProposal(ctx context.Context, txs [][]byte) (finalTxs [][]byte, invalidTxs [][]byte, err error)
+	PrepareProposal(ctx context.Context, txs []*ktypes.Transaction) (finalTxs []*ktypes.Transaction, invalidTxs []*ktypes.Transaction, err error)
 	ExecuteBlock(ctx context.Context, req *ktypes.BlockExecRequest) (*ktypes.BlockExecResult, error)
 	Commit(ctx context.Context, req *ktypes.CommitRequest) error
 	Rollback(ctx context.Context, height int64, appHash ktypes.Hash) error

--- a/node/node.go
+++ b/node/node.go
@@ -635,7 +635,7 @@ func (n *Node) TxQuery(ctx context.Context, hash types.Hash, prove bool) (*ktype
 }
 
 func (n *Node) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, _ /*sync TODO*/ uint8) (*ktypes.ResultBroadcastTx, error) {
-	rawTx, _ := tx.MarshalBinary()
+	rawTx := tx.Bytes()
 	txHash := types.HashBytes(rawTx)
 
 	if err := n.ce.CheckTx(ctx, tx); err != nil {

--- a/node/nogossip.go
+++ b/node/nogossip.go
@@ -227,11 +227,7 @@ func (n *Node) startTxAnns(ctx context.Context, reannouncePeriod time.Duration) 
 				n.log.Infof("re-announcing %d unconfirmed txns", len(txns))
 
 				for _, nt := range txns {
-					rawTx, err := nt.Tx.MarshalBinary()
-					if err != nil {
-						n.log.Errorf("Failed to marshal transaction %v: %v", nt.Hash, err)
-						continue
-					}
+					rawTx := nt.Tx.Bytes()
 					n.announceTx(ctx, nt.Hash, rawTx, n.host.ID()) // response handling is async
 					if ctx.Err() != nil {
 						n.log.Warn("interrupting long re-broadcast")

--- a/node/services/jsonrpc/adminsvc/service.go
+++ b/node/services/jsonrpc/adminsvc/service.go
@@ -594,7 +594,7 @@ func (svc *Service) BlockExecStatus(ctx context.Context, req *adminjson.BlockExe
 	for i, txID := range status.TxIDs {
 		txInfo[i] = &types.TxInfo{
 			ID:     txID,
-			Status: status.TxStatus[txID.String()],
+			Status: status.TxStatus[txID],
 		}
 	}
 	resp.TxInfo = txInfo

--- a/node/store/memstore/memstore.go
+++ b/node/store/memstore/memstore.go
@@ -85,7 +85,7 @@ func (bs *MemBS) Store(block *ktypes.Block, appHash types.Hash) error {
 		appHash: appHash,
 	}
 	for _, tx := range block.Txns {
-		txHash := types.HashBytes(tx)
+		txHash := tx.Hash()
 		bs.txIds[txHash] = blkHash
 	}
 	return nil
@@ -170,12 +170,9 @@ func (bs *MemBS) GetTx(txHash types.Hash) (tx *ktypes.Transaction, height int64,
 	if !have {
 		return nil, 0, types.Hash{}, 0, types.ErrNotFound
 	}
-	for idx, rawTx := range blk.Txns {
-		if types.HashBytes(rawTx) == txHash {
-			tx := new(ktypes.Transaction)
-			if err = tx.UnmarshalBinary(rawTx); err != nil {
-				return nil, 0, types.Hash{}, 0, err
-			}
+	for idx, tx := range blk.Txns {
+		txHashi := tx.Hash()
+		if txHashi == txHash {
 			return tx, blk.Header.Height, blk.Hash(), uint32(idx), nil
 		}
 	}


### PR DESCRIPTION
```
types: use structured tx in block, no error Tx srlzn

This updates the block structure with a `Txns []*Transaction` field
insead of `[][]byte`.

This also updates transaction serialization so that it is guaranteed
not to error (except if a writer fails). This means that it supports
a nil Body even if that is invalid in a block. The Bytes() method may
be used instead of MarshalBinary for this.

Finally, two bytes for version are added to transaction and transaction
results serializations.
```