### PR TITLE
hoisted pg connection config in testing

### DIFF
--- a/cmd/kwil-cli/cmds/utils/test.go
+++ b/cmd/kwil-cli/cmds/utils/test.go
@@ -9,7 +9,6 @@ import (
 
 	"github.com/kwilteam/kwil-db/cmd/common/display"
 	"github.com/kwilteam/kwil-db/core/log"
-	"github.com/kwilteam/kwil-db/internal/sql/pg"
 	"github.com/kwilteam/kwil-db/testing"
 	"github.com/spf13/cobra"
 )
@@ -89,7 +88,7 @@ func testCmd() *cobra.Command {
 					return display.PrintErr(cmd, fmt.Errorf("must specify either postgres connection flags or --test-container"))
 				}
 
-				opts.Conn = &pg.ConnConfig{
+				opts.Conn = &testing.ConnConfig{
 					Host:   host,
 					Port:   port,
 					User:   user,

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -576,9 +576,20 @@ type Options struct {
 	UseTestContainer bool
 	// Conn specifies a manually setup Postgres connection that the
 	// test can connect to.
-	Conn *pg.ConnConfig
+	Conn *ConnConfig
 	// Logger is a logger to be used in the test
 	Logger Logger
+}
+
+// ConnConfig groups the basic connection settings used to construct the DSN
+// "connection string" used to open a new connection to a postgres host.
+type ConnConfig struct {
+	// Host, Port, User, Pass, and DBName are used verbatim to create a
+	// connection string in DSN format.
+	// https://www.postgresql.org/docs/current/libpq-connect.html#LIBPQ-CONNSTRING
+	Host, Port string
+	User, Pass string
+	DBName     string
 }
 
 func (d *Options) valid() error {


### PR DESCRIPTION
Duplicated the `pg.ConnConfig` into `testing` so that users who are writing their own tests in Go can specify their own connections.

Previously, we allowed users to specify their own connections, but only in CLI tests. Not supporting this was simply an oversight.