### PR TITLE
fix: engine incorrectly gives foreign keys to planner

### DIFF
--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -652,8 +652,7 @@ func Test_SQL(t *testing.T) {
 					id UUID PRIMARY KEY,
 					address TEXT NOT NULL, -- eth address
 					contract_id UUID NOT NULL REFERENCES erc20rw_contracts(id) ON UPDATE CASCADE ON DELETE CASCADE,
-					UNIQUE (address, contract_id),
-					foreign key (address) references deleteme (id)
+					UNIQUE (address, contract_id)
 				);`,
 			},
 			execSQL: `SELECT * FROM erc20rw_signers WHERE contract_id = $contract_id;`,

--- a/node/engine/interpreter/schema.sql
+++ b/node/engine/interpreter/schema.sql
@@ -254,7 +254,7 @@ ORDER BY 1, 2;
 
 -- info.columns is a public view that provides a list of all columns in the database
 CREATE VIEW info.columns AS
-SELECT 
+SELECT DISTINCT
     c.table_schema::TEXT AS namespace,
     c.table_name::TEXT AS table_name,
     c.column_name::TEXT AS name,
@@ -294,9 +294,10 @@ JOIN
     kwild_engine.namespaces us ON n.nspname::TEXT = us.name
 WHERE cl.relkind IN ('r', 'v') -- only tables and views
 ORDER BY 
-    c.table_name, 
-    c.ordinal_position,
+    table_name, 
+    ordinal_position,
     1, 2, 3, 4, 5, 6, 7, 8;
+    
 
 -- info.indexes is a public view that provides a list of all indexes in the database
 CREATE VIEW info.indexes AS


### PR DESCRIPTION
This fixes a bug with foreign keys that @Yaiba found
