### PR TITLE
core/crypto/auth: checksummed eth address from Identifier

### DIFF
--- a/core/crypto/auth/auth_test.go
+++ b/core/crypto/auth/auth_test.go
@@ -16,7 +16,7 @@ import (
 
 const (
 	secp256k1Key  = "f1aa5a7966c3863ccde3047f6a1e266cdc0c76b399e256b8fede92b1c69e4f4e"
-	secp256k1Addr = "0xc89d42189f0450c2b2c3c61f58ec5d628176a1e7"
+	secp256k1Addr = "0xc89D42189f0450C2b2c3c61f58Ec5d628176A1E7"
 	ed25519Key    = "7c67e60fce0c403ff40193a3128e5f3d8c2139aed36d76d7b5f1e70ec19c43f00aa611bf555596912bc6f9a9f169f8785918e7bab9924001895798ff13f05842"
 	ed25519Addr   = "0aa611bf555596912bc6f9a9f169f8785918e7bab9924001895798ff13f05842"
 )
@@ -61,7 +61,7 @@ func Test_AuthSignAndVerify(t *testing.T) {
 			name:          "eth personal sign",
 			signer:        secp256k1Signer(t, [32]byte{1, 2, 3}),
 			authenticator: auth.EthSecp256k1Authenticator{},
-			ident:         "0x1b7c6c9938cd93c10910dbc4d4ac8c9275e96925", // 0x prefixed 20 byte address
+			ident:         "0x1b7C6c9938cD93C10910dbC4d4aC8c9275e96925", // 0x prefixed 20 byte address
 		},
 		{
 			name:          "ed25519",

--- a/core/crypto/auth/eth_personal_sign_test.go
+++ b/core/crypto/auth/eth_personal_sign_test.go
@@ -1,0 +1,43 @@
+package auth
+
+import (
+	"testing"
+)
+
+func Test_eip55ChecksumAddr(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    [20]byte
+		expected string
+	}{
+		{
+			name:     "Basic address",
+			input:    [20]byte{0x5a, 0xAA, 0xfE, 0x6F, 0x8E, 0x4E, 0x44, 0xAA, 0x5d, 0x4c, 0xBd, 0x08, 0x7A, 0x63, 0x9B, 0x5E, 0x8A, 0x3E, 0xd3, 0x95},
+			expected: "0x5aaaFe6F8e4E44aa5D4cBd087a639b5e8a3Ed395",
+		},
+		{
+			name:     "All zeros",
+			input:    [20]byte{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+			expected: "0x0000000000000000000000000000000000000000",
+		},
+		{
+			name:     "Mixed case address",
+			input:    [20]byte{0x00, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56, 0x78, 0x9a, 0xbc, 0xde, 0xf0, 0x12, 0x34, 0x56},
+			expected: "0x00123456789AbcdeF0123456789abCdef0123456",
+		},
+		{
+			name:     "All F's",
+			input:    [20]byte{0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff},
+			expected: "0xFFfFfFffFFfffFFfFFfFFFFFffFFFffffFfFFFfF",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := eip55ChecksumAddr(tt.input)
+			if result != tt.expected {
+				t.Errorf("checksumHex() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This makes the `(*EthSecp256k1Authenticator).Identifier` format the string in EIP-55 checksumed case.