### PR TITLE
added admin client barebones

### DIFF
--- a/test/setup/admin_client.go
+++ b/test/setup/admin_client.go
@@ -1,3 +1,44 @@
 package setup
 
-type AdminClient struct{}
+import (
+	"context"
+	"encoding/json"
+	"errors"
+
+	"github.com/kwilteam/kwil-db/app/shared/display"
+	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/testcontainers/testcontainers-go"
+)
+
+type AdminClient struct {
+	container *testcontainers.DockerContainer
+}
+
+// exec runs a command in the admin container.
+// It will JSON unmarshal the result into result.
+func exec[T any](a *AdminClient, ctx context.Context, result T, args ...string) error {
+	_, reader, err := a.container.Exec(ctx, append([]string{"/app/kwil-admin"}, args...))
+	if err != nil {
+		return err
+	}
+
+	d := display.MessageReader[T]{
+		Result: result,
+	}
+
+	err = json.NewDecoder(reader).Decode(&d)
+	if err != nil {
+		return err
+	}
+
+	if d.Error != "" {
+		return errors.New(d.Error)
+	}
+
+	return nil
+}
+func (a *AdminClient) ValidatorNodeApprove(ctx context.Context, joinerPubKey []byte) (types.Hash, error) {
+	var hash types.Hash
+	err := exec(a, ctx, &hash, "validators", "approve", string(joinerPubKey))
+	return hash, err
+}

--- a/test/setup/node.go
+++ b/test/setup/node.go
@@ -453,10 +453,22 @@ func (k *kwilNode) JSONRPCClient(t *testing.T, ctx context.Context, usingGateway
 	return client
 }
 
+func (k *kwilNode) AdminClient(t *testing.T, ctx context.Context) *AdminClient {
+	container, ok := k.testCtx.containers[k.generatedInfo.KwilNodeServiceName]
+	if !ok {
+		t.Fatalf("container %s not found", k.generatedInfo.KwilNodeServiceName)
+	}
+
+	return &AdminClient{
+		container: container,
+	}
+}
+
 type KwilNode interface {
 	PrivateKey() *crypto.Secp256k1PrivateKey
 	PublicKey() *crypto.Secp256k1PublicKey
 	IsValidator() bool
 	Config() *config.Config
 	JSONRPCClient(t *testing.T, ctx context.Context, usingKGW bool) JSONRPCClient
+	AdminClient(t *testing.T, ctx context.Context) *AdminClient
 }


### PR DESCRIPTION
Adds the ability to contact the `kwil-admin` for each node.

