### PR TITLE
Rollback if the consensusTx creation is partially successful

### DIFF
--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -61,7 +61,6 @@ func TestSingleNodeMocknet(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		wg.Wait()
-		cleanupDB(db1)
 	})
 
 	privKeys, _ := newGenesis(t, [][]byte{pk1})
@@ -193,8 +192,6 @@ func TestDualNodeMocknet(t *testing.T) {
 	t.Cleanup(func() {
 		cancel()
 		wg.Wait()
-		cleanupDB(db1)
-		cleanupDB(db2)
 	})
 
 	privKeys, _ := newGenesis(t, [][]byte{pk1, pk2})
@@ -365,7 +362,7 @@ func initDB(t *testing.T, port, dbName string) *pg.DB {
 		Pass:   "kwild", // would be ignored if pg_hba.conf set with trust
 		DBName: dbName,
 	}
-	db, err := pgtest.NewTestDBWithCfg(t, cfg)
+	db, err := pgtest.NewTestDBWithCfg(t, cfg, cleanupDB)
 	require.NoError(t, err)
 	ctx := context.Background()
 

--- a/node/pg/test/testdb.go
+++ b/node/pg/test/testdb.go
@@ -118,7 +118,7 @@ func NewTestDBNamed(t *testing.T, dbName string, port int, cleanUp func(*pg.DB))
 	return db
 }
 
-func NewTestDBWithCfg(t *testing.T, dbCfg *config.DBConfig) (db *pg.DB, err error) {
+func NewTestDBWithCfg(t *testing.T, dbCfg *config.DBConfig, cleanUp func(*pg.DB)) (db *pg.DB, err error) {
 	cfg := &pg.DBConfig{
 		PoolConfig: pg.PoolConfig{
 			ConnConfig: pg.ConnConfig{
@@ -134,5 +134,15 @@ func NewTestDBWithCfg(t *testing.T, dbCfg *config.DBConfig) (db *pg.DB, err erro
 			return strings.Contains(s, pg.DefaultSchemaFilterPrefix)
 		},
 	}
-	return pg.NewDB(context.Background(), cfg)
+	db, err = pg.NewDB(context.Background(), cfg)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Cleanup(func() {
+		defer db.Close()
+		cleanUp(db)
+	})
+
+	return db, nil
 }


### PR DESCRIPTION
Explicit rollback is if beginWriterTx() fails after creating the Consensus Tx, else the db.Close() will panic