### PR TITLE
--sync flag support in the broadcastTx request to wait for the transa…

### DIFF
--- a/app/node/build.go
+++ b/app/node/build.go
@@ -420,6 +420,7 @@ func buildConsensusEngine(_ context.Context, d *coreDependencies, db *pg.DB,
 		ProposeTimeout:        time.Duration(d.cfg.Consensus.ProposeTimeout),
 		BlockProposalInterval: time.Duration(d.cfg.Consensus.BlockProposalInterval),
 		BlockAnnInterval:      time.Duration(d.cfg.Consensus.BlockAnnInterval),
+		BroadcastTxTimeout:    time.Duration(d.cfg.RPC.BroadcastTxTimeout),
 		GenesisHeight:         d.genesisCfg.InitialHeight,
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -180,6 +180,7 @@ func DefaultConfig() *Config {
 		},
 		RPC: RPCConfig{
 			ListenAddress:      "0.0.0.0:8484",
+			BroadcastTxTimeout: Duration(15 * time.Second),
 			Timeout:            Duration(20 * time.Second),
 			MaxReqSize:         6_000_000,
 			Private:            false,
@@ -279,6 +280,7 @@ type ConsensusConfig struct {
 
 type RPCConfig struct {
 	ListenAddress      string   `toml:"listen" comment:"address in host:port format on which the RPC server will listen"`
+	BroadcastTxTimeout Duration `toml:"broadcast_tx_timeout" comment:"duration to wait for a tx to be committed when transactions are authored with --sync flag"`
 	Timeout            Duration `toml:"timeout" comment:"user request duration limit after which it is cancelled"`
 	MaxReqSize         int      `toml:"max_req_size" comment:"largest permissible user request size"`
 	Private            bool     `toml:"private" comment:"enable private mode that requires challenge authentication for each call"`

--- a/core/rpc/client/opts.go
+++ b/core/rpc/client/opts.go
@@ -29,13 +29,11 @@ func WithAuthCookie(cookie *http.Cookie) ActionCallOption {
 }
 
 // BroadcastWait is an argument type that indicates how long to wait when
-// broadcasting a transaction. The levels are async (do not wait for mempool
-// acceptance), sync (wait for mempool acceptance), and commit (wait for it to
-// be included in a block).
+// broadcasting a transaction. The levels are sync (wait for mempool acceptance),
+// and commit (wait for it to be included in a block).
 type BroadcastWait uint8
 
 const (
-	BroadcastWaitAsync  = BroadcastWait(userjson.BroadcastSyncAsync)
 	BroadcastWaitSync   = BroadcastWait(userjson.BroadcastSyncSync)
 	BroadcastWaitCommit = BroadcastWait(userjson.BroadcastSyncCommit)
 )

--- a/core/rpc/json/user/commands.go
+++ b/core/rpc/json/user/commands.go
@@ -54,15 +54,12 @@ type BroadcastSync uint8
 
 // These are the recognized BroadcastSync values used with BroadcastRequest.
 const (
-	// BroadcastSyncAsync does not wait for acceptance into mempool, only
-	// computing the transaction hash.
-	BroadcastSyncAsync BroadcastSync = 0
 	// BroadcastSyncSync ensures the transaction is accepted to mempool before
-	// responding. Ths should be preferred to BroadcastSyncAsync in most cases.
-	BroadcastSyncSync BroadcastSync = 1
+	// responding. This is the default behavior.
+	BroadcastSyncSync BroadcastSync = 0
 	// BroadcastSyncCommit will wait for the transaction to be included in a
 	// block.
-	BroadcastSyncCommit BroadcastSync = 2
+	BroadcastSyncCommit BroadcastSync = 1
 )
 
 // CallRequest contains the request parameters for MethodCall.

--- a/go.work.example
+++ b/go.work.example
@@ -3,6 +3,7 @@ go 1.22.0
 use (
 	.
 	./core
+	./test
 )
 
 // replace github.com/kwilteam/kuneiform => ../kuneiform

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -25,6 +25,7 @@ type Mempool interface {
 	PeekN(maxSize int) []types.NamedTx
 	Remove(txid types.Hash)
 	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
+	Store(types.Hash, *ktypes.Transaction)
 }
 
 // BlockStore includes both txns and blocks

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	ktypes "github.com/kwilteam/kwil-db/core/types"
-	blockprocessor "github.com/kwilteam/kwil-db/node/block_processor"
 	"github.com/kwilteam/kwil-db/node/consensus"
 	"github.com/kwilteam/kwil-db/node/snapshotter"
 	"github.com/kwilteam/kwil-db/node/types"
@@ -27,11 +26,10 @@ type ConsensusEngine interface {
 
 	NotifyDiscoveryMessage(validatorPK []byte, height int64)
 
-	Start(ctx context.Context, proposerBroadcaster consensus.ProposalBroadcaster,
-		blkAnnouncer consensus.BlkAnnouncer, ackBroadcaster consensus.AckBroadcaster,
-		blkRequester consensus.BlkRequester, stateResetter consensus.ResetStateBroadcaster, discoveryBroadcaster consensus.DiscoveryReqBroadcaster, txBroadcaster blockprocessor.BroadcastTxFn) error
+	Start(ctx context.Context, fns consensus.BroadcastFns) error
 
 	CheckTx(ctx context.Context, tx *ktypes.Transaction) error
+	BroadcastTx(ctx context.Context, tx *ktypes.Transaction, sync uint8) (*ktypes.ResultBroadcastTx, error)
 
 	ConsensusParams() *ktypes.ConsensusParams
 	CancelBlockExecution(height int64, txIDs []types.Hash) error

--- a/node/node.go
+++ b/node/node.go
@@ -22,6 +22,7 @@ import (
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	adminTypes "github.com/kwilteam/kwil-db/core/types/admin"
 	chainTypes "github.com/kwilteam/kwil-db/core/types/chain"
+	"github.com/kwilteam/kwil-db/node/consensus"
 	"github.com/kwilteam/kwil-db/node/peers"
 	"github.com/kwilteam/kwil-db/node/types"
 
@@ -443,8 +444,19 @@ func (n *Node) Start(ctx context.Context, bootpeers ...string) error {
 	go func() {
 		defer n.wg.Done()
 		defer cancel()
-		// TODO: umm, should node bringup the consensus engine? or server?
-		nodeErr = n.ce.Start(ctx, n.announceBlkProp, n.announceBlk, n.sendACK, n.getBlkHeight, n.sendReset, n.sendDiscoveryRequest, n.BroadcastTx)
+
+		broadcastFns := consensus.BroadcastFns{
+			ProposalBroadcaster:     n.announceBlkProp,
+			TxAnnouncer:             n.announceTx,
+			BlkAnnouncer:            n.announceBlk,
+			AckBroadcaster:          n.sendACK,
+			BlkRequester:            n.getBlkHeight,
+			RstStateBroadcaster:     n.sendReset,
+			DiscoveryReqBroadcaster: n.sendDiscoveryRequest,
+			TxBroadcaster:           n.BroadcastTx,
+		}
+
+		nodeErr = n.ce.Start(ctx, broadcastFns)
 		if err != nil {
 			n.log.Errorf("Consensus engine failed: %v", nodeErr)
 			return // cancel context
@@ -634,23 +646,8 @@ func (n *Node) TxQuery(ctx context.Context, hash types.Hash, prove bool) (*ktype
 	}, nil
 }
 
-func (n *Node) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, _ /*sync TODO*/ uint8) (*ktypes.ResultBroadcastTx, error) {
-	rawTx := tx.Bytes()
-	txHash := types.HashBytes(rawTx)
-
-	if err := n.ce.CheckTx(ctx, tx); err != nil {
-		return nil, err
-	}
-
-	n.mp.Store(txHash, tx)
-
-	n.log.Infof("broadcasting new tx %v", txHash)
-	n.announceTx(ctx, txHash, rawTx, n.host.ID())
-
-	return &ktypes.ResultBroadcastTx{
-		Hash: txHash,
-		// Log and Code just for sync?
-	}, nil
+func (n *Node) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, sync uint8) (*ktypes.ResultBroadcastTx, error) {
+	return n.ce.BroadcastTx(ctx, tx, sync)
 }
 
 // ChainTx return tx info that is used in Chain rpc.

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -116,6 +116,7 @@ func TestSingleNodeMocknet(t *testing.T) {
 		ProposeTimeout:        1 * time.Second,
 		BlockProposalInterval: 1 * time.Second,
 		BlockAnnInterval:      3 * time.Second,
+		BroadcastTxTimeout:    15 * time.Second,
 		DB:                    db1,
 	}
 	ce1 := consensus.New(ceCfg1)

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/log"
 	ktypes "github.com/kwilteam/kwil-db/core/types"
-	blockprocessor "github.com/kwilteam/kwil-db/node/block_processor"
 	"github.com/kwilteam/kwil-db/node/consensus"
 	"github.com/kwilteam/kwil-db/node/mempool"
 	"github.com/kwilteam/kwil-db/node/store/memstore"
@@ -325,6 +324,10 @@ func (ce *dummyCE) CheckTx(ctx context.Context, tx *ktypes.Transaction) error {
 	return nil
 }
 
+func (ce *dummyCE) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, sync uint8) (*ktypes.ResultBroadcastTx, error) {
+	return nil, nil
+}
+
 func (ce *dummyCE) ConsensusParams() *ktypes.ConsensusParams {
 	return nil
 }
@@ -337,15 +340,12 @@ func (ce *dummyCE) CancelBlockExecution(height int64, txIDs []types.Hash) error 
 	return nil
 }
 
-func (ce *dummyCE) Start(ctx context.Context, proposerBroadcaster consensus.ProposalBroadcaster,
-	blkAnnouncer consensus.BlkAnnouncer, ackBroadcaster consensus.AckBroadcaster,
-	blkRequester consensus.BlkRequester, stateResetter consensus.ResetStateBroadcaster,
-	discReqBroadcaster consensus.DiscoveryReqBroadcaster, txBroadcaster blockprocessor.BroadcastTxFn) error {
-	ce.proposerBroadcaster = proposerBroadcaster
-	ce.blkAnnouncer = blkAnnouncer
-	ce.ackBroadcaster = ackBroadcaster
-	ce.blkRequester = blkRequester
-	ce.stateResetter = stateResetter
+func (ce *dummyCE) Start(ctx context.Context, fns consensus.BroadcastFns) error {
+	ce.proposerBroadcaster = fns.ProposalBroadcaster
+	ce.blkAnnouncer = fns.BlkAnnouncer
+	ce.ackBroadcaster = fns.AckBroadcaster
+	ce.blkRequester = fns.BlkRequester
+	ce.stateResetter = fns.RstStateBroadcaster
 	return nil
 }
 

--- a/node/peers/convert.go
+++ b/node/peers/convert.go
@@ -42,12 +42,12 @@ func NewPeerList(nodeIDs []string) (*PeerList, error) {
 }*/
 
 // PeerIDFromPubKey converts a pubkey to a peer ID string.
-func PeerIDFromPubKey(pubkey crypto.PublicKey) (string, error) {
+func PeerIDFromPubKey(pubkey crypto.PublicKey) (peer.ID, error) {
 	_, peerID, err := convertPubKey(pubkey)
 	if err != nil {
 		return "", err
 	}
-	return peerID.String(), nil // base58 encoding of identity multihash
+	return peerID, nil // base58 encoding of identity multihash
 }
 
 // PubKeyFromPeerID tries to decode the pubkey from a peer ID string.

--- a/node/peers/convert_test.go
+++ b/node/peers/convert_test.go
@@ -47,12 +47,12 @@ func TestPeerIDPubKeyRoundTrip(t *testing.T) {
 				return
 			}
 
-			if peerID != tt.expectedPeerID {
+			if peerID.String() != tt.expectedPeerID {
 				t.Errorf("PeerIDFromPubKey() = %v, want %v", peerID, tt.expectedPeerID)
 			}
 
 			// Test round trip back to PubKeyFromPeerID
-			recoveredPubKey, err := PubKeyFromPeerID(peerID)
+			recoveredPubKey, err := PubKeyFromPeerID(peerID.String())
 			if err != nil {
 				t.Errorf("PubKeyFromPeerID() error = %v", err)
 				return

--- a/node/services/jsonrpc/usersvc/service.go
+++ b/node/services/jsonrpc/usersvc/service.go
@@ -46,10 +46,6 @@ type NodeApp interface {
 	GetMigrationMetadata(ctx context.Context) (*types.MigrationMetadata, error)
 }
 
-// type Accounts interface {
-// 	GetAccount(ctx context.Context, tx sql.Executor, acctID []byte) (*types.Account, error)
-// }
-
 type Validators interface {
 	SetValidatorPower(ctx context.Context, tx sql.Executor, pubKey []byte, power int64) error
 	GetValidatorPower(ctx context.Context, pubKey []byte) (int64, error)


### PR DESCRIPTION
…ction to be included in the block

```
❯ ./.build/kwil-cli database execute -s "CREATE NAMESPACE test13;" --chain-id "kwil-testnet" --sync

TxHash: 5abf49a231a0235261978a7d6da815fe3f7cae156cb98356879f4520d7ccaf7b
Status: success
Height: 150
Log: success



❯ ./.build/kwil-cli database execute -s "CREATE NAMESPACE test13;" --chain-id "kwil-testnet" --sync
error executing SQL statement: broadcast error: code = 120, hash = 76c1b6e821c4fba067cd148bf7b8ab57e8e0611b7b90d786ae57771ce7151ddc, msg = namespace already exists: "test13"
jsonrpc.Error: code = -201, message = broadcast error, data = {
  "tx_code": 120,
  "hash": "76c1b6e821c4fba067cd148bf7b8ab57e8e0611b7b90d786ae57771ce7151ddc",
  "message": "namespace already exists: \"test13\""
}
err code = -201, msg = broadcast error
```