### PR TITLE
set dbOwner as the leader when run with --autogen

### DIFF
--- a/app/node/conf/conf.go
+++ b/app/node/conf/conf.go
@@ -172,7 +172,7 @@ func PreRunBindConfigFile(cmd *cobra.Command, args []string) error {
 	// The above can be modified to standardize to "-".
 
 	// Load config from file
-	confPath, _ := filepath.Abs(filepath.Join(rootDir, config.ConfigFileName))
+	confPath, _ := filepath.Abs(config.ConfigFilePath(rootDir))
 	if err := k.Load(file.Provider(confPath), toml.Parser() /*, mergeFn*/); err != nil {
 		if !errors.Is(err, os.ErrNotExist) {
 			return fmt.Errorf("error loading config: %v", err)

--- a/app/node/conf/conf_test.go
+++ b/app/node/conf/conf_test.go
@@ -2,7 +2,6 @@ package conf
 
 import (
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/knadh/koanf/v2"
@@ -27,7 +26,7 @@ number = 42
 [nested]
 string_value = "nested-string"
 `
-	configPath := filepath.Join(tmpDir, config.ConfigFileName)
+	configPath := config.ConfigFilePath(tmpDir)
 	err := os.WriteFile(configPath, []byte(configContent), 0644)
 	assert.NoError(t, err)
 

--- a/app/node/start.go
+++ b/app/node/start.go
@@ -13,6 +13,7 @@ import (
 
 func StartCmd() *cobra.Command {
 	var autogen bool
+	var dbOwner string
 	cmd := &cobra.Command{
 		Use:               "start",
 		Short:             "start the node (default command)",
@@ -47,7 +48,7 @@ func StartCmd() *cobra.Command {
 			}
 			defer stopProfiler()
 
-			return runNode(cmd.Context(), rootDir, cfg, autogen)
+			return runNode(cmd.Context(), rootDir, cfg, autogen, dbOwner)
 		},
 	}
 
@@ -59,5 +60,6 @@ func StartCmd() *cobra.Command {
 	cmd.SetVersionTemplate(custom.BinaryConfig.NodeCmd + " {{printf \"version %s\" .Version}}\n")
 	cmd.Flags().BoolVarP(&autogen, "autogen", "a", false,
 		"auto generate private key, genesis file, and config file if not exist")
+	cmd.Flags().StringVarP(&dbOwner, "db-owner", "d", "", "owner of the database. This is either a hex pubkey or an address string")
 	return cmd
 }

--- a/app/setup/genesis.go
+++ b/app/setup/genesis.go
@@ -104,7 +104,7 @@ func GenesisCmd() *cobra.Command {
 // bindGenesisFlags binds the genesis configuration flags to the given command.
 func bindGenesisFlags(cmd *cobra.Command, cfg *genesisFlagConfig) {
 	cmd.Flags().StringVar(&cfg.chainID, "chain-id", "", "chainID for the genesis.json file")
-	cmd.Flags().StringSliceVar(&cfg.validators, "validators", nil, "public key, keyType and power of initial validator(s)") // accept: [pubkey1#keyType1:power1]
+	cmd.Flags().StringSliceVar(&cfg.validators, "validators", nil, "public key, keyType and power of initial validator(s)") // accept: [hexpubkey1#keyType1:power1]
 	cmd.Flags().StringSliceVar(&cfg.allocs, "allocs", nil, "address and initial balance allocation(s)")
 	cmd.Flags().BoolVar(&cfg.withGas, "with-gas", false, "include gas costs in the genesis.json file")
 	cmd.Flags().StringVar(&cfg.leader, "leader", "", "public key of the block proposer")

--- a/app/setup/init.go
+++ b/app/setup/init.go
@@ -14,6 +14,7 @@ import (
 	"github.com/kwilteam/kwil-db/app/shared/display"
 	"github.com/kwilteam/kwil-db/config"
 	"github.com/kwilteam/kwil-db/core/crypto"
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/core/utils"
 	"github.com/kwilteam/kwil-db/node"
@@ -133,6 +134,16 @@ func InitCmd() *cobra.Command {
 					},
 					Power: 1,
 				})
+
+				// If DB owner is not set, set it to the node's public key
+				if genCfg.DBOwner == "" {
+					signer := auth.GetUserSigner(privKey)
+					ident, err := auth.GetIdentifierFromSigner(signer)
+					if err != nil {
+						return display.PrintErr(cmd, fmt.Errorf("failed to get identifier for dbOwner: %w", err))
+					}
+					genCfg.DBOwner = ident
+				}
 
 				// allocate some initial balance to validators if gas is enabled and
 				// if no funds are allocated to that validators.

--- a/config/config.go
+++ b/config/config.go
@@ -18,11 +18,6 @@ import (
 	"github.com/pelletier/go-toml/v2"
 )
 
-const (
-	ConfigFileName  = "kwil.toml"
-	GenesisFileName = "genesis.json"
-)
-
 // Duration is a wrapper around time.Duration that implements text
 // (un)marshalling for the go-toml package to work with Go duration strings
 // instead of integers.

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -290,7 +290,6 @@ func (r *TxApp) processVotes(ctx context.Context, db sql.DB, block *common.Block
 		return err
 	}
 
-	fmt.Println("expired resolutions", expired)
 	expiredIDs := make([]*types.UUID, 0, len(expired))
 	requiredPowerMap := make(map[string]int64) // map of resolution type to required power
 
@@ -370,7 +369,6 @@ type creditMap map[string]*big.Int
 func (c creditMap) applyResolution(res *resolutions.Resolution) {
 	// reward voters.
 	// this will include the proposer, even if they did not submit a vote id
-	fmt.Println("crediting the resolution", res)
 
 	for _, voter := range res.Voters {
 		// if the voter is the proposer, then we will reward them below,

--- a/node/voting/voting.go
+++ b/node/voting/voting.go
@@ -242,7 +242,6 @@ func DeleteResolution(ctx context.Context, db sql.TxMaker, id *types.UUID) error
 // It expects there to be 7 columns in the row, in the following order:
 // id, body, type, expiration, approved_power, voters, voteBodyProposer
 func fromRow(ctx context.Context, db sql.Executor, row []any) (*resolutions.Resolution, error) {
-	fmt.Println("fromROW: ", row)
 	if len(row) != 7 {
 		return nil, fmt.Errorf("expected 7 columns, got %d", len(row))
 	}
@@ -387,7 +386,6 @@ func GetExpired(ctx context.Context, db sql.Executor, blockHeight int64) ([]*res
 
 	ids := make([]*resolutions.Resolution, len(res.Rows))
 	for i, row := range res.Rows {
-		fmt.Println("Expired ROW: ", row)
 		ids[i], err = fromRow(ctx, db, row)
 		if err != nil {
 			return nil, fmt.Errorf("internal bug: %w", err)
@@ -741,7 +739,6 @@ func getValidator(ctx context.Context, db sql.Executor, pubKey []byte, keyType c
 	}
 
 	row := res.Rows[0]
-	fmt.Println("Voter Row: ", row)
 	voterBts, ok := row[0].([]byte)
 	if !ok {
 		return nil, errors.New("invalid type for voter")


### PR DESCRIPTION
`init`, `testnet` and `autogen` will take `--db-owner` flag to configure the Owner, if not set, it sets it to the leader. 