### PR TITLE
log: use parent logger level for sub loggers

### DIFF
--- a/core/log/log.go
+++ b/core/log/log.go
@@ -285,6 +285,7 @@ func (l *plainLogger) NewWithLevel(lvl Level, name string) Logger {
 
 func (l *plainLogger) New(name string) Logger {
 	logger := l.be.Logger(name)
+	logger.SetLevel(l.log.Level())
 	return &plainLogger{
 		be:  l.be,
 		log: logger,


### PR DESCRIPTION
Sub loggers derived from the main `KWILD` logger were reset to Info level logging rather than maintaining the same level as the parent.  This fixes that.