### PR TITLE
fixes to app, block store, ce

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,8 +16,10 @@ linters-settings:
   sloglint:
     forbidden-keys: ["time","level","msg","source"]
   govet:
-    enable:
-      - stdversion
+    enable-all: true
+    disable:
+      - fieldalignment
+      - shadow
 
 linters:
   disable-all: true

--- a/app/block/abort.go
+++ b/app/block/abort.go
@@ -1,21 +1,29 @@
 package block
 
 import (
+	"fmt"
+	"strconv"
+
 	"github.com/kwilteam/kwil-db/app/rpc"
 	"github.com/kwilteam/kwil-db/app/shared/display"
 	"github.com/spf13/cobra"
 )
 
 func abortCmd() *cobra.Command {
-	var blockHeight int64
 	var txIDs []string
 
 	cmd := &cobra.Command{
-		Use:   "abort <block_height> <tx_ids>",
-		Short: "Aborts the execution of the current block if it's at block_height and removes the tx_ids from the mempool.",
-		Args:  cobra.NoArgs,
+		Use:   `abort <block_height>`,
+		Short: "Abort active execution of the current block.",
+		Long:  "Aborts the execution of the current block if it is at given height, and removes specified transactions from the mempool.",
+		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := cmd.Context()
+
+			blockHeight, err := strconv.ParseInt(args[0], 10, 64)
+			if err != nil {
+				return display.PrintErr(cmd, fmt.Errorf("invalid block height: %w", err))
+			}
 
 			clt, err := rpc.AdminSvcClient(ctx, cmd)
 			if err != nil {
@@ -31,7 +39,7 @@ func abortCmd() *cobra.Command {
 		},
 	}
 
-	cmd.Flags().Int64VarP(&blockHeight, "block_height", "b", 0, "Block height to rollback")
-	cmd.Flags().StringSliceVarP(&txIDs, "tx_ids", "t", nil, "Transaction IDs to remove from the mempool")
+	cmd.Flags().StringSliceVarP(&txIDs, "txns", "t", nil, "Transaction IDs to remove from the mempool")
+
 	return cmd
 }

--- a/app/block/cmd.go
+++ b/app/block/cmd.go
@@ -8,8 +8,8 @@ import (
 
 var blockCmd = &cobra.Command{
 	Use:   "block",
-	Short: "",
-	Long:  "",
+	Short: "Leader block execution commands",
+	Long:  "The block command group has subcommands for managing leader block execution, including status and aborting.",
 }
 
 func NewBlockExecCmd() *cobra.Command {

--- a/app/block/status.go
+++ b/app/block/status.go
@@ -14,7 +14,7 @@ import (
 func statusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "status",
-		Short:   "Get the status of the ongoing block execution.",
+		Short:   "Get the status of any ongoing block execution.",
 		Example: "kwild block status",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/app/key/cmd.go
+++ b/app/key/cmd.go
@@ -11,15 +11,13 @@ import (
 	"github.com/kwilteam/kwil-db/core/crypto"
 )
 
-const keyExplain = "The `key` command provides subcommands for private key generation and inspection."
-
-var keyCmd = &cobra.Command{
-	Use:   "key",
-	Short: keyExplain,
-	Long:  "The `key` command provides subcommands for private key generation and inspection. These are the private keys that identify the node on the network and provide validator transaction signing capability.",
-}
-
 func KeyCmd() *cobra.Command {
+	keyCmd := &cobra.Command{
+		Use:   "key",
+		Short: "Tools for private key generation and inspection",
+		Long:  "The key command provides subcommands for private key generation and inspection. These are the private keys that identify the node on the network and provide validator transaction signing capability.",
+	}
+
 	keyCmd.AddCommand(
 		GenCmd(),
 		InfoCmd(),

--- a/app/key/gen.go
+++ b/app/key/gen.go
@@ -25,8 +25,8 @@ func GenCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "gen [<keytype>]",
-		Short:   "Generate private keys for usage in validators.",
-		Long:    "Generate private keys for usage in validators.",
+		Short:   "Generate a private key for validator use.",
+		Long:    "The gen command generates a private key for use by validators.",
 		Example: genExample,
 		Args:    cobra.RangeArgs(0, 1),
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/app/migration/cmd.go
+++ b/app/migration/cmd.go
@@ -9,8 +9,8 @@ import (
 
 var migrationCmd = &cobra.Command{
 	Use:   "migrate",
-	Short: "The `migrate` command provides functions for managing migration proposals.",
-	Long:  "The `migrate` command provides functions for managing migration proposals.",
+	Short: "Management of migration proposals",
+	Long:  "The migrate command provides functions for managing network migration proposals.",
 }
 
 func NewMigrationCmd() *cobra.Command {

--- a/app/node/printcfg.go
+++ b/app/node/printcfg.go
@@ -14,6 +14,7 @@ func PrintConfigCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "print-config",
 		Short: "Print the node configuration",
+		Long:  `The print-config command shows the parsed node configuration based on the combination of the default configuration, configuration file, flags,and environment variables. The configuration is printed to stdout in TOML format. All flags available to the start command are recognized by this command.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			_, err := bind.RootDir(cmd)
 			if err != nil {

--- a/app/node/start.go
+++ b/app/node/start.go
@@ -16,13 +16,14 @@ func StartCmd() *cobra.Command {
 	var dbOwner string
 	cmd := &cobra.Command{
 		Use:               "start",
-		Short:             "start the node (default command)",
-		Long:              "Start the node running",
+		Short:             "Start the node (default command if none given)",
+		Long:              "The start command starts the Kwil DB blockchain node.",
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
+		Args:    cobra.NoArgs,
 		Version: version.KwilVersion,
 		Example: custom.BinaryConfig.NodeCmd + " start -r .testnet",
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/app/params/cmd.go
+++ b/app/params/cmd.go
@@ -8,8 +8,8 @@ import (
 
 var consensusCmd = &cobra.Command{
 	Use:   "consensus",
-	Short: "Functions for dealing with consensus update proposals.",
-	Long:  "The `consensus` command provides functions for dealing with consensus update proposals.",
+	Short: "Functions for dealing with consensus update proposals",
+	Long:  "The consensus command provides functions for dealing with consensus update proposals.",
 }
 
 func NewConsensusCmd() *cobra.Command {

--- a/app/root.go
+++ b/app/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kwilteam/kwil-db/app/setup"
 	"github.com/kwilteam/kwil-db/app/shared/bind"
 	"github.com/kwilteam/kwil-db/app/shared/display"
+	verCmd "github.com/kwilteam/kwil-db/app/shared/version"
 	"github.com/kwilteam/kwil-db/app/snapshot"
 	"github.com/kwilteam/kwil-db/app/utils"
 	"github.com/kwilteam/kwil-db/app/validator"
@@ -67,6 +68,7 @@ func RootCmd() *cobra.Command {
 	// There is a virtual "node" command grouping, but no actual "node" command yet.
 	cmd.AddCommand(node.StartCmd())
 	cmd.AddCommand(node.PrintConfigCmd())
+
 	cmd.AddCommand(rpc.NewAdminCmd())
 	cmd.AddCommand(validator.NewValidatorsCmd())
 	cmd.AddCommand(params.NewConsensusCmd())
@@ -78,6 +80,7 @@ func RootCmd() *cobra.Command {
 	cmd.AddCommand(block.NewBlockExecCmd())
 	cmd.AddCommand(seed.SeedCmd())
 	cmd.AddCommand(utils.NewCmdUtils())
+	cmd.AddCommand(verCmd.NewVersionCmd())
 
 	return cmd
 }

--- a/app/rpc/cmd.go
+++ b/app/rpc/cmd.go
@@ -1,15 +1,16 @@
 package rpc
 
 import (
+	"github.com/kwilteam/kwil-db/app/shared/display"
 	"github.com/spf13/cobra"
 )
 
-const adminExplain = "The `admin` command is used to get information about a running Kwil node."
+const adminExplain = "The admin command is used to get information about a running Kwil node using the admin RPC service."
 
 func NewAdminCmd() *cobra.Command {
 	adminCmd := &cobra.Command{
 		Use:   "admin",
-		Short: "commands for admin RPCs",
+		Short: "Administrative commands using the secure admin RPC service",
 		Long:  adminExplain,
 	}
 
@@ -22,7 +23,7 @@ func NewAdminCmd() *cobra.Command {
 	)
 
 	BindRPCFlags(adminCmd)
-	// display.BindOutputFormatFlag(adminCmd)
+	display.BindOutputFormatFlag(adminCmd)
 
 	return adminCmd
 }

--- a/app/rpc/dump-cfg.go
+++ b/app/rpc/dump-cfg.go
@@ -11,15 +11,15 @@ import (
 )
 
 var (
-	dumpCfgLong    = `Gets the current config from the node.`
+	dumpCfgLong    = `The dump-config command retrieves and displays the active config from the running node.`
 	dumpCfgExample = `# Get the current config from the node.
-kwil-admin node dump-config --rpcserver /tmp/kwild.socket`
+kwild admin dump-config --rpcserver /tmp/kwild.socket`
 )
 
 func dumpCfgCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "dump-config",
-		Short:   "Gets the current config from the node.",
+		Short:   "Get and display the current config from the node.",
 		Long:    dumpCfgLong,
 		Example: dumpCfgExample,
 		Args:    cobra.NoArgs,

--- a/app/rpc/peers.go
+++ b/app/rpc/peers.go
@@ -10,10 +10,10 @@ import (
 )
 
 var (
-	peersLong = `Print a list of the node's peers, with their public information.`
+	peersLong = `The peers command retrieves and print a list of the node's peers, with their public information.`
 
 	peersExample = `# Print a list of the node's peers
-kwil-admin node peers --rpcserver /tmp/kwild.socket`
+kwild admin peers --rpcserver /tmp/kwild.socket`
 )
 
 func peersCmd() *cobra.Command {

--- a/app/rpc/status.go
+++ b/app/rpc/status.go
@@ -4,16 +4,17 @@ import (
 	"context"
 	"encoding/json"
 
+	"github.com/spf13/cobra"
+
 	"github.com/kwilteam/kwil-db/app/shared/display"
 	types "github.com/kwilteam/kwil-db/core/types/admin"
-	"github.com/spf13/cobra"
 )
 
 var (
-	statusLong = `Print the node's status information.`
+	statusLong = `The status command retrieves and prints the node's status.`
 
-	statusExample = `# Print a remote node's status (TLS with self-signed certificate)
-kwil-admin node status --rpcserver /tmp/kwild.socket`
+	statusExample = `# Print a running node's status
+kwild admin status --rpcserver /tmp/kwild.socket`
 )
 
 func statusCmd() *cobra.Command {

--- a/app/rpc/version.go
+++ b/app/rpc/version.go
@@ -8,7 +8,7 @@ import (
 )
 
 var (
-	versionLong = `Print the node's version information. The version is the Kwil's version string, set at compile time.`
+	versionLong = `The version command retrieves and prints the node's version information. The version is the Kwil's version string, set at compile time.`
 
 	versionExample = `# Print the node's version information
 kwil-admin node version --rpcserver /tmp/kwild.socket`
@@ -17,10 +17,11 @@ kwil-admin node version --rpcserver /tmp/kwild.socket`
 func versionCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "version",
-		Short:   "Print the node's version information.",
+		Short:   "Print the node's version.",
 		Long:    versionLong,
 		Example: versionExample,
 		Args:    cobra.NoArgs,
+		Aliases: []string{"ver"},
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			ctx := context.Background()
 			client, err := AdminSvcClient(ctx, cmd)

--- a/app/seed/seed.go
+++ b/app/seed/seed.go
@@ -16,20 +16,15 @@ import (
 	"github.com/kwilteam/kwil-db/node/peers/seeder"
 )
 
-var (
-	genExample = `# Run a seeder for peer exchange bootstrapping`
-)
-
 func SeedCmd() *cobra.Command {
 	var dir, chainID string
 	var bootnodes []string
 
 	cmd := &cobra.Command{
-		Use:     "seed",
-		Short:   "Run seeder.",
-		Long:    "Runs a peer seeder to crawl and bootstrap the network.",
-		Example: genExample,
-		// Args:    cobra.NoArgs,
+		Use:   "seed",
+		Short: "Run a network seeder",
+		Long:  "The seed command starts a peer seeder process to crawl and bootstrap the network. This does not use the kwild node config. It will bind to TCP port 6609, and store config and data in the specified directory.",
+		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := log.New(log.WithWriter(os.Stdout), log.WithFormat(log.FormatUnstructured),
 				log.WithName("SEEDER"))

--- a/app/setup/genesis-hash.go
+++ b/app/setup/genesis-hash.go
@@ -45,7 +45,7 @@ func GenesisHashCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "genesis-hash",
-		Short:   "Compute genesis hash from existing PostgreSQL datasets, and optionally update `genesis.json`.",
+		Short:   "Compute genesis hash from existing PostgreSQL data, and optionally update genesis.json.",
 		Long:    genesisHashLong,
 		Example: genesisHashExample,
 		Args:    cobra.NoArgs,

--- a/app/setup/genesis.go
+++ b/app/setup/genesis.go
@@ -17,20 +17,18 @@ import (
 )
 
 var (
-	genesisLong = `` + "`" + `genesis` + "`" + ` creates a new genesis.json file.
+	genesisLong = `The genesis command creates a new genesis.json file with optionally specified modifications.
 
-This command creates a new genesis file with optionally specified modifications.
-
-Validators, balance allocations should have the format "pubkey:power", "address:balance" respectively.`
+Validators and balance allocations should have the format "pubkey:power", "address:balance" respectively.`
 
 	genesisExample = `# Create a new genesis.json file in the current directory
-kwil-admin setup genesis
+kwild setup genesis
 
 # Create a new genesis.json file in a specific directory with a specific chain ID and a validator with 1 power
-kwil-admin setup genesis --out /path/to/directory --chain-id mychainid --validator 890fe7ae9cb1fa6177555d5651e1b8451b4a9c64021c876236c700bc2690ff1d:1
+kwild setup genesis --out /path/to/directory --chain-id mychainid --validator 890fe7ae9cb1fa6177555d5651e1b8451b4a9c64021c876236c700bc2690ff1d:1
 
 # Create a new genesis.json with the specified allocation
-kwil-admin setup genesis --alloc 0x7f5f4552091a69125d5dfcb7b8c2659029395bdf:100`
+kwild setup genesis --alloc 0x7f5f4552091a69125d5dfcb7b8c2659029395bdf:100`
 )
 
 type genesisFlagConfig struct {
@@ -52,7 +50,7 @@ func GenesisCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:               "genesis",
-		Short:             "`genesis` creates a new genesis.json file",
+		Short:             "Create a new genesis.json file",
 		Long:              genesisLong,
 		Example:           genesisExample,
 		DisableAutoGenTag: true,
@@ -60,6 +58,7 @@ func GenesisCmd() *cobra.Command {
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outDir, err := node.ExpandPath(output)
 			if err != nil {

--- a/app/setup/init.go
+++ b/app/setup/init.go
@@ -30,7 +30,7 @@ var (
 )
 
 var (
-	initLong = `The ` + "`" + `init` + "`" + ` command facilitates quick setup of an isolated Kwil node either on a fresh network in which that node is the single validator or to join an existing network.
+	initLong = `The init command facilitates quick setup of an isolated Kwil node either on a fresh network in which that node is the single validator or to join an existing network.
 This permits rapid prototyping and evaluation of Kwil functionality. An output directory can be specified using the ` + "`" + `--output-dir` + "`" + `" flag.
 If no output directory is specified, the node will be initialized ` + "`" + `./testnet` + "`" + `.`
 
@@ -52,6 +52,7 @@ func InitCmd() *cobra.Command {
 		CompletionOptions: cobra.CompletionOptions{
 			DisableDefaultCmd: true,
 		},
+		Args: cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			genSnapshotFlag := cmd.Flag("genesis-snapshot").Changed
 			genStateFlag := cmd.Flag("genesis-state").Changed

--- a/app/setup/reset.go
+++ b/app/setup/reset.go
@@ -14,7 +14,7 @@ import (
 )
 
 var (
-	resetLong = `To delete all of a Kwil node's data files, use the ` + "`" + `reset` + "`" + ` command. If the root directory is not specified, the node's default root directory will be used.
+	resetLong = `To delete all of a Kwil node's data files, use the reset command. If the root directory is not specified, the node's default root directory will be used.
 
 WARNING: This command should not be used on production systems. This should only be used to reset disposable test nodes.`
 
@@ -27,7 +27,7 @@ func ResetCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:     "reset",
-		Short:   "Reset the blockchain and the application state",
+		Short:   "Reset blockchain data and the application state.",
 		Long:    resetLong,
 		Example: resetExample,
 		Args:    cobra.NoArgs,

--- a/app/setup/setup.go
+++ b/app/setup/setup.go
@@ -8,7 +8,7 @@ func SetupCmd() *cobra.Command {
 	- resetting node state and all data files (reset)`
 	setupCmd := &cobra.Command{
 		Use:   "setup",
-		Short: "The setup command provides functions for creating and managing node configuration and data.",
+		Short: "Tools for creating and managing node configuration and data",
 		Long:  setupLong,
 	}
 	setupCmd.AddCommand(ResetCmd(), TestnetCmd(), InitCmd(), GenesisCmd())

--- a/app/setup/testnet.go
+++ b/app/setup/testnet.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strconv"
 
+	"github.com/spf13/cobra"
+
 	"github.com/kwilteam/kwil-db/app/custom"
 	"github.com/kwilteam/kwil-db/app/key"
 	"github.com/kwilteam/kwil-db/app/shared/bind"
@@ -19,8 +21,6 @@ import (
 	"github.com/kwilteam/kwil-db/core/types"
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node"
-
-	"github.com/spf13/cobra"
 )
 
 // accept: #vals, #n-vals and set the first validator as the leader.
@@ -33,7 +33,7 @@ func TestnetCmd() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "testnet",
-		Short: "Generate configuration for multiple nodes",
+		Short: "Generate configuration for a new test network with multiple nodes",
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return GenerateTestnetConfigs(&TestnetConfig{
 				RootDir:      outDir,

--- a/app/shared/version/version.go
+++ b/app/shared/version/version.go
@@ -69,7 +69,7 @@ func (v *respVersionInfo) MarshalText() ([]byte, error) {
 func NewVersionCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:   "version",
-		Short: "Displays the cli version information.",
+		Short: "Display the application version",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			resp := &respVersionInfo{

--- a/app/snapshot/cmd.go
+++ b/app/snapshot/cmd.go
@@ -8,7 +8,7 @@ const (
 
 var snapshotCmd = &cobra.Command{
 	Use:   "snapshot",
-	Short: "snapshot related actions",
+	Short: "Snapshot related actions",
 	Long:  snapshotExplain,
 }
 

--- a/app/snapshot/create.go
+++ b/app/snapshot/create.go
@@ -58,7 +58,7 @@ func createCmd() *cobra.Command {
 	var snapshotDir string
 	cmd := &cobra.Command{
 		Use:     "create",
-		Short:   "Creates a snapshot of the database.",
+		Short:   "Creates a snapshot of the database for use with a new network.",
 		Long:    createLongExplain,
 		Example: createExample,
 		Args:    cobra.NoArgs,

--- a/app/validator/approve.go
+++ b/app/validator/approve.go
@@ -11,16 +11,16 @@ import (
 )
 
 var (
-	approveLong = "A current validator may approve an active join request for a candidate validator using the `approve` subcommand. If enough validators approve the join request, the candidate validator will be added to the validator set."
+	approveLong = "The approve command creates and approves an active join request for a candidate validator using the node's validator keys to publish an approval transaction. If enough validators approve the join request, the candidate validator will be added to the validator set."
 
 	approveExample = `# Approve a join request for a candidate validator by providing the validator info in format <hexPubkey#pubkeytype>
-kwil-admin validators approve 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0#1`
+kwild validators approve 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0#1`
 )
 
 func approveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "approve <joiner>",
-		Short:   "A current validator may approve an active join request for a candidate validator using the `approve` subcommand.",
+		Short:   "Approve an active join request for a candidate validator (your node must be a validator).",
 		Long:    approveLong,
 		Example: approveExample,
 		Args:    cobra.ExactArgs(1),

--- a/app/validator/cmd.go
+++ b/app/validator/cmd.go
@@ -12,7 +12,7 @@ const validatorsLong = "The validators command provides functions for creating a
 func NewValidatorsCmd() *cobra.Command {
 	validatorsCmd := &cobra.Command{
 		Use:   "validators",
-		Short: "validator related actions",
+		Short: "Validator related actions",
 		Long:  validatorsLong,
 	}
 

--- a/app/validator/join-status.go
+++ b/app/validator/join-status.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	joinStatusLong    = `Query the status of a pending validator join request.`
+	joinStatusLong    = `The query command gets the status of a pending validator join request.`
 	joinStatusExample = `# Query the status of a pending validator join request, by providing the validator info in format <hexPubkey#pubkeytype>
 kwil-admin validators join-status 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd702fa3820c5034e9d0#0`
 )
@@ -26,7 +26,7 @@ kwil-admin validators join-status 6ecaca8e9394c939a858c2c7b47acb1db26a96d7ab38bd
 func joinStatusCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "join-status <joiner>",
-		Short:   "Query the status of a pending validator join request.",
+		Short:   "Get the status of a pending validator join request.",
 		Long:    joinStatusLong,
 		Example: joinStatusExample,
 		Args:    cobra.ExactArgs(1),

--- a/app/validator/join.go
+++ b/app/validator/join.go
@@ -10,16 +10,16 @@ import (
 )
 
 var (
-	joinLong = "A node may request to join the validator set by submitting a join request using the `join` command. The key used to sign the join request will be the treated as the node request to join the validator set. The node will be added to the validator set if the join request is approved by the current validator set. The status of a join request can be queried using the `join-status` command."
+	joinLong = "The join command submitting a request to join the validator set. This node will be the subject of the request. The node will be added to the validator set if the join request is approved by the current validator set. The status of a join request can be queried using the join-status command."
 
 	joinExample = `# Request to join the validator set
-kwil-admin validators join`
+kwild validators join`
 )
 
 func joinCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "join",
-		Short:   "A node may request to join the validator set by submitting a join request using the `join` command.",
+		Short:   "Request to join the validator set.",
 		Long:    joinLong,
 		Example: joinExample,
 		Args:    cobra.NoArgs,

--- a/app/validator/leave.go
+++ b/app/validator/leave.go
@@ -10,7 +10,7 @@ import (
 )
 
 var (
-	leaveLong = "A current validator may leave the validator set using the `leave` command."
+	leaveLong = "The leave command submits a transaction to leave the validator set. This node will be removed from the validator set if the transaction is included in a block."
 
 	leaveExample = `# Leave the validator set
 kwil-admin validators leave`
@@ -19,7 +19,7 @@ kwil-admin validators leave`
 func leaveCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "leave",
-		Short:   "A current validator may leave the validator set using the `leave` command.",
+		Short:   "Leave the validator set (your node must be a validator).",
 		Long:    leaveLong,
 		Example: leaveExample,
 		Args:    cobra.NoArgs,

--- a/app/validator/list-join-requests.go
+++ b/app/validator/list-join-requests.go
@@ -15,13 +15,13 @@ import (
 )
 
 var (
-	listJoinRequestsLong = `Command ` + "`" + `list-join-requests` + "`" + ` lists all pending join requests.
+	listJoinRequestsLong = `The list-join-requests command lists all pending join requests.
 	
 Join requests are created when a validator wants to join the validator set. The validator must be approved by 2/3 of the current validator set to be added to the validator set.
 Each join request has an expiration block height, after which it is no longer valid.`
 
 	listJoinRequestsExample = `# List all pending join requests
-kwil-admin validators list-join-requests`
+kwild validators list-join-requests`
 )
 
 func listJoinRequestsCmd() *cobra.Command {
@@ -30,6 +30,7 @@ func listJoinRequestsCmd() *cobra.Command {
 		Short:   "List all pending join requests.",
 		Long:    listJoinRequestsLong,
 		Example: listJoinRequestsExample,
+		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()
 

--- a/app/validator/list.go
+++ b/app/validator/list.go
@@ -22,8 +22,8 @@ kwil-admin validators list`
 
 func listCmd() *cobra.Command {
 	cmd := &cobra.Command{
-		Use:     "list-validators", // validators list-validators
-		Aliases: []string{"list"},  // validators list
+		Use:     "list",                      // validators list
+		Aliases: []string{"list-validators"}, // validators list-validators
 		Short:   "List the current validator set of the network.",
 		Long:    listLong,
 		Example: listExample,

--- a/app/validator/remove.go
+++ b/app/validator/remove.go
@@ -11,7 +11,7 @@ import (
 )
 
 var (
-	removeLong = "Command `remove` votes to remove a validator from the validator set. If enough validators vote to remove the validator, the validator will be removed from the validator set."
+	removeLong = "The remove command votes to remove a validator from the validator set. If enough validators vote to remove the validator, the validator will be removed from the validator set."
 
 	removeExample = `# Remove a validator from the validator set by providing the validator info in format <hexPubkey#pubkeytype>
 kwil-admin validators remove e16141e4def3a7f2dfc5bbf40d50619b4d7bc9c9f670fcad98327b0d3d7b97b6#0`
@@ -20,7 +20,7 @@ kwil-admin validators remove e16141e4def3a7f2dfc5bbf40d50619b4d7bc9c9f670fcad983
 func removeCmd() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "remove <validator>",
-		Short:   "Command `remove` votes to remove a validator from the validator set.",
+		Short:   "Votes to remove a validator from the validator set (this node must be a validator).",
 		Long:    removeLong,
 		Example: removeExample,
 		Args:    cobra.ExactArgs(1),

--- a/app/whitelist/add.go
+++ b/app/whitelist/add.go
@@ -13,8 +13,9 @@ import (
 func addCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "add <peerID>",
-		Short:   "Add a peer to the node's whitelist of peers to accept connections from.",
-		Example: "kwil-admin whitelist add <peerID>",
+		Short:   "Add a peer to the node's connection whitelist.",
+		Long:    "The add command adds a peer to the node's whitelist of peers to accept connections from.",
+		Example: "kwild whitelist add <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/app/whitelist/cmd.go
+++ b/app/whitelist/cmd.go
@@ -7,7 +7,7 @@ import (
 
 var peersCmd = &cobra.Command{
 	Use:   "whitelist",
-	Short: "The whitelist command is used to manage a node's peer whitelist.",
+	Short: "Manage a node's peer whitelist",
 }
 
 func WhitelistCmd() *cobra.Command {

--- a/app/whitelist/list.go
+++ b/app/whitelist/list.go
@@ -15,7 +15,8 @@ func listCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "list",
 		Short:   "List the peers in the node's whitelist.",
-		Example: "kwil-admin whitelist list",
+		Long:    "The list command lists the peers in the node's whitelist.",
+		Example: "kwild whitelist list",
 		Args:    cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/app/whitelist/remove.go
+++ b/app/whitelist/remove.go
@@ -14,7 +14,8 @@ func removeCmd() *cobra.Command {
 	var cmd = &cobra.Command{
 		Use:     "remove <peerID>",
 		Short:   "Remove a peer from the node's whitelist and disconnect it.",
-		Example: "kwil-admin whitelist remove <peerID>",
+		Long:    "The remove command removes a peer from the node's whitelist and disconnects it.",
+		Example: "kwild whitelist remove <peerID>",
 		Args:    cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			ctx := context.Background()

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -148,7 +148,7 @@ func (r *respCall) MarshalText() (text []byte, err error) {
 }
 
 // buildProcedureInputs will build the inputs for either
-// an action or procedure executon/call.
+// an action or procedure execution/call.
 func buildExecutionInputs(ctx context.Context, client clientType.Client, namespace string, action string, inputs []map[string]string) ([][]any, error) {
 	params, err := GetParamList(ctx, client.Query, namespace, action)
 	if err != nil {
@@ -195,10 +195,10 @@ func GetParamList(ctx context.Context,
 	}
 
 	if len(res.Values) == 0 {
-		return nil, errors.New(`action "%s" not found in namespace "%s"`)
+		return nil, fmt.Errorf(`action "%s" not found in namespace "%s"`, action, namespace)
 	}
 	if len(res.Values) > 1 {
-		return nil, errors.New(`action "%s" is ambiguous in namespace "%s"`)
+		return nil, fmt.Errorf(`action "%s" is ambiguous in namespace "%s"`, action, namespace)
 	}
 
 	var paramNames []string

--- a/config/config.go
+++ b/config/config.go
@@ -18,6 +18,14 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
+const (
+	ConfigFileName  = "config.toml"
+	GenesisFileName = "genesis.json"
+
+	DefaultAdminRPCAddr = "/tmp/kwild.socket"
+	AdminCertName       = "admin.cert"
+)
+
 // Duration is a wrapper around time.Duration that implements text
 // (un)marshalling for the go-toml package to work with Go duration strings
 // instead of integers.
@@ -229,10 +237,10 @@ func DefaultConfig() *Config {
 		},
 		Admin: AdminConfig{
 			Enable:        true,
-			ListenAddress: "/tmp/kwild.socket",
+			ListenAddress: DefaultAdminRPCAddr,
 			Pass:          "",
 			NoTLS:         false,
-			TLSCertFile:   "admin.cert",
+			TLSCertFile:   AdminCertName,
 			TLSKeyFile:    "admin.key",
 		},
 		Snapshots: SnapshotConfig{

--- a/core/client/tx.go
+++ b/core/client/tx.go
@@ -8,17 +8,6 @@ import (
 	"github.com/kwilteam/kwil-db/core/types"
 )
 
-// NewSignedTx creates a signed transaction with a prepared payload. This will
-// set the nonce to signer's latest, build the Transaction, set the Fee, and
-// sign the transaction. It may then be broadcast on a kwil network. The
-// TxOptions may be set to override the nonce and fee.
-//
-// WARNING: This is an advanced method, and most applications should use the
-// other Client methods to interact with a Kwil network.
-func (c *Client) NewSignedTx(ctx context.Context, data types.Payload, txOpts *clientType.TxOptions) (*types.Transaction, error) {
-	return c.newTx(ctx, data, txOpts)
-}
-
 // newTx creates a new Transaction signed by the Client's Signer
 func (c *Client) newTx(ctx context.Context, data types.Payload, txOpts *clientType.TxOptions) (*types.Transaction, error) {
 	if c.Signer() == nil {

--- a/core/rpc/client/admin/jsonrpc/client.go
+++ b/core/rpc/client/admin/jsonrpc/client.go
@@ -140,7 +140,7 @@ func (cl *Client) Status(ctx context.Context) (*adminTypes.Status, error) {
 	if err != nil {
 		return nil, err
 	}
-	// TODO: convert!
+
 	return &adminTypes.Status{
 		Node: res.Node,
 		Sync: &adminTypes.SyncInfo{

--- a/core/rpc/json/admin/responses.go
+++ b/core/rpc/json/admin/responses.go
@@ -16,6 +16,11 @@ type StatusResponse struct {
 
 type NodeInfo = adminTypes.NodeInfo
 
+// type NodeInfo struct {
+// 	adminTypes.NodeInfo
+// 	RPCAddr string `json:"rpc_addr"`
+// }
+
 // type SyncInfo = adminTypes.SyncInfo
 // type Validator = adminTypes.ValidatorInfo
 type Validator = types.Validator

--- a/core/types/admin/types.go
+++ b/core/types/admin/types.go
@@ -8,17 +8,14 @@ import (
 	"github.com/kwilteam/kwil-db/core/types"
 )
 
-// NodeInfo describes a peer node. This may be a peer or a node being
-// administered.
+// NodeInfo describes the administered node.
 type NodeInfo struct {
-	ChainID         string `json:"chain_id"`
-	Name            string `json:"name"`
-	NodeID          string `json:"node_id"`
-	ProtocolVersion uint64 `json:"proto_ver"`
-	AppVersion      uint64 `json:"app_ver"`
-	BlockVersion    uint64 `json:"block_ver"`
-	ListenAddr      string `json:"listen_addr"`
-	RPCAddr         string `json:"rpc_addr"`
+	ChainID    string `json:"chain_id"`
+	NodeID     string `json:"node_id"`
+	AppVersion uint64 `json:"app_ver"`
+	ListenAddr string `json:"listen_addr"`
+	Role       string `json:"role"`
+	RPCAddr    string `json:"rpc_addr"`
 }
 
 // SyncInfo describes the sync state of a node.
@@ -46,9 +43,9 @@ type Status struct {
 
 // PeerInfo describes a connected peer node.
 type PeerInfo struct {
-	NodeInfo   *NodeInfo `json:"node"`
-	Inbound    bool      `json:"inbound"`
-	RemoteAddr string    `json:"remote_addr"`
+	RemoteAddr string `json:"remote_addr"`
+	LocalAddr  string `json:"local_addr"`
+	Inbound    bool   `json:"inbound"`
 }
 
 type MigrationInfo struct {

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -51,6 +51,14 @@ type CommitInfo struct {
 	ParamUpdates ParamUpdates
 }
 
+type NodeStatus struct {
+	Role            string             `json:"role"`
+	CatchingUp      bool               `json:"catching_up"`
+	CommittedHeader *BlockHeader       `json:"committed_header"`
+	CommitInfo      *CommitInfo        `json:"commit_info"`
+	Params          *NetworkParameters `json:"params"`
+}
+
 type AckStatus int
 
 const (
@@ -105,7 +113,7 @@ func NewBlock(height int64, prevHash, appHash, valSetHash Hash, stamp time.Time,
 		PrevHash:    prevHash,
 		PrevAppHash: appHash,
 		NumTxns:     uint32(numTxns),
-		Timestamp:   stamp.UTC(),
+		Timestamp:   stamp.Truncate(time.Millisecond).UTC(),
 		MerkleRoot:  merkelRoot,
 
 		ValidatorSetHash: valSetHash,

--- a/node/admin/client.go
+++ b/node/admin/client.go
@@ -136,7 +136,7 @@ func prepareHTTPDialerURL(target string) (*neturl.URL, dialerFunc, error) {
 }
 
 // NewClient creates a new admin client . The target arg is usually either
-// "127.0.0.1:8585" or "/path/to/socket.socket". The scheme http:// or https://
+// "127.0.0.1:8584" or "/path/to/socket.socket". The scheme http:// or https://
 // may be included, to dictate if TLS is required or not. If no scheme is given,
 // http:// is assumed. UNIX socket transport may not use TLS. The endpoint path
 // is a separate argument to distinguish it from the UNIX socket file path.

--- a/node/block.go
+++ b/node/block.go
@@ -348,7 +348,7 @@ func (n *Node) getBlkHeight(ctx context.Context, height int64) (types.Hash, []by
 // will be returned.
 func (n *Node) BlockByHeight(height int64) (types.Hash, *ktypes.Block, *ktypes.CommitInfo, error) {
 	if height <= 0 { // I think this is correct since block height starts from 1
-		height, _, _ = n.bki.Best()
+		height, _, _, _ = n.bki.Best()
 	}
 	return n.bki.GetByHeight(height)
 }

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -13,6 +13,7 @@ import (
 	"slices"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/config"
@@ -270,7 +271,7 @@ func (bp *BlockProcessor) Rollback(ctx context.Context, height int64, appHash kt
 	return nil
 }
 
-func (bp *BlockProcessor) CheckTx(ctx context.Context, tx *ktypes.Transaction, recheck bool) error {
+func (bp *BlockProcessor) CheckTx(ctx context.Context, tx *ktypes.Transaction, height int64, blockTime time.Time, recheck bool) error {
 	txHash := tx.Hash()
 
 	// If the network is halted for migration, we reject all transactions.
@@ -315,7 +316,8 @@ func (bp *BlockProcessor) CheckTx(ctx context.Context, tx *ktypes.Transaction, r
 		Ctx: ctx,
 		BlockContext: &common.BlockContext{
 			ChainContext: bp.chainCtx,
-			Height:       bp.height.Load() + 1,
+			Height:       height + 1,
+			Timestamp:    blockTime.Unix() + 1, // eh, one second later... ?
 			Proposer:     bp.chainCtx.NetworkParameters.Leader,
 		},
 		TxID:          hex.EncodeToString(txHash[:]),

--- a/node/consensus.go
+++ b/node/consensus.go
@@ -428,7 +428,7 @@ func (n *Node) startDiscoveryRequestGossip(ctx context.Context, ps *pubsub.PubSu
 			n.log.Infof("received Discovery request from %s", peers.PeerIDStringer(discMsg.ReceivedFrom))
 
 			// Check the block store for the best height and respond
-			bestHeight, _, _ := n.bki.Best()
+			bestHeight, _, _, _ := n.bki.Best()
 			n.sendDiscoveryResponse(bestHeight)
 
 			n.log.Info("responded to Discovery request", "height", bestHeight)

--- a/node/consensus/blocksync.go
+++ b/node/consensus/blocksync.go
@@ -110,7 +110,7 @@ func (ce *ConsensusEngine) replayBlockFromNetwork(ctx context.Context) error {
 	t0 := time.Now()
 
 	for {
-		ce.log.Info("Requesting block from network(replay mode)", "height", ce.state.lc.height+1)
+		ce.log.Info("Requesting block from network (replay mode)", "height", ce.state.lc.height+1)
 		_, rawblk, ci, err := ce.blkRequester(ctx, ce.state.lc.height+1)
 		if err != nil { // all kinds of errors?
 			ce.log.Info("Error requesting block from network", "height", ce.state.lc.height+1, "error", err)

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -2,6 +2,7 @@ package consensus
 
 import (
 	"context"
+	"time"
 
 	blockprocessor "github.com/kwilteam/kwil-db/node/block_processor"
 	"github.com/kwilteam/kwil-db/node/mempool"
@@ -30,15 +31,11 @@ type Mempool interface {
 
 // BlockStore includes both txns and blocks
 type BlockStore interface {
-	// GetBlockByHeight(height int64) (types.Block, error)
-	Best() (int64, types.Hash, types.Hash)
+	Best() (height int64, blkHash, appHash types.Hash, stamp time.Time)
 	Store(block *ktypes.Block, commitInfo *ktypes.CommitInfo) error
-	// Have(blkid types.Hash) bool
 	Get(blkid types.Hash) (*ktypes.Block, *ktypes.CommitInfo, error)
-	// TODO: should return commitInfo instead of appHash
 	GetByHeight(height int64) (types.Hash, *ktypes.Block, *ktypes.CommitInfo, error)
 	StoreResults(hash types.Hash, results []ktypes.TxResult) error
-	// Results(hash types.Hash) ([]types.TxResult, error)
 }
 
 type BlockProcessor interface {
@@ -51,7 +48,7 @@ type BlockProcessor interface {
 	Rollback(ctx context.Context, height int64, appHash ktypes.Hash) error
 	Close() error
 
-	CheckTx(ctx context.Context, tx *ktypes.Transaction, recheck bool) error
+	CheckTx(ctx context.Context, tx *ktypes.Transaction, height int64, blockTime time.Time, recheck bool) error
 
 	GetValidators() []*ktypes.Validator
 	ConsensusParams() *ktypes.NetworkParameters

--- a/node/consensus/leader.go
+++ b/node/consensus/leader.go
@@ -106,7 +106,7 @@ func (ce *ConsensusEngine) startNewRound(ctx context.Context) error {
 
 			// Recheck the transactions in the mempool
 			ce.mempoolMtx.Lock()
-			ce.mempool.RecheckTxs(ctx, ce.blockProcessor.CheckTx)
+			ce.mempool.RecheckTxs(ctx, ce.recheckTx)
 			ce.mempoolMtx.Unlock()
 
 			// signal ce to start a new round
@@ -161,7 +161,8 @@ func (ce *ConsensusEngine) createBlockProposal(ctx context.Context) (*blockPropo
 	}
 
 	valSetHash := ce.validatorSetHash()
-	blk := ktypes.NewBlock(ce.state.lc.height+1, ce.state.lc.blkHash, ce.state.lc.appHash, valSetHash, time.Now(), finalTxs)
+	stamp := time.Now().Truncate(time.Millisecond).UTC()
+	blk := ktypes.NewBlock(ce.state.lc.height+1, ce.state.lc.blkHash, ce.state.lc.appHash, valSetHash, stamp, finalTxs)
 
 	// Sign the block
 	if err := blk.Sign(ce.privKey); err != nil {

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -11,7 +11,9 @@ import (
 )
 
 type ConsensusEngine interface {
-	Role() types.Role // maybe: Role() (rol types.Role, power int64)
+	Status() *ktypes.NodeStatus // includes: role, inCatchup, consensus params, last commit info and block header
+
+	Role() types.Role
 	InCatchup() bool
 
 	AcceptProposal(height int64, blkID, prevBlkID types.Hash, leaderSig []byte, timestamp int64) bool

--- a/node/mempool/mempool.go
+++ b/node/mempool/mempool.go
@@ -116,14 +116,14 @@ func (mp *Mempool) PeekN(n int) []types.NamedTx {
 	return txns
 }
 
-type CheckFn func(ctx context.Context, tx *ktypes.Transaction, recheck bool) error
+type CheckFn func(ctx context.Context, tx *ktypes.Transaction) error
 
 func (mp *Mempool) RecheckTxs(ctx context.Context, fn CheckFn) {
 	mp.mtx.RLock()
 	defer mp.mtx.RUnlock()
 
 	for _, tx := range mp.txQ {
-		if err := fn(ctx, tx.Tx, true); err != nil {
+		if err := fn(ctx, tx.Tx); err != nil {
 			mp.remove(tx.Hash)
 		}
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -291,6 +291,10 @@ func (ce *dummyCE) NotifyBlockCommit(blk *ktypes.Block, ci *ktypes.CommitInfo) {
 	}
 }
 
+func (ce *dummyCE) Status() *ktypes.NodeStatus {
+	return &ktypes.NodeStatus{}
+}
+
 func (ce *dummyCE) NotifyACK(validatorPK []byte, ack types.AckRes) {
 	if ce.ackHandler != nil {
 		ce.ackHandler(validatorPK, ack)

--- a/node/services/jsonrpc/methods.go
+++ b/node/services/jsonrpc/methods.go
@@ -28,6 +28,7 @@ func ioTypes[I, O any](Handler[I, O]) (reflect.Type, reflect.Type) {
 func MakeMethodHandler[I, O any](fn Handler[I, O]) MethodHandler {
 	return func(ctx context.Context, s *Server) (any, func() (any, *jsonrpc.Error)) {
 		req := new(I)
+		ctx = context.WithValue(ctx, ServerCtx, s)
 		return req, func() (any, *jsonrpc.Error) { return fn(ctx, req) }
 	}
 }

--- a/node/store/memstore/memstore_test.go
+++ b/node/store/memstore/memstore_test.go
@@ -122,7 +122,7 @@ func TestMemBS_Best(t *testing.T) {
 		}
 	}
 
-	height, hash, appHash := bs.Best()
+	height, hash, appHash, _ := bs.Best()
 	if height != 3 {
 		t.Errorf("got height %d, want 3", height)
 	}

--- a/node/store/store_test.go
+++ b/node/store/store_test.go
@@ -313,7 +313,7 @@ func TestBlockStore_StoreDuplicateBlock(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	height, hash, gotAppHash := bs.Best()
+	height, hash, gotAppHash, _ := bs.Best()
 	if height != block.Header.Height {
 		t.Errorf("Expected height %d, got %d", block.Header.Height, height)
 	}

--- a/node/types/interfaces.go
+++ b/node/types/interfaces.go
@@ -1,6 +1,8 @@
 package types
 
 import (
+	"time"
+
 	"github.com/kwilteam/kwil-db/core/types"
 )
 
@@ -17,8 +19,7 @@ type BlockStore interface {
 	TxGetter
 	BlockResultsStorer
 
-	// TODO: Should this return commitInfo or AppHash?
-	Best() (int64, Hash, Hash)
+	Best() (height int64, blkHash, appHash Hash, stamp time.Time)
 
 	PreFetch(Hash) (bool, func()) // should be app level instead (TODO: remove)
 


### PR DESCRIPTION
Tons of fixes and improvements all around.  This is based on https://github.com/kwilteam/kwil-db/pull/1230

- cleanup and consistency of all kwild commands, including descriptions (e.g. consistent capitalization and sentence structure, `kwil-admin` => `kwild admin` etc.
- make the `block abort` command's `--block_height` flag into a required argument, as it is in fact required.  The default of 0 would never be applicable.
- the `app/rpc.AdminSvcClient` function that construct the admin RPC client now tries to find any config from kwild's loaded config (including config.toml) if `--rpcserver` has not been set.  The rationale here is that if it finds *local* kwild config then you are likely to want to talk to that unless the flag is set to override that.
- the `admin gen-auth-key` command will now automatically write the generated client certificate to the node's clients.pem file, which is essentially the list of authorized client TLS certificates if operating in mTLS mode.
- consistent toml config file name (config.toml rather than kwil.toml)
- Fix the node status RPC and the Node method that handles it.  Several fields were unset, which had the effect of leaving block time stamp set to the zero Time in a call's BlockContext.
- The block store in `node/store` has the `Best` method now returning the timestamp.  The implementation of `Best` is now less ridiculously inefficient by tracking the best block height and hash as fields rather than looping through the block index map.
- In CE (`node/consensus`), the `stateInfo` struct that supports external methods such as RPC calls now includes the `lastCommit`, which gives access the last `CommitInfo` as well as the `BlockHeader` of the latest committed block.
- The rpc server now calls service methods with a context that contains the `*Server` instance in under the `ServerCtx` context key.  The `MethodHandler` signature is designed with a `*Server` input parameter for this purpose, but it had never been used previously.


With these changes, it will serve as the bases for docs generated with `cmd/kwild/generate` and `cmd/kwil-cli/generate`.