### PR TITLE
kwil-cli: minor improvements and bug fixes

### DIFF
--- a/cmd/kwil-cli/cmds/database/batch.go
+++ b/cmd/kwil-cli/cmds/database/batch.go
@@ -58,7 +58,7 @@ func batchCmd() *cobra.Command {
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return client.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl clientType.Client, conf *config.KwilCliConfig) error {
-				dbid, err := getSelectedNamespace(cmd)
+				dbid, _, err := getSelectedNamespace(cmd)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("error getting selected dbid from CLI flags: %w", err))
 				}

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -62,7 +62,7 @@ func callCmd() *cobra.Command {
 			}
 
 			return client.DialClient(cmd.Context(), cmd, dialFlags, func(ctx context.Context, clnt clientType.Client, conf *config.KwilCliConfig) error {
-				dbid, err := getSelectedNamespace(cmd)
+				dbid, _, err := getSelectedNamespace(cmd)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("error getting selected dbid from CLI flags: %w", err))
 				}

--- a/cmd/kwil-cli/cmds/database/execute.go
+++ b/cmd/kwil-cli/cmds/database/execute.go
@@ -57,7 +57,7 @@ func executeCmd() *cobra.Command {
 					are the parameters.
 				*/
 
-				namespace, err := getSelectedNamespace(cmd)
+				namespace, wasSet, err := getSelectedNamespace(cmd)
 				if err != nil {
 					return display.PrintErr(cmd, fmt.Errorf("error getting selected namespace from CLI flags: %w", err))
 				}
@@ -105,7 +105,7 @@ func executeCmd() *cobra.Command {
 				stmt := strings.TrimSpace(sqlStmt)
 
 				// if the namespace is set, we should prepend it to the statement
-				if namespace != "" {
+				if wasSet {
 					if strings.HasPrefix(stmt, "{") {
 						return display.PrintErr(cmd, fmt.Errorf("cannot specify both --namespace and a statement with a {namespace} prefix"))
 					}

--- a/cmd/kwil-cli/cmds/database/flags.go
+++ b/cmd/kwil-cli/cmds/database/flags.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/kwilteam/kwil-db/node/engine/interpreter"
 	"github.com/spf13/cobra"
 )
 
@@ -13,21 +14,20 @@ const (
 	actionNameFlag = "action"
 )
 
-// getSelectedNamespace returns the Dbid selected by the user.
-// Since the user can pass either a name and owner, or a dbid, we need to
-// check which one they passed and return the appropriate dbid.
-// If only a name flag is passed, it will get the owner from the configuration file.
-func getSelectedNamespace(cmd *cobra.Command) (string, error) {
+// getSelectedNamespace returns the namespace selected by the user.
+// If none is provided, it returns the default namespace.
+// If the namespace flag is not set, returns wasSet as false.
+func getSelectedNamespace(cmd *cobra.Command) (namespace string, wasSet bool, err error) {
 	if !cmd.Flags().Changed(nameFlag) {
-		return "", errors.New("no namespace selected")
+		return interpreter.DefaultNamespace, false, nil
 	}
 
 	name, err := cmd.Flags().GetString(nameFlag)
 	if err != nil {
-		return "", fmt.Errorf("failed to get name from flag: %w", err)
+		return "", false, fmt.Errorf("failed to get name from flag: %w", err)
 	}
 
-	return name, nil
+	return name, true, nil
 }
 
 // bindFlagsTargetingAction binds the flags for any command that targets a procedure or action.


### PR DESCRIPTION
Fixes a small bug where not selecting a namespace does not default to the default namespace `main`.
