### PR TITLE
engine: better testing for `info` schema

### DIFF
--- a/core/types/data_types.go
+++ b/core/types/data_types.go
@@ -107,7 +107,9 @@ func (c *DataType) String() string {
 	return str.String()
 }
 
-var ZeroMetadata = [2]uint16{}
+func (c *DataType) HasMetadata() bool {
+	return c.Metadata != [2]uint16{}
+}
 
 // PGString returns the string representation of the type in Postgres.
 func (c *DataType) PGString() (string, error) {
@@ -141,7 +143,7 @@ func (c *DataType) PGScalar() (string, error) {
 	case uint256Str:
 		scalar = "UINT256"
 	case NumericStr:
-		if c.Metadata == ZeroMetadata {
+		if !c.HasMetadata() {
 			return "", errors.New("decimal type requires metadata")
 		} else {
 			scalar = fmt.Sprintf("NUMERIC(%d,%d)", c.Metadata[0], c.Metadata[1])
@@ -167,11 +169,11 @@ func (c *DataType) Clean() error {
 
 	switch referencedType {
 	case intStr, textStr, boolStr, byteaStr, uuidStr, uint256Str: // ok
-		if c.Metadata != ZeroMetadata {
+		if c.HasMetadata() {
 			return fmt.Errorf("type %s cannot have metadata", c.Name)
 		}
 	case NumericStr:
-		if c.Metadata == ZeroMetadata {
+		if !c.HasMetadata() {
 			return fmt.Errorf("type %s requires metadata", c.Name)
 		}
 		err := decimal.CheckPrecisionAndScale(c.Metadata[0], c.Metadata[1])
@@ -184,7 +186,7 @@ func (c *DataType) Clean() error {
 			return fmt.Errorf("type %s cannot be an array", c.Name)
 		}
 
-		if c.Metadata != ZeroMetadata {
+		if c.HasMetadata() {
 			return fmt.Errorf("type %s cannot have metadata", c.Name)
 		}
 	default:

--- a/core/types/data_types.go
+++ b/core/types/data_types.go
@@ -96,7 +96,7 @@ func (c *DataType) String() string {
 		return str.String() + "[]"
 	}
 
-	if c.Name == DecimalStr {
+	if c.Name == NumericStr {
 		str.WriteString("(")
 		str.WriteString(strconv.FormatUint(uint64(c.Metadata[0]), 10))
 		str.WriteString(",")
@@ -107,9 +107,9 @@ func (c *DataType) String() string {
 	return str.String()
 }
 
-func (c *DataType) HasMetadata() bool {
-	return c.Metadata != ZeroMetadata
-}
+// func (c *DataType) HasMetadata() bool {
+// 	return c.Metadata != ZeroMetadata
+// }
 
 var ZeroMetadata = [2]uint16{}
 
@@ -138,15 +138,15 @@ func (c *DataType) PGScalar() (string, error) {
 		scalar = "TEXT"
 	case boolStr:
 		scalar = "BOOL"
-	case blobStr:
+	case byteaStr:
 		scalar = "BYTEA"
 	case uuidStr:
 		scalar = "UUID"
 	case uint256Str:
 		scalar = "UINT256"
-	case DecimalStr:
+	case NumericStr:
 		if c.Metadata == ZeroMetadata {
-			scalar = "NUMERIC"
+			return "", errors.New("decimal type requires metadata")
 		} else {
 			scalar = fmt.Sprintf("NUMERIC(%d,%d)", c.Metadata[0], c.Metadata[1])
 		}
@@ -170,17 +170,19 @@ func (c *DataType) Clean() error {
 	}
 
 	switch referencedType {
-	case intStr, textStr, boolStr, blobStr, uuidStr, uint256Str: // ok
+	case intStr, textStr, boolStr, byteaStr, uuidStr, uint256Str: // ok
 		if c.Metadata != ZeroMetadata {
 			return fmt.Errorf("type %s cannot have metadata", c.Name)
 		}
-	case DecimalStr:
-		if c.Metadata != ZeroMetadata {
-			err := decimal.CheckPrecisionAndScale(c.Metadata[0], c.Metadata[1])
-			if err != nil {
-				return err
-			}
+	case NumericStr:
+		if c.Metadata == ZeroMetadata {
+			return fmt.Errorf("type %s requires metadata", c.Name)
 		}
+		err := decimal.CheckPrecisionAndScale(c.Metadata[0], c.Metadata[1])
+		if err != nil {
+			return err
+		}
+
 	case nullStr, unknownStr:
 		if c.IsArray {
 			return fmt.Errorf("type %s cannot be an array", c.Name)
@@ -222,13 +224,8 @@ func (c *DataType) EqualsStrict(other *DataType) bool {
 		return false
 	}
 
-	if (c.Metadata == ZeroMetadata) != (other.Metadata == ZeroMetadata) {
+	if c.Metadata[0] != other.Metadata[0] || c.Metadata[1] != other.Metadata[1] {
 		return false
-	}
-	if c.Metadata != ZeroMetadata {
-		if c.Metadata[0] != other.Metadata[0] || c.Metadata[1] != other.Metadata[1] {
-			return false
-		}
 	}
 
 	return strings.EqualFold(c.Name, other.Name)
@@ -249,7 +246,7 @@ func (c *DataType) IsNumeric() bool {
 		return false
 	}
 
-	return c.Name == intStr || c.Name == DecimalStr || c.Name == uint256Str || c.Name == unknownStr
+	return c.Name == intStr || c.Name == NumericStr || c.Name == uint256Str || c.Name == unknownStr
 }
 
 // declared DataType constants.
@@ -268,7 +265,7 @@ var (
 	}
 	BoolArrayType = ArrayType(BoolType)
 	BlobType      = &DataType{
-		Name: blobStr,
+		Name: byteaStr,
 	}
 	BlobArrayType = ArrayType(BlobType)
 	UUIDType      = &DataType{
@@ -279,22 +276,22 @@ var (
 	// For type detection, users should prefer compare a datatype
 	// name with the DecimalStr constant.
 	DecimalType = &DataType{
-		Name:     DecimalStr,
-		Metadata: [2]uint16{1, 0}, // the minimum precision and scale
+		Name:     NumericStr,
+		Metadata: [2]uint16{0, 0}, // unspecified precision and scale
 	}
 	DecimalArrayType = ArrayType(DecimalType)
 	Uint256Type      = &DataType{
-		Name: uint256Str,
+		Name: uint256Str, // TODO: delete
 	}
 	Uint256ArrayType = ArrayType(Uint256Type)
 	// NullType is a special type used internally
 	NullType = &DataType{
-		Name: nullStr,
+		Name: nullStr, // TODO: delete
 	}
 	// Unknown is a special type used internally
 	// when a type is unknown until runtime.
 	UnknownType = &DataType{
-		Name: unknownStr,
+		Name: unknownStr, // TODO: delete
 	}
 )
 
@@ -315,11 +312,11 @@ const (
 	textStr    = "text"
 	intStr     = "int8"
 	boolStr    = "bool"
-	blobStr    = "blob"
+	byteaStr   = "bytea"
 	uuidStr    = "uuid"
 	uint256Str = "uint256"
-	// DecimalStr is a fixed point number.
-	DecimalStr = "decimal"
+	// NumericStr is a fixed point number.
+	NumericStr = "numeric"
 	nullStr    = "null"
 	unknownStr = "unknown"
 )
@@ -332,7 +329,7 @@ func NewDecimalType(precision, scale uint16) (*DataType, error) {
 	}
 
 	return &DataType{
-		Name:     DecimalStr,
+		Name:     NumericStr,
 		Metadata: [2]uint16{precision, scale},
 	}, nil
 }
@@ -369,7 +366,7 @@ func ParseDataType(s string) (*DataType, error) {
 	if rawMetadata != "" {
 		metadata = [2]uint16{}
 		// only decimal types can have metadata
-		if baseName != DecimalStr {
+		if baseName != NumericStr {
 			return nil, fmt.Errorf("metadata is only allowed for decimal type")
 		}
 
@@ -406,9 +403,9 @@ var typeAlias = map[string]string{
 	"int8":    intStr,
 	"bool":    boolStr,
 	"boolean": boolStr,
-	"blob":    blobStr,
-	"bytea":   blobStr,
+	"blob":    byteaStr,
+	"bytea":   byteaStr,
 	"uuid":    uuidStr,
-	"decimal": DecimalStr,
-	"numeric": DecimalStr,
+	"decimal": NumericStr,
+	"numeric": NumericStr,
 }

--- a/core/types/data_types.go
+++ b/core/types/data_types.go
@@ -107,10 +107,6 @@ func (c *DataType) String() string {
 	return str.String()
 }
 
-// func (c *DataType) HasMetadata() bool {
-// 	return c.Metadata != ZeroMetadata
-// }
-
 var ZeroMetadata = [2]uint16{}
 
 // PGString returns the string representation of the type in Postgres.

--- a/core/types/data_types_test.go
+++ b/core/types/data_types_test.go
@@ -119,34 +119,34 @@ func Test_ParseDataTypes(t *testing.T) {
 		{
 			in: "int8",
 			out: DataType{
-				Name: "int8",
+				Name: intStr,
 			},
 		},
 		{
 			in: "int8[]",
 			out: DataType{
-				Name:    "int8",
+				Name:    intStr,
 				IsArray: true,
 			},
 		},
 		{
 			in: "text[]",
 			out: DataType{
-				Name:    "text",
+				Name:    textStr,
 				IsArray: true,
 			},
 		},
 		{
 			in: "decimal(10, 2)",
 			out: DataType{
-				Name:     "decimal",
+				Name:     NumericStr,
 				Metadata: [2]uint16{10, 2},
 			},
 		},
 		{
 			in: "decimal(10, 2)[]",
 			out: DataType{
-				Name:     "decimal",
+				Name:     NumericStr,
 				Metadata: [2]uint16{10, 2},
 				IsArray:  true,
 			},

--- a/core/types/marshal_fuzz_test.go
+++ b/core/types/marshal_fuzz_test.go
@@ -93,8 +93,8 @@ func FuzzDataTypeUnmarshalBinary(f *testing.F) {
 					// If Clean() succeeds, verify the type is one of the known types
 					validTypes := map[string]bool{
 						"int8": true, "text": true, "bool": true,
-						"blob": true, "uuid": true, "uint256": true,
-						"decimal": true, "null": true, "unknown": true,
+						"bytea": true, "uuid": true, "uint256": true,
+						"numeric": true, "null": true, "unknown": true,
 					}
 					if !validTypes[dt.Name] {
 						t.Errorf("unmarshaled invalid type name: %s", dt.Name)

--- a/core/types/payloads.go
+++ b/core/types/payloads.go
@@ -326,7 +326,7 @@ func (e *EncodedValue) Decode() (any, error) {
 			return nil, nil
 		case Uint256Type.Name:
 			return Uint256FromBytes(data)
-		case DecimalStr:
+		case NumericStr:
 			return decimal.NewFromString(string(data))
 		default:
 			return nil, fmt.Errorf("cannot decode type %s", typeName)
@@ -406,7 +406,7 @@ func (e *EncodedValue) Decode() (any, error) {
 				arr = append(arr, dec.(*Uint256))
 			}
 			arrAny = arr
-		case DecimalStr:
+		case NumericStr:
 			arr := make(decimal.DecimalArray, 0, len(e.Data))
 			for _, elem := range e.Data {
 				dec, err := decodeScalar(elem, e.Type.Name, true)

--- a/extensions/precompiles/actions.go
+++ b/extensions/precompiles/actions.go
@@ -183,7 +183,7 @@ func (m *Method[T]) verify() error {
 type MethodReturn struct {
 	// If true, then the method returns any number of rows.
 	// If false, then the method returns exactly one row.
-	ReturnsTable bool
+	IsTable bool
 	// ColumnTypes is a list of column types.
 	// It is required. If the extension returns types that are
 	// not matching the column types, the engine will return an error.

--- a/extensions/precompiles/values.go
+++ b/extensions/precompiles/values.go
@@ -132,7 +132,7 @@ func init() {
 		valueMapping{
 			KwilType: types.DecimalType,
 			ZeroValue: func(t *types.DataType) (Value, error) {
-				if t.Metadata == types.ZeroMetadata {
+				if !t.HasMetadata() {
 					return nil, fmt.Errorf("cannot create zero value of decimal type with zero precision and scale")
 				}
 
@@ -149,7 +149,7 @@ func init() {
 				return dec2, nil
 			},
 			NullValue: func(t *types.DataType) (Value, error) {
-				if t.Metadata == types.ZeroMetadata {
+				if !t.HasMetadata() {
 					return nil, fmt.Errorf("cannot create null value of decimal type with zero precision and scale")
 				}
 				prec := t.Metadata[0]
@@ -214,7 +214,7 @@ func init() {
 		valueMapping{
 			KwilType: types.DecimalArrayType,
 			ZeroValue: func(t *types.DataType) (Value, error) {
-				if t.Metadata == types.ZeroMetadata {
+				if !t.HasMetadata() {
 					return nil, fmt.Errorf("cannot create zero value of decimal type with zero precision and scale")
 				}
 
@@ -228,7 +228,7 @@ func init() {
 				return arr, nil
 			},
 			NullValue: func(t *types.DataType) (Value, error) {
-				if t.Metadata == types.ZeroMetadata {
+				if !t.HasMetadata() {
 					return nil, fmt.Errorf("cannot create null value of decimal array type with zero precision and scale")
 				}
 

--- a/extensions/precompiles/values_test.go
+++ b/extensions/precompiles/values_test.go
@@ -124,9 +124,10 @@ func Test_Arithmetic(t *testing.T) {
 				eq(t, want, raw)
 
 				// operations on null values should always return null
-				null := MakeNull(a.Type()).(ScalarValue)
+				null, err := MakeNull(a.Type())
+				require.NoError(t, err)
 
-				res, err = a.Arithmetic(null, op)
+				res, err = a.Arithmetic(null.(ScalarValue), op)
 				require.NoError(t, err)
 
 				require.True(t, res.Null())
@@ -763,7 +764,7 @@ func Test_Array(t *testing.T) {
 			}
 
 			for i := range res.Len() {
-				s, err := res.Index(i + 1) // 1-indexed
+				s, err := res.Get(i + 1) // 1-indexed
 				require.NoError(t, err)
 
 				eq(t, tt.vals[i], s.RawValue())
@@ -772,12 +773,15 @@ func Test_Array(t *testing.T) {
 			// we will now set them all to nulls and test that the array is created successfully
 			dt := vals[0].Type()
 			for i := range vals {
-				err = res.Set(int32(i+1), MakeNull(dt).(ScalarValue))
+				nullVal, err := MakeNull(dt)
+				require.NoError(t, err)
+
+				err = res.Set(int32(i+1), nullVal.(ScalarValue))
 				require.NoError(t, err)
 			}
 
 			for i := range res.Len() {
-				s, err := res.Index(i + 1) // 1-indexed
+				s, err := res.Get(i + 1) // 1-indexed
 				require.NoError(t, err)
 
 				isNull := s.Null()

--- a/node/engine/functions.go
+++ b/node/engine/functions.go
@@ -15,7 +15,7 @@ var (
 					return nil, wrapErrArgumentNumber(1, len(args))
 				}
 
-				if !args[0].EqualsStrict(types.IntType) && args[0].Name != types.DecimalStr {
+				if !args[0].EqualsStrict(types.IntType) && args[0].Name != types.NumericStr {
 					return nil, fmt.Errorf("%w: expected argument to be int or decimal, got %s", ErrType, args[0].String())
 				}
 
@@ -704,7 +704,7 @@ var (
 				switch {
 				case args[0].EqualsStrict(types.IntType):
 					retType = decimal1000.Copy()
-				case args[0].Name == types.DecimalStr:
+				case args[0].Name == types.NumericStr:
 					retType = args[0].Copy()
 					retType.Metadata[0] = 1000 // max precision
 				case args[0].EqualsStrict(types.Uint256Type):
@@ -795,7 +795,7 @@ var (
 					return nil, wrapErrArgumentNumber(1, len(args))
 				}
 
-				if !strings.EqualFold(args[0].Name, types.DecimalStr) {
+				if !strings.EqualFold(args[0].Name, types.NumericStr) {
 					return nil, fmt.Errorf("%w: expected argument to be numeric, got %s", ErrType, args[0].String())
 				}
 

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -788,11 +788,6 @@ func Test_Roundtrip(t *testing.T) {
 		},
 		{
 			name:     "decimal",
-			datatype: "DECIMAL",
-			value:    mustDecimal("100.101"),
-		},
-		{
-			name:     "explicit_decimal",
 			datatype: "DECIMAL(70,5)",
 			value:    mustExplicitDecimal("100.101", 70, 5),
 		},
@@ -800,6 +795,41 @@ func Test_Roundtrip(t *testing.T) {
 			name:     "uuid",
 			datatype: "UUID",
 			value:    mustUUID("d3b3b3b3-3b3b-3b3b-3b3b-3b3b3b3b3b3b"),
+		},
+		{
+			name:     "bytea",
+			datatype: "BYTEA",
+			value:    []byte("hello"),
+		},
+		{
+			name:     "int_array",
+			datatype: "INT[]",
+			value:    []int64{1, 2},
+		},
+		{
+			name:     "text_array",
+			datatype: "TEXT[]",
+			value:    []string{"hello", "world"},
+		},
+		{
+			name:     "bool_array",
+			datatype: "BOOL[]",
+			value:    []bool{true, false},
+		},
+		{
+			name:     "decimal_array",
+			datatype: "DECIMAL(70,5)[]",
+			value:    []*decimal.Decimal{mustExplicitDecimal("100.101", 70, 5), mustExplicitDecimal("200.202", 70, 5)},
+		},
+		{
+			name:     "uuid_array",
+			datatype: "UUID[]",
+			value:    []*types.UUID{mustUUID("d3b3b3b3-3b3b-3b3b-3b3b-3b3b3b3b3b3b"), mustUUID("d3b3b3b3-3b3b-3b3b-3b3b-3b3b3b3b3b3b")},
+		},
+		{
+			name:     "bytea_array",
+			datatype: "BYTEA[]",
+			value:    [][]byte{[]byte("hello"), []byte("world")},
 		},
 	}
 
@@ -818,11 +848,11 @@ func Test_Roundtrip(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			// we will create a table with the datatype
 			// and then insert the value into the table
-			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("CREATE TABLE tbl_%s (val %s primary key);", test.name, test.datatype), nil, nil)
+			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("CREATE TABLE tbl_%s (id int primary key, val %s);", test.name, test.datatype), nil, nil)
 			require.NoError(t, err)
 
 			// insert the value
-			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("INSERT INTO tbl_%s (val) VALUES ($val);", test.name), map[string]common.EngineValue{"$val": mustVal(test.value)}, nil)
+			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("INSERT INTO tbl_%s (id, val) VALUES (1, $val);", test.name), map[string]common.EngineValue{"$val": mustVal(test.value)}, nil)
 			require.NoError(t, err)
 
 			// select the value
@@ -837,6 +867,16 @@ func Test_Roundtrip(t *testing.T) {
 			require.NoError(t, err)
 
 			require.True(t, boolVal.Bool.Bool)
+
+			// roundtrip nulls as well
+			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("INSERT INTO tbl_%s (id, val) VALUES (2, NULL);", test.name), nil, nil)
+			require.NoError(t, err)
+
+			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("SELECT val FROM tbl_%s WHERE id = 2;", test.name), nil, func(r *common.Row) error {
+				assert.True(t, r.Values[0].Null())
+				return nil
+			})
+			require.NoError(t, err)
 		})
 	}
 }
@@ -1631,7 +1671,12 @@ func Test_Extensions(t *testing.T) {
 					}
 
 					if inputs[0].Null() || inputs[1].Null() {
-						return resultFn([]precompiles.Value{precompiles.MakeNull(types.TextType)})
+						nv, err := precompiles.NewValue(types.TextType)
+						if err != nil {
+							return err
+						}
+
+						return resultFn([]precompiles.Value{nv})
 					}
 
 					return resultFn([]precompiles.Value{precompiles.MakeText(inputs[0].RawValue().(string) + inputs[1].RawValue().(string))})

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -761,46 +761,85 @@ func Test_SQL(t *testing.T) {
 	}
 }
 
-// // Test_Roundtrip tries roundtripping each data type
-// // to the database
-// func Test_Roundtrip(t *testing.T) {
-// 	type testcase struct {
-// 		name     string
-// 		datatype string
-// 		value    any
-// 	}
+// Test_Roundtrip tries roundtripping each data type
+// to the database
+func Test_Roundtrip(t *testing.T) {
+	type testcase struct {
+		name     string
+		datatype string
+		value    any
+	}
 
-// 	tests := []testcase{}
+	tests := []testcase{
+		{
+			name:     "int",
+			datatype: "INT",
+			value:    int64(100),
+		},
+		{
+			name:     "text",
+			datatype: "TEXT",
+			value:    "hello",
+		},
+		{
+			name:     "bool",
+			datatype: "BOOL",
+			value:    true,
+		},
+		{
+			name:     "decimal",
+			datatype: "DECIMAL",
+			value:    mustDecimal("100.101"),
+		},
+		{
+			name:     "explicit_decimal",
+			datatype: "DECIMAL(70,5)",
+			value:    mustExplicitDecimal("100.101", 70, 5),
+		},
+		{
+			name:     "uuid",
+			datatype: "UUID",
+			value:    mustUUID("d3b3b3b3-3b3b-3b3b-3b3b-3b3b3b3b3b3b"),
+		},
+	}
 
-// 	db, err := newTestDB()
-// 	require.NoError(t, err)
-// 	defer db.Close()
+	db, err := newTestDB()
+	require.NoError(t, err)
+	defer db.Close()
 
-// 	ctx := context.Background()
-// 	tx, err := db.BeginTx(ctx)
-// 	require.NoError(t, err)
-// 	defer tx.Rollback(ctx) // always rollback
+	ctx := context.Background()
+	tx, err := db.BeginTx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx) // always rollback
 
-// 	interp := newTestInterp(t, tx, nil, false)
+	interp := newTestInterp(t, tx, nil, false)
 
-// 	for _, test := range tests {
-// 		// we will create a table with the datatype
-// 		// and then insert the value into the table
-// 		err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("CREATE TABLE tbl_%s (val %s);", test.datatype, test.datatype), nil, nil)
-// 		require.NoError(t, err)
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			// we will create a table with the datatype
+			// and then insert the value into the table
+			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("CREATE TABLE tbl_%s (val %s primary key);", test.name, test.datatype), nil, nil)
+			require.NoError(t, err)
 
-// 		// insert the value
-// 		err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("INSERT INTO tbl_%s (val) VALUES ($val);", test.datatype), map[string]common.EngineValue{"$val": mustVal(test.value)}, nil)
-// 		require.NoError(t, err)
+			// insert the value
+			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("INSERT INTO tbl_%s (val) VALUES ($val);", test.name), map[string]common.EngineValue{"$val": mustVal(test.value)}, nil)
+			require.NoError(t, err)
 
-// 		// select the value
-// 		var value precompiles.Value
-// 		err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("SELECT val FROM tbl_%s;", test.datatype), nil, func(r *common.Row) error {
-// 			value = r.Values[0].(precompiles.Value)
-// 			return nil
-// 		})
-// 	}
-// }
+			// select the value
+			var value precompiles.Value
+			err = interp.ExecuteWithoutEngineCtx(ctx, tx, fmt.Sprintf("SELECT val FROM tbl_%s;", test.name), nil, func(r *common.Row) error {
+				value = r.Values[0].(precompiles.Value)
+				return nil
+			})
+			require.NoError(t, err)
+
+			boolVal, err := value.Compare(mustVal(test.value), engine.EQUAL)
+			require.NoError(t, err)
+
+			require.True(t, boolVal.Bool.Bool)
+		})
+	}
+}
 
 func mustVal(v any) precompiles.Value {
 	val, err := precompiles.NewValue(v)

--- a/node/engine/interpreter/planner.go
+++ b/node/engine/interpreter/planner.go
@@ -176,7 +176,12 @@ type stmtFunc func(exec *executionContext, fn resultFunc) error
 
 func (i *interpreterPlanner) VisitActionStmtDeclaration(p0 *parse.ActionStmtDeclaration) any {
 	return stmtFunc(func(exec *executionContext, fn resultFunc) error {
-		return exec.allocateVariable(p0.Variable.Name, precompiles.MakeNull(p0.Type))
+		nv, err := precompiles.MakeNull(p0.Type)
+		if err != nil {
+			return err
+		}
+
+		return exec.allocateVariable(p0.Variable.Name, nv)
 	})
 }
 
@@ -499,7 +504,7 @@ func (i *interpreterPlanner) VisitLoopTermExpression(p0 *parse.LoopTermExpressio
 		}
 
 		for i := range arr.Len() {
-			scalar, err := arr.Index(i + 1) // all arrays are 1-indexed
+			scalar, err := arr.Get(i + 1) // all arrays are 1-indexed
 			if err != nil {
 				return err
 			}
@@ -843,7 +848,7 @@ func (i *interpreterPlanner) VisitExpressionArrayAccess(p0 *parse.ExpressionArra
 				return nil, err
 			}
 
-			return arr.Index(int32(index.RawValue().(int64)))
+			return arr.Get(int32(index.RawValue().(int64)))
 		}
 
 		// 1-indexed
@@ -900,7 +905,7 @@ func (i *interpreterPlanner) VisitExpressionArrayAccess(p0 *parse.ExpressionArra
 
 		j := int32(1)
 		for i := start; i <= end; i++ {
-			idx, err := arr.Index(i)
+			idx, err := arr.Get(i)
 			if err != nil {
 				return nil, err
 			}
@@ -1046,11 +1051,11 @@ func makeLogicalFunc(left, right exprFunc, and bool) exprFunc {
 		}
 
 		if leftVal.Null() {
-			return precompiles.MakeNull(types.BoolType), nil
+			return precompiles.MakeNull(types.BoolType)
 		}
 
 		if rightVal.Null() {
-			return precompiles.MakeNull(types.BoolType), nil
+			return precompiles.MakeNull(types.BoolType)
 		}
 
 		if leftVal.Type() != types.BoolType || rightVal.Type() != types.BoolType {

--- a/node/engine/interpreter/sql.go
+++ b/node/engine/interpreter/sql.go
@@ -461,7 +461,7 @@ func getExtensionInitializationMetadata(ctx context.Context, db sql.DB) ([]*stor
 // getTypeMetadata gets the serialized type metadata.
 // If there is none, it returns nil.
 func getTypeMetadata(t *types.DataType) []byte {
-	if t.Metadata == types.ZeroMetadata {
+	if !t.HasMetadata() {
 		return nil
 	}
 

--- a/node/engine/planner/logical/planner_test.go
+++ b/node/engine/planner/logical/planner_test.go
@@ -158,7 +158,7 @@ func Test_Planner(t *testing.T) {
 		{
 			name: "aggregate without group by",
 			sql:  "select sum(age) from users",
-			wt: "Return: sum [decimal(1000,0)]\n" +
+			wt: "Return: sum [numeric(1000,0)]\n" +
 				"└─Project: {#ref(A)}\n" +
 				"  └─Aggregate: {#ref(A) = sum(users.age)}\n" +
 				"    └─Scan Table: users [physical]\n",
@@ -166,7 +166,7 @@ func Test_Planner(t *testing.T) {
 		{
 			name: "aggregate with group by",
 			sql:  "select name, sum(age) from users where name = 'a' group by name having sum(age)::int8 > 100",
-			wt: "Return: name [text], sum [decimal(1000,0)]\n" +
+			wt: "Return: name [text], sum [numeric(1000,0)]\n" +
 				"└─Project: {#ref(A)}; {#ref(B)}\n" +
 				"  └─Filter: {#ref(B)}::int8 > 100\n" +
 				"    └─Aggregate [{#ref(A) = users.name}]: {#ref(B) = sum(users.age)}\n" +
@@ -223,7 +223,7 @@ func Test_Planner(t *testing.T) {
 		{
 			name: "complex having",
 			sql:  "select name, sum(age/2)+sum(age*10) from users group by name having sum(age)::int8 > 100 or sum(age/2)::int8 > 10",
-			wt: "Return: name [text], ?column? [decimal(1000,0)]\n" +
+			wt: "Return: name [text], ?column? [numeric(1000,0)]\n" +
 				"└─Project: {#ref(A)}; {#ref(C)} + {#ref(D)}\n" +
 				"  └─Filter: {#ref(B)}::int8 > 100 OR {#ref(C)}::int8 > 10\n" +
 				"    └─Aggregate [{#ref(A) = users.name}]: {#ref(B) = sum(users.age)}; {#ref(C) = sum(users.age / 2)}; {#ref(D) = sum(users.age * 10)}\n" +
@@ -271,7 +271,7 @@ func Test_Planner(t *testing.T) {
 		{
 			name: "basic inline window",
 			sql:  "select name, sum(age) over (partition by name) from users",
-			wt: "Return: name [text], sum [decimal(1000,0)]\n" +
+			wt: "Return: name [text], sum [numeric(1000,0)]\n" +
 				"└─Project: users.name; {#ref(A)}\n" +
 				"  └─Window [partition_by=users.name]: {#ref(A) = sum(users.age)}\n" +
 				"    └─Scan Table: users [physical]\n",
@@ -279,7 +279,7 @@ func Test_Planner(t *testing.T) {
 		{
 			name: "named window used several times",
 			sql:  "select name, sum(age) over w1, array_agg(name) over w1 from users window w1 as (partition by name order by age)",
-			wt: "Return: name [text], sum [decimal(1000,0)], array_agg [text[]]\n" +
+			wt: "Return: name [text], sum [numeric(1000,0)], array_agg [text[]]\n" +
 				"└─Project: users.name; {#ref(A)}; {#ref(B)}\n" +
 				"  └─Window [partition_by=users.name] [order_by=users.age asc nulls last]: {#ref(A) = sum(users.age)}; {#ref(B) = array_agg(users.name)}\n" +
 				"    └─Scan Table: users [physical]\n",
@@ -365,7 +365,7 @@ func Test_Planner(t *testing.T) {
 		{
 			name: "sort with group by",
 			sql:  "select name, sum(age) from users group by name order by name, sum(age)",
-			wt: "Return: name [text], sum [decimal(1000,0)]\n" +
+			wt: "Return: name [text], sum [numeric(1000,0)]\n" +
 				"└─Project: {#ref(A)}; {#ref(B)}\n" +
 				"  └─Sort: {#ref(A)} asc nulls last; {#ref(B)} asc nulls last\n" +
 				"    └─Aggregate [{#ref(A) = users.name}]: {#ref(B) = sum(users.age)}\n" +
@@ -405,7 +405,7 @@ func Test_Planner(t *testing.T) {
 		{
 			name: "distinct aggregate",
 			sql:  "select count(distinct name), sum(age) from users",
-			wt: "Return: count [int8], sum [decimal(1000,0)]\n" +
+			wt: "Return: count [int8], sum [numeric(1000,0)]\n" +
 				"└─Project: {#ref(A)}; {#ref(B)}\n" +
 				"  └─Aggregate: {#ref(A) = count(distinct users.name)}; {#ref(B) = sum(users.age)}\n" +
 				"    └─Scan Table: users [physical]\n",


### PR DESCRIPTION
This PR fixes several bugs within the engine. It fixes the bug that @KwilLuke hit where decimal arrays are not handled properly from the DB. It also adds better testing to the info namespace.

It slightly changes the info schema to make it easier to use. It also adds exponentiation to the engine.