### PR TITLE
core: added scanning for results

### DIFF
--- a/core/types/data_types.go
+++ b/core/types/data_types.go
@@ -7,8 +7,6 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
-
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 )
 
 // DataType is a data type.
@@ -144,7 +142,7 @@ func (c *DataType) PGScalar() (string, error) {
 		scalar = "UINT256"
 	case NumericStr:
 		if !c.HasMetadata() {
-			return "", errors.New("decimal type requires metadata")
+			return "", errors.New("numeric type requires metadata")
 		} else {
 			scalar = fmt.Sprintf("NUMERIC(%d,%d)", c.Metadata[0], c.Metadata[1])
 		}
@@ -174,7 +172,7 @@ func (c *DataType) Clean() error {
 		if !c.HasMetadata() {
 			return fmt.Errorf("type %s requires metadata", c.Name)
 		}
-		err := decimal.CheckPrecisionAndScale(c.Metadata[0], c.Metadata[1])
+		err := CheckDecimalPrecisionAndScale(c.Metadata[0], c.Metadata[1])
 		if err != nil {
 			return err
 		}
@@ -263,14 +261,14 @@ var (
 		Name: uuidStr,
 	}
 	UUIDArrayType = ArrayType(UUIDType)
-	// DecimalType contains 1,0 metadata.
+	// NumericType contains 1,0 metadata.
 	// For type detection, users should prefer compare a datatype
-	// name with the DecimalStr constant.
-	DecimalType = &DataType{
+	// name with the NumericStr constant.
+	NumericType = &DataType{
 		Name:     NumericStr,
 		Metadata: [2]uint16{0, 0}, // unspecified precision and scale
 	}
-	DecimalArrayType = ArrayType(DecimalType)
+	NumericArrayType = ArrayType(NumericType)
 	Uint256Type      = &DataType{
 		Name: uint256Str, // TODO: delete
 	}
@@ -307,9 +305,9 @@ const (
 	nullStr    = "null"
 )
 
-// NewDecimalType creates a new fixed point decimal type.
-func NewDecimalType(precision, scale uint16) (*DataType, error) {
-	err := decimal.CheckPrecisionAndScale(precision, scale)
+// NewNumericType creates a new fixed point numeric type.
+func NewNumericType(precision, scale uint16) (*DataType, error) {
+	err := CheckDecimalPrecisionAndScale(precision, scale)
 	if err != nil {
 		return nil, err
 	}
@@ -351,20 +349,23 @@ func ParseDataType(s string) (*DataType, error) {
 	var metadata [2]uint16
 	if rawMetadata != "" {
 		metadata = [2]uint16{}
-		// only decimal types can have metadata
+		// only numeric types can have metadata
 		if baseName != NumericStr {
-			return nil, fmt.Errorf("metadata is only allowed for decimal type")
+			return nil, fmt.Errorf("metadata is only allowed for numeric type")
 		}
 
 		parts := strings.Split(rawMetadata, ",")
-		// can be either DECIMAL(10,5) or just DECIMAL
-		if len(parts) != 2 && len(parts) != 0 {
+		// must be either NUMERIC(10,5)
+		if len(parts) != 2 {
 			return nil, fmt.Errorf("invalid metadata format: %s", rawMetadata)
 		}
 		for i, part := range parts {
 			num, err := strconv.Atoi(strings.TrimSpace(part))
 			if err != nil {
 				return nil, fmt.Errorf("invalid metadata value: %s", part)
+			}
+			if num > int(maxPrecision) {
+				return nil, fmt.Errorf("precision must be less than %d", maxPrecision)
 			}
 			metadata[i] = uint16(num)
 		}

--- a/core/types/encoded_value_test.go
+++ b/core/types/encoded_value_test.go
@@ -5,7 +5,6 @@ import (
 	"math/big"
 	"testing"
 
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -45,13 +44,13 @@ func TestEncodedValue_EdgeCases(t *testing.T) {
 
 	// THIS IS INCORRECT WITH scientific notation e.g 1e-28
 	t.Run("encode decimal with max precision", func(t *testing.T) {
-		d, err := decimal.NewFromBigInt(new(big.Int).SetInt64(1), -6)
+		d, err := NewDecimalFromBigInt(new(big.Int).SetInt64(1), -6)
 		require.NoError(t, err)
 		ev, err := EncodeValue(d)
 		require.NoError(t, err)
 		decoded, err := ev.Decode()
 		require.NoError(t, err)
-		assert.Equal(t, d.String(), decoded.(*decimal.Decimal).String())
+		assert.Equal(t, d.String(), decoded.(*Decimal).String())
 	})
 
 	t.Run("encode mixed array types should fail", func(t *testing.T) {
@@ -103,9 +102,9 @@ func TestEncodedValue_EdgeCases(t *testing.T) {
 	})
 
 	t.Run("encode/decode decimal array", func(t *testing.T) {
-		d1, _ := decimal.NewFromString("100")
-		d2, _ := decimal.NewFromString("200")
-		arr := decimal.DecimalArray{d1, d2}
+		d1, _ := ParseDecimal("100")
+		d2, _ := ParseDecimal("200")
+		arr := DecimalArray{d1, d2}
 
 		ev, err := EncodeValue(arr)
 		require.NoError(t, err)
@@ -113,7 +112,7 @@ func TestEncodedValue_EdgeCases(t *testing.T) {
 		decoded, err := ev.Decode()
 		require.NoError(t, err)
 
-		decodedArr, ok := decoded.(decimal.DecimalArray)
+		decodedArr, ok := decoded.(DecimalArray)
 		require.True(t, ok)
 		assert.Equal(t, arr[0].String(), decodedArr[0].String())
 		assert.Equal(t, arr[1].String(), decodedArr[1].String())

--- a/core/types/payloads.go
+++ b/core/types/payloads.go
@@ -20,7 +20,6 @@ import (
 	"strconv"
 
 	"github.com/kwilteam/kwil-db/core/crypto"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 )
 
 // PayloadType is the type of payload
@@ -631,7 +630,7 @@ func (e *EncodedValue) Decode() (any, error) {
 		case Uint256Type.Name:
 			return Uint256FromBytes(data)
 		case NumericStr:
-			return decimal.NewFromString(string(data))
+			return ParseDecimal(string(data))
 		default:
 			return nil, fmt.Errorf("cannot decode type %s", typeName)
 		}
@@ -711,14 +710,14 @@ func (e *EncodedValue) Decode() (any, error) {
 			}
 			arrAny = arr
 		case NumericStr:
-			arr := make(decimal.DecimalArray, 0, len(e.Data))
+			arr := make(DecimalArray, 0, len(e.Data))
 			for _, elem := range e.Data {
 				dec, err := decodeScalar(elem, e.Type.Name, true)
 				if err != nil {
 					return nil, err
 				}
 
-				arr = append(arr, dec.(*decimal.Decimal))
+				arr = append(arr, dec.(*Decimal))
 			}
 			arrAny = arr
 		default:
@@ -780,15 +779,15 @@ func EncodeValue(v any) (*EncodedValue, error) {
 		case nil: // since we quick return for nil, we can only reach this point if the type is nil
 			// and we are in an array
 			return nil, nil, fmt.Errorf("cannot encode nil in type array")
-		case *decimal.Decimal:
-			decTyp, err := NewDecimalType(t.Precision(), t.Scale())
+		case *Decimal:
+			decTyp, err := NewNumericType(t.Precision(), t.Scale())
 			if err != nil {
 				return nil, nil, err
 			}
 
 			return []byte(t.String()), decTyp, nil
-		case decimal.Decimal:
-			decTyp, err := NewDecimalType(t.Precision(), t.Scale())
+		case Decimal:
+			decTyp, err := NewNumericType(t.Precision(), t.Scale())
 			if err != nil {
 				return nil, nil, err
 			}

--- a/core/types/results.go
+++ b/core/types/results.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
+	"strconv"
 )
 
 type TxCode uint16
@@ -148,6 +150,12 @@ func (e *Event) UnmarshalBinary(data []byte) error {
 	return nil
 }
 
+// CallResult is the result of a procedure call.
+type CallResult struct {
+	QueryResult *QueryResult `json:"query_result"`
+	Logs        []string     `json:"logs"`
+}
+
 // QueryResult is the result of a SQL query or action.
 type QueryResult struct {
 	ColumnNames []string    `json:"column_names"`
@@ -168,8 +176,239 @@ func (qr *QueryResult) ExportToStringMap() []map[string]string {
 	return res
 }
 
-// CallResult is the result of a procedure call.
-type CallResult struct {
-	QueryResult *QueryResult `json:"query_result"`
-	Logs        []string     `json:"logs"`
+// Scan scans a value from the query result.
+// It accepts a slice of pointers to values, and a function that will be called
+// for each row in the result set.
+// The passed values can be of type *string, *int64, *int, *bool, *[]byte, *UUID, *Decimal,
+// *[]string, *[]int64, *[]int, *[]bool, *[]*int64, *[]*int, *[]*bool, *[]*UUID, *[]*Decimal,
+// *[]UUID, *[]Decimal, *[][]byte, or *[]*[]byte.
+func (q *QueryResult) Scan(vals []any, fn func() error) error {
+
+	for _, row := range q.Values {
+		if err := ScanTo(row, vals); err != nil {
+			return err
+		}
+		if err := fn(); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+// ScanTo scans the src values into the dst values.
+func ScanTo(src []any, dst []any) error {
+	if len(src) != len(dst) {
+		return fmt.Errorf("expected %d columns, got %d", len(dst), len(src))
+	}
+
+	for j, col := range src {
+		// if the column val is nil, we skip it.
+		// If it is an array, we need to
+		typeOf := reflect.TypeOf(col)
+		if col == nil {
+			continue
+		} else if typeOf.Kind() == reflect.Slice && typeOf.Elem().Kind() != reflect.Uint8 {
+			if err := convertArray(col, dst[j]); err != nil {
+				return err
+			}
+			continue
+		} else if typeOf.Kind() == reflect.Slice && typeOf.Elem().Kind() == reflect.Uint8 {
+			if err := convertScalar(col, dst[j]); err != nil {
+				return err
+			}
+			continue
+		} else if typeOf.Kind() == reflect.Map {
+			return fmt.Errorf("cannot scan value into map type: %T", dst[j])
+		} else {
+			if err := convertScalar(col, dst[j]); err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
+}
+
+func convertArray(src any, dst any) error {
+	arr, ok := src.([]any)
+	if !ok {
+		return fmt.Errorf("unexpected JSON array type: %T", src)
+	}
+
+	switch v := dst.(type) {
+	case *[]string:
+		return convArr(arr, v)
+	case *[]*string:
+		return convPtrArr(arr, v)
+	case *[]int64:
+		return convArr(arr, v)
+	case *[]int:
+		return convArr(arr, v)
+	case *[]bool:
+		return convArr(arr, v)
+	case *[]*int64:
+		return convPtrArr(arr, v)
+	case *[]*int:
+		return convPtrArr(arr, v)
+	case *[]*bool:
+		return convPtrArr(arr, v)
+	case *[]*UUID:
+		return convPtrArr(arr, v)
+	case *[]UUID:
+		return convArr(arr, v)
+	case *[]*Decimal:
+		return convPtrArr(arr, v)
+	case *[]Decimal:
+		return convArr(arr, v)
+	case *[][]byte:
+		return convArr(arr, v)
+	case *[]*[]byte:
+		return convPtrArr(arr, v)
+	default:
+		return fmt.Errorf("unexpected scan type: %T", dst)
+	}
+}
+
+func convArr[T any](src []any, dst *[]T) error {
+	dst2 := make([]T, len(src)) // we dont set the new slice to dst until we know we can convert all values
+	for i, val := range src {
+		if err := convertScalar(val, &dst2[i]); err != nil {
+			return err
+		}
+	}
+	*dst = dst2
+	return nil
+}
+
+func convPtrArr[T any](src []any, dst *[]*T) error {
+	dst2 := make([]*T, len(src)) // we dont set the new slice to dst until we know we can convert all values
+	for i, val := range src {
+		if val == nil {
+			continue
+		}
+
+		s := new(T)
+
+		err := convertScalar(val, s)
+		if err != nil {
+			return err
+		}
+
+		dst2[i] = s
+	}
+	*dst = dst2
+	return nil
+}
+
+// convertScalar converts a scalar value to the specified type.
+// It converts the source value to a string, then parses it into the specified type.
+func convertScalar(src any, dst any) error {
+	var null bool
+	if src == nil {
+		null = true
+	}
+	str, err := stringify(src)
+	if err != nil {
+		return err
+	}
+	switch v := dst.(type) {
+	case *string:
+		if null {
+			return nil
+		}
+		*v = str
+		return nil
+	case *int64:
+		if null {
+			return nil
+		}
+		i, err := strconv.ParseInt(str, 10, 64)
+		if err != nil {
+			return err
+		}
+		*v = i
+		return nil
+	case *int:
+		if null {
+			return nil
+		}
+		i, err := strconv.Atoi(str)
+		if err != nil {
+			return err
+		}
+		*v = i
+		return nil
+	case *bool:
+		if null {
+			return nil
+		}
+		b, err := strconv.ParseBool(str)
+		if err != nil {
+			return err
+		}
+		*v = b
+		return nil
+	case *[]byte:
+		if null {
+			return nil
+		}
+		*v = []byte(str)
+		return nil
+	case *UUID:
+		if null {
+			return nil
+		}
+
+		if len([]byte(str)) == 16 {
+			*v = UUID([]byte(str))
+			return nil
+		}
+
+		u, err := ParseUUID(str)
+		if err != nil {
+			return err
+		}
+		*v = *u
+		return nil
+	case *Decimal:
+		if null {
+			return nil
+		}
+
+		dec, err := ParseDecimal(str)
+		if err != nil {
+			return err
+		}
+		*v = *dec
+		return nil
+	default:
+		return fmt.Errorf("unexpected scan type: %T", dst)
+	}
+}
+
+// stringify converts a value as a string.
+// It only expects values returned from JSON marshalling.
+// It does NOT expect slices/arrays (except for []byte) or maps
+func stringify(v any) (str string, err error) {
+	switch val := v.(type) {
+	case string:
+		return val, nil
+	case []byte:
+		return string(val), nil
+	case int64:
+		return strconv.FormatInt(val, 10), nil
+	case int:
+		return strconv.Itoa(val), nil
+	case float64:
+		return strconv.FormatFloat(val, 'f', -1, 64), nil
+	case bool:
+		return strconv.FormatBool(val), nil
+	case nil:
+		return "", nil
+	case float32:
+		return strconv.FormatFloat(float64(val), 'f', -1, 32), nil
+	default:
+		return "", fmt.Errorf("unexpected type: %T", v)
+	}
 }

--- a/core/types/results_test.go
+++ b/core/types/results_test.go
@@ -2,7 +2,12 @@ package types
 
 import (
 	"encoding/binary"
+	"errors"
+	"reflect"
+	"strconv"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTxResultMarshalUnmarshal(t *testing.T) {
@@ -126,4 +131,505 @@ func TestTxResultMarshalUnmarshal(t *testing.T) {
 			t.Errorf("got %d events, want 0", len(decoded.Events))
 		}
 	})
+}
+
+// errTestAny is a special error type used within tests if we want
+// to signal that we just want any error, and dont care about the
+// specific error type.
+var errTestAny = errors.New("any test error")
+
+func TestQueryResultScanScalars(t *testing.T) {
+	type testcase struct {
+		name   string
+		rawval any // the value received from json unmarshalling
+		// all of the "exp" (expect) values are the expected results
+		// of scanning the rawval into the corresponding type.
+		// They should be one of 3 values: the core type, nil, or error
+		expString any
+		expInt64  any
+		expInt    any
+		expBool   any
+		expBytes  any
+		expDec    any
+		expUUID   any
+	}
+
+	tests := []testcase{
+		{
+			name:      "string",
+			rawval:    "hello",
+			expString: "hello",
+			expInt64:  strconv.ErrSyntax,
+			expInt:    strconv.ErrSyntax,
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("hello"),
+			expDec:    strconv.ErrSyntax,
+			expUUID:   errTestAny,
+		},
+		{
+			name:      "int64",
+			rawval:    int64(123),
+			expString: "123",
+			expInt64:  int64(123),
+			expInt:    int(123),
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("123"),
+			expDec:    *MustParseDecimal("123"),
+			expUUID:   errTestAny,
+		},
+		{
+			name:      "int",
+			rawval:    int(123),
+			expString: "123",
+			expInt64:  int64(123),
+			expInt:    int(123),
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("123"),
+			expDec:    *MustParseDecimal("123"),
+			expUUID:   errTestAny,
+		},
+		{
+			name: "int string",
+			// this is a string that looks like an int
+			rawval:    "123",
+			expString: "123",
+			expInt64:  int64(123),
+			expInt:    int(123),
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("123"),
+			expDec:    *MustParseDecimal("123"),
+			expUUID:   errTestAny,
+		},
+		{
+			name:      "bool",
+			rawval:    true,
+			expString: "true",
+			expInt64:  strconv.ErrSyntax,
+			expInt:    strconv.ErrSyntax,
+			expBool:   true,
+			expBytes:  []byte("true"),
+			expDec:    strconv.ErrSyntax,
+			expUUID:   errTestAny,
+		},
+		{
+			name:      "bytes",
+			rawval:    []byte("hello"),
+			expString: "hello",
+			expInt64:  strconv.ErrSyntax,
+			expInt:    strconv.ErrSyntax,
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("hello"),
+			expDec:    strconv.ErrSyntax,
+			expUUID:   errTestAny,
+		},
+		{
+			name:      "bytes (16 bytes)",
+			rawval:    MustParseUUID("12345678-1234-1234-1234-123456789abc").Bytes(),
+			expString: string(MustParseUUID("12345678-1234-1234-1234-123456789abc").Bytes()),
+			expInt64:  strconv.ErrSyntax,
+			expInt:    strconv.ErrSyntax,
+			expBool:   strconv.ErrSyntax,
+			expBytes:  MustParseUUID("12345678-1234-1234-1234-123456789abc").Bytes(),
+			expDec:    errTestAny,
+			expUUID:   *MustParseUUID("12345678-1234-1234-1234-123456789abc"),
+		},
+		{
+			name:      "decimal",
+			rawval:    "123.456",
+			expString: "123.456",
+			expInt64:  strconv.ErrSyntax,
+			expInt:    strconv.ErrSyntax,
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("123.456"),
+			expDec:    *MustParseDecimal("123.456"),
+			expUUID:   errTestAny,
+		},
+		{
+			name:      "uuid",
+			rawval:    "12345678-1234-1234-1234-123456789abc",
+			expString: "12345678-1234-1234-1234-123456789abc",
+			expInt64:  strconv.ErrSyntax,
+			expInt:    strconv.ErrSyntax,
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("12345678-1234-1234-1234-123456789abc"),
+			expDec:    errTestAny,
+			expUUID:   *MustParseUUID("12345678-1234-1234-1234-123456789abc"),
+		},
+		{
+			name: "nil",
+			// this is a nil value
+			rawval:    nil,
+			expString: nil,
+			expInt64:  nil,
+			expInt:    nil,
+			expBool:   nil,
+			expBytes:  nil,
+			expDec:    nil,
+			expUUID:   nil,
+		},
+		{
+			name:      "float",
+			rawval:    float64(123.456),
+			expString: "123.456",
+			expInt64:  strconv.ErrSyntax,
+			expInt:    strconv.ErrSyntax,
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("123.456"),
+			expDec:    *MustParseDecimal("123.456"),
+			expUUID:   errTestAny,
+		},
+		{
+			name:      "round float",
+			rawval:    float32(123),
+			expString: "123",
+			expInt64:  int64(123),
+			expInt:    int(123),
+			expBool:   strconv.ErrSyntax,
+			expBytes:  []byte("123"),
+			expDec:    *MustParseDecimal("123"),
+			expUUID:   errTestAny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qr := &QueryResult{
+				Values: [][]any{{tt.rawval}},
+			}
+			checkType[string](t, qr, tt.expString)
+			checkType[int64](t, qr, tt.expInt64)
+			checkType[int](t, qr, tt.expInt)
+			checkType[bool](t, qr, tt.expBool)
+			checkType[[]byte](t, qr, tt.expBytes)
+			checkType[Decimal](t, qr, tt.expDec)
+			checkType[UUID](t, qr, tt.expUUID)
+		})
+	}
+}
+
+func checkType[T any](t *testing.T, q *QueryResult, want any) {
+	var name string
+	_, wantErr := want.(error)
+	if want != nil && !wantErr {
+		typeof := reflect.TypeOf(want)
+		isPtr := false
+		if typeof.Kind() == reflect.Ptr {
+			isPtr = true
+			typeof = typeof.Elem()
+		}
+		name = typeof.String()
+		if isPtr {
+			name = "*" + name
+		}
+	} else if wantErr {
+		name = "error"
+	} else {
+		name = "nil"
+	}
+	t.Logf("testing type %T, expecting %s", *new(T), name)
+
+	v := new(T)
+	err := q.Scan([]any{v}, func() error {
+		return nil
+	})
+
+	switch want := want.(type) {
+	case nil:
+		assert.NoError(t, err)
+
+		newNil := new(T)
+		assert.EqualValues(t, newNil, v)
+	case error:
+		if want == errTestAny {
+			assert.Error(t, err)
+		} else {
+			assert.ErrorIs(t, err, want)
+		}
+
+		newNil := new(T)
+		assert.EqualValues(t, newNil, v)
+	case T:
+		assert.NoError(t, err)
+		assert.EqualValues(t, want, *v)
+	default:
+		t.Fatalf("unexpected want type %T", want)
+	}
+}
+
+func TestQueryResultScanArrays(t *testing.T) {
+	type testcase struct {
+		name   string
+		rawval any // the value received from json unmarshalling
+		// all of the "exp" (expect) values are the expected results
+		// of scanning the rawval into the corresponding type.
+		// They should be one of 3 values: the core type, nil, or error.
+		expStringArr    any
+		expStringArrPtr any
+		expInt64Arr     any
+		expInt64ArrPtr  any
+		expIntArr       any
+		expIntArrPtr    any
+		expBoolArr      any
+		expBoolArrPtr   any
+		expBytesArr     any
+		expBytesArrPtr  any
+		expDecArr       any
+		expDecArrPtr    any
+		expUUIDArr      any
+		expUUIDArrPtr   any
+	}
+
+	tests := []testcase{
+		{
+			name:            "string",
+			rawval:          []any{"hello", "world", nil},
+			expStringArr:    []string{"hello", "world", ""},
+			expStringArrPtr: ptrArr[string]("hello", "world", nil),
+			expInt64Arr:     errTestAny,
+			expInt64ArrPtr:  errTestAny,
+			expIntArr:       errTestAny,
+			expIntArrPtr:    errTestAny,
+			expBoolArr:      errTestAny,
+			expBoolArrPtr:   errTestAny,
+			expBytesArr:     [][]byte{[]byte("hello"), []byte("world"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("hello"), []byte("world"), nil),
+			expDecArr:       errTestAny,
+			expDecArrPtr:    errTestAny,
+			expUUIDArr:      errTestAny,
+			expUUIDArrPtr:   errTestAny,
+		},
+		{
+			name:            "int64",
+			rawval:          []any{int64(123), int64(456), nil},
+			expStringArr:    []string{"123", "456", ""},
+			expStringArrPtr: ptrArr[string]("123", "456", nil),
+			expInt64Arr:     []int64{int64(123), int64(456), 0},
+			expInt64ArrPtr:  ptrArr[int64](int64(123), int64(456), nil),
+			expIntArr:       []int{123, 456, 0},
+			expIntArrPtr:    ptrArr[int](123, 456, nil),
+			expBoolArr:      errTestAny,
+			expBoolArrPtr:   errTestAny,
+			expBytesArr:     [][]byte{[]byte("123"), []byte("456"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("123"), []byte("456"), nil),
+			expDecArr:       []Decimal{*MustParseDecimal("123"), *MustParseDecimal("456"), {}},
+			expDecArrPtr:    ptrArr[Decimal](*MustParseDecimal("123"), *MustParseDecimal("456"), nil),
+			expUUIDArr:      errTestAny,
+			expUUIDArrPtr:   errTestAny,
+		},
+		{
+			name:            "int",
+			rawval:          []any{int(123), int(456), nil},
+			expStringArr:    []string{"123", "456", ""},
+			expStringArrPtr: ptrArr[string]("123", "456", nil),
+			expInt64Arr:     []int64{int64(123), int64(456), 0},
+			expInt64ArrPtr:  ptrArr[int64](int64(123), int64(456), nil),
+			expIntArr:       []int{123, 456, 0},
+			expIntArrPtr:    ptrArr[int](123, 456, nil),
+			expBoolArr:      errTestAny,
+			expBoolArrPtr:   errTestAny,
+			expBytesArr:     [][]byte{[]byte("123"), []byte("456"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("123"), []byte("456"), nil),
+			expDecArr:       []Decimal{*MustParseDecimal("123"), *MustParseDecimal("456"), {}},
+			expDecArrPtr:    ptrArr[Decimal](*MustParseDecimal("123"), *MustParseDecimal("456"), nil),
+			expUUIDArr:      errTestAny,
+			expUUIDArrPtr:   errTestAny,
+		},
+		{
+			name:            "bool",
+			rawval:          []any{true, false, nil},
+			expStringArr:    []string{"true", "false", ""},
+			expStringArrPtr: ptrArr[string]("true", "false", nil),
+			expInt64Arr:     errTestAny,
+			expInt64ArrPtr:  errTestAny,
+			expIntArr:       errTestAny,
+			expIntArrPtr:    errTestAny,
+			expBoolArr:      []bool{true, false, false},
+			expBoolArrPtr:   ptrArr[bool](true, false, nil),
+			expBytesArr:     [][]byte{[]byte("true"), []byte("false"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("true"), []byte("false"), nil),
+			expDecArr:       errTestAny,
+			expDecArrPtr:    errTestAny,
+			expUUIDArr:      errTestAny,
+			expUUIDArrPtr:   errTestAny,
+		},
+		{
+			name:            "bytes",
+			rawval:          []any{[]byte("hello"), []byte("world"), nil},
+			expStringArr:    []string{"hello", "world", ""},
+			expStringArrPtr: ptrArr[string]("hello", "world", nil),
+			expInt64Arr:     errTestAny,
+			expInt64ArrPtr:  errTestAny,
+			expIntArr:       errTestAny,
+			expIntArrPtr:    errTestAny,
+			expBoolArr:      errTestAny,
+			expBoolArrPtr:   errTestAny,
+			expBytesArr:     [][]byte{[]byte("hello"), []byte("world"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("hello"), []byte("world"), nil),
+			expDecArr:       errTestAny,
+			expDecArrPtr:    errTestAny,
+			expUUIDArr:      errTestAny,
+			expUUIDArrPtr:   errTestAny,
+		},
+		{
+			name:            "decimal",
+			rawval:          []any{"123.456", "789.012", nil},
+			expStringArr:    []string{"123.456", "789.012", ""},
+			expStringArrPtr: ptrArr[string]("123.456", "789.012", nil),
+			expInt64Arr:     errTestAny,
+			expInt64ArrPtr:  errTestAny,
+			expIntArr:       errTestAny,
+			expIntArrPtr:    errTestAny,
+			expBoolArr:      errTestAny,
+			expBoolArrPtr:   errTestAny,
+			expBytesArr:     [][]byte{[]byte("123.456"), []byte("789.012"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("123.456"), []byte("789.012"), nil),
+			expDecArr:       []Decimal{*MustParseDecimal("123.456"), *MustParseDecimal("789.012"), {}},
+			expDecArrPtr:    ptrArr[Decimal](*MustParseDecimal("123.456"), *MustParseDecimal("789.012"), nil),
+			expUUIDArr:      errTestAny,
+			expUUIDArrPtr:   errTestAny,
+		},
+		{
+			name:            "uuid",
+			rawval:          []any{"12345678-1234-1234-1234-123456789abc", "12345678-1234-1234-1234-123456789def", nil},
+			expStringArr:    []string{"12345678-1234-1234-1234-123456789abc", "12345678-1234-1234-1234-123456789def", ""},
+			expStringArrPtr: ptrArr[string]("12345678-1234-1234-1234-123456789abc", "12345678-1234-1234-1234-123456789def", nil),
+			expInt64Arr:     errTestAny,
+			expInt64ArrPtr:  errTestAny,
+			expIntArr:       errTestAny,
+			expIntArrPtr:    errTestAny,
+			expBoolArr:      errTestAny,
+			expBoolArrPtr:   errTestAny,
+			expBytesArr:     [][]byte{[]byte("12345678-1234-1234-1234-123456789abc"), []byte("12345678-1234-1234-1234-123456789def"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("12345678-1234-1234-1234-123456789abc"), []byte("12345678-1234-1234-1234-123456789def"), nil),
+			expDecArr:       errTestAny,
+			expDecArrPtr:    errTestAny,
+			expUUIDArr:      []UUID{*MustParseUUID("12345678-1234-1234-1234-123456789abc"), *MustParseUUID("12345678-1234-1234-1234-123456789def"), {}},
+			expUUIDArrPtr:   ptrArr[UUID](*MustParseUUID("12345678-1234-1234-1234-123456789abc"), *MustParseUUID("12345678-1234-1234-1234-123456789def"), nil),
+		},
+		{
+			name:            "all nil values",
+			rawval:          []any{nil, nil, nil},
+			expStringArr:    []string{"", "", ""},
+			expStringArrPtr: ptrArr[string](nil, nil, nil),
+			expInt64Arr:     []int64{0, 0, 0},
+			expInt64ArrPtr:  ptrArr[int64](nil, nil, nil),
+			expIntArr:       []int{0, 0, 0},
+			expIntArrPtr:    ptrArr[int](nil, nil, nil),
+			expBoolArr:      []bool{false, false, false},
+			expBoolArrPtr:   ptrArr[bool](nil, nil, nil),
+			expBytesArr:     [][]byte{nil, nil, nil},
+			expBytesArrPtr:  ptrArr[[]byte](nil, nil, nil),
+			expDecArr:       []Decimal{{}, {}, {}},
+			expDecArrPtr:    ptrArr[Decimal](nil, nil, nil),
+			expUUIDArr:      []UUID{{}, {}, {}},
+			expUUIDArrPtr:   ptrArr[UUID](nil, nil, nil),
+		},
+		{
+			name:            "nil",
+			rawval:          nil,
+			expStringArr:    nil,
+			expStringArrPtr: nil,
+			expInt64Arr:     nil,
+			expInt64ArrPtr:  nil,
+			expIntArr:       nil,
+			expIntArrPtr:    nil,
+			expBoolArr:      nil,
+			expBoolArrPtr:   nil,
+			expBytesArr:     nil,
+			expBytesArrPtr:  nil,
+			expDecArr:       nil,
+			expDecArrPtr:    nil,
+			expUUIDArr:      nil,
+			expUUIDArrPtr:   nil,
+		},
+		{
+			name:            "float",
+			rawval:          []any{float64(123.456), float64(789), nil},
+			expStringArr:    []string{"123.456", "789", ""},
+			expStringArrPtr: ptrArr[string]("123.456", "789", nil),
+			expInt64Arr:     errTestAny,
+			expInt64ArrPtr:  errTestAny,
+			expIntArr:       errTestAny,
+			expIntArrPtr:    errTestAny,
+			expBoolArr:      errTestAny,
+			expBoolArrPtr:   errTestAny,
+			expBytesArr:     [][]byte{[]byte("123.456"), []byte("789"), nil},
+			expBytesArrPtr:  ptrArr[[]byte]([]byte("123.456"), []byte("789"), nil),
+			expDecArr:       []Decimal{*MustParseDecimal("123.456"), *MustParseDecimal("789"), {}},
+			expDecArrPtr:    ptrArr[Decimal](*MustParseDecimal("123.456"), *MustParseDecimal("789"), nil),
+			expUUIDArr:      errTestAny,
+			expUUIDArrPtr:   errTestAny,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			qr := &QueryResult{
+				Values: [][]any{{tt.rawval}},
+			}
+			checkType[[]string](t, qr, tt.expStringArr)
+			checkType[[]*string](t, qr, tt.expStringArrPtr)
+			checkType[[]int64](t, qr, tt.expInt64Arr)
+			checkType[[]*int64](t, qr, tt.expInt64ArrPtr)
+			checkType[[]int](t, qr, tt.expIntArr)
+			checkType[[]*int](t, qr, tt.expIntArrPtr)
+			checkType[[]bool](t, qr, tt.expBoolArr)
+			checkType[[]*bool](t, qr, tt.expBoolArrPtr)
+			checkType[[][]byte](t, qr, tt.expBytesArr)
+			checkType[[]*[]byte](t, qr, tt.expBytesArrPtr)
+			checkType[[]Decimal](t, qr, tt.expDecArr)
+			checkType[[]*Decimal](t, qr, tt.expDecArrPtr)
+			checkType[[]UUID](t, qr, tt.expUUIDArr)
+			checkType[[]*UUID](t, qr, tt.expUUIDArrPtr)
+		})
+	}
+}
+
+// Im checking here that users are capable of detecting zero length
+// arrays vs null arrays
+func TestScanArrayNullability(t *testing.T) {
+	v := new([]string)
+	qr := &QueryResult{
+		Values: [][]any{{[]any{}}},
+	}
+	err := qr.Scan([]any{v}, func() error {
+		return nil
+	})
+	assert.NoError(t, err)
+
+	assert.True(t, *v != nil)
+	assert.Len(t, *v, 0)
+
+	v = new([]string)
+	v2 := new([]string)
+	qr = &QueryResult{
+		Values: [][]any{{[]any{"a"}, nil}},
+	}
+	err = qr.Scan([]any{v, v2}, func() error {
+		return nil
+	})
+	assert.NoError(t, err)
+
+	assert.True(t, *v != nil)
+	assert.Len(t, *v, 1)
+
+	assert.False(t, *v2 != nil)
+}
+
+func ptrArr[T any](v ...any) []*T {
+	out := make([]*T, len(v))
+	for i, b := range v {
+		if b == nil {
+			out[i] = nil
+			continue
+		}
+
+		convV, ok := b.(T)
+		if !ok {
+			panic("invalid type")
+		}
+
+		out[i] = &convV
+	}
+	return out
 }

--- a/core/types/uuid.go
+++ b/core/types/uuid.go
@@ -58,6 +58,15 @@ func ParseUUID(s string) (*UUID, error) {
 	return &u2, nil
 }
 
+// MustParseUUID parses a uuid from a string and panics on error
+func MustParseUUID(s string) *UUID {
+	u, err := ParseUUID(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
 // String returns the string representation of the uuid
 func (u UUID) String() string {
 	return uuid.UUID(u).String()

--- a/node/engine/functions.go
+++ b/node/engine/functions.go
@@ -937,12 +937,12 @@ var (
 
 func init() {
 	var err error
-	decimal1000, err = types.NewDecimalType(1000, 0)
+	decimal1000, err = types.NewNumericType(1000, 0)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create decimal type: 1000, 0: %v", err))
 	}
 
-	decimal16_6, err = types.NewDecimalType(16, 6)
+	decimal16_6, err = types.NewNumericType(16, 6)
 	if err != nil {
 		panic(fmt.Sprintf("failed to create decimal type: 16, 6: %v", err))
 	}

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -13,7 +13,6 @@ import (
 
 	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/extensions/precompiles"
 	"github.com/kwilteam/kwil-db/node/engine"
 	"github.com/kwilteam/kwil-db/node/engine/interpreter"
@@ -699,8 +698,8 @@ func Test_SQL(t *testing.T) {
 				for j, val := range row {
 					// if it is a numeric, we should do a special comparison
 					if test.results[i][j] != nil {
-						if decVal, ok := test.results[i][j].(*decimal.Decimal); ok {
-							cmp, err := decVal.Cmp(val.(*decimal.Decimal))
+						if decVal, ok := test.results[i][j].(*types.Decimal); ok {
+							cmp, err := decVal.Cmp(val.(*types.Decimal))
 							require.NoError(t, err)
 
 							require.Equal(t, 0, cmp)
@@ -780,7 +779,7 @@ func Test_Roundtrip(t *testing.T) {
 		{
 			name:     "decimal_array",
 			datatype: "DECIMAL(70,5)[]",
-			value:    []*decimal.Decimal{mustExplicitDecimal("100.101", 70, 5), mustExplicitDecimal("200.202", 70, 5)},
+			value:    []*types.Decimal{mustExplicitDecimal("100.101", 70, 5), mustExplicitDecimal("200.202", 70, 5)},
 		},
 		{
 			name:     "uuid_array",
@@ -1761,7 +1760,7 @@ func (t *testPrecompile) makeGetMethod(datatype *types.DataType) precompiles.Met
 }
 
 func mustDecType(precision, scale uint16) *types.DataType {
-	t, err := types.NewDecimalType(precision, scale)
+	t, err := types.NewNumericType(precision, scale)
 	if err != nil {
 		panic(err)
 	}
@@ -2019,7 +2018,7 @@ func Test_Extensions(t *testing.T) {
 			{"bool_array", []bool{true}},
 			{"bytea_array", [][]byte{{1, 2, 3}}},
 			{"uuid_array", []*types.UUID{mustUUID("f47ac10b-58cc-4372-a567-0e02b2c3d479")}},
-			{"numeric_array", []*decimal.Decimal{mustExplicitDecimal("1.23", 10, 2)}},
+			{"numeric_array", []*types.Decimal{mustExplicitDecimal("1.23", 10, 2)}},
 		} {
 			err = adminCall("test_ext", "get_"+get.key, []any{get.key}, exact(get.value))
 			require.NoErrorf(t, err, "key: %s", get.key)
@@ -2480,8 +2479,8 @@ func eq(a, b any) error {
 	return nil
 }
 
-func mustExplicitDecimal(s string, prec, scale uint16) *decimal.Decimal {
-	d, err := decimal.NewExplicit(s, prec, scale)
+func mustExplicitDecimal(s string, prec, scale uint16) *types.Decimal {
+	d, err := types.NewDecimalExplicit(s, prec, scale)
 	if err != nil {
 		panic(err)
 	}

--- a/node/engine/interpreter/sql_test.go
+++ b/node/engine/interpreter/sql_test.go
@@ -10,7 +10,6 @@ import (
 
 	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/extensions/precompiles"
 	"github.com/kwilteam/kwil-db/node/engine"
 	"github.com/kwilteam/kwil-db/node/pg"
@@ -268,7 +267,7 @@ func Test_built_in_sql(t *testing.T) {
 						"strarr":  mustNewVal([]string{"a", "b", "c"}),
 						"intarr":  mustNewVal([]int{1, 2, 3}),
 						"boolarr": mustNewVal([]bool{true, false, true}),
-						"decarr":  mustNewVal([]*decimal.Decimal{mustDec("1.23"), mustDec("4.56")}),
+						"decarr":  mustNewVal([]*types.Decimal{mustDec("1.23"), mustDec("4.56")}),
 						"uuidarr": mustNewVal([]*types.UUID{mustUUID("c7b6a54c-392c-48f9-803d-31cb97e76052"), mustUUID("c7b6a54c-392c-48f9-803d-31cb97e76053")}),
 						"blobarr": mustNewVal([][]byte{{1, 2, 3}, {4, 5, 6}}),
 					}
@@ -1068,7 +1067,7 @@ func Test_Metadata(t *testing.T) {
 }
 
 func mustDecType(prec, scale uint16) *types.DataType {
-	dt, err := types.NewDecimalType(prec, scale)
+	dt, err := types.NewNumericType(prec, scale)
 	if err != nil {
 		panic(err)
 	}

--- a/node/engine/interpreter/values_test.go
+++ b/node/engine/interpreter/values_test.go
@@ -4,7 +4,6 @@ import (
 	"testing"
 
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/node/engine"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -153,8 +152,8 @@ func Test_Arithmetic(t *testing.T) {
 // It handles the semantics of comparing decimal values.
 func eq(t *testing.T, a, b any) {
 	// if the values are decimals, we need to compare them manually
-	if aDec, ok := a.(*decimal.Decimal); ok {
-		bDec, ok := b.(*decimal.Decimal)
+	if aDec, ok := a.(*types.Decimal); ok {
+		bDec, ok := b.(*types.Decimal)
 		require.True(t, ok)
 
 		rec, err := aDec.Cmp(bDec)
@@ -163,8 +162,8 @@ func eq(t *testing.T, a, b any) {
 		return
 	}
 
-	if aDec, ok := a.([]*decimal.Decimal); ok {
-		bDec, ok := b.([]*decimal.Decimal)
+	if aDec, ok := a.([]*types.Decimal); ok {
+		bDec, ok := b.([]*types.Decimal)
 		require.True(t, ok)
 
 		require.Len(t, aDec, len(bDec))
@@ -297,8 +296,8 @@ func Test_Comparison(t *testing.T) {
 		},
 		{
 			name:         "decimal-array",
-			a:            []*decimal.Decimal{mustDec("1.00"), mustDec("2.00"), mustDec("3.00")},
-			b:            []*decimal.Decimal{mustDec("1.00"), mustDec("2.00"), mustDec("3.00")},
+			a:            []*types.Decimal{mustDec("1.00"), mustDec("2.00"), mustDec("3.00")},
+			b:            []*types.Decimal{mustDec("1.00"), mustDec("2.00"), mustDec("3.00")},
 			eq:           true,
 			gt:           engine.ErrComparison,
 			lt:           engine.ErrComparison,
@@ -426,9 +425,9 @@ func Test_Cast(t *testing.T) {
 		blobArr    any
 	}
 
-	mDec := func(dec string) *decimal.Decimal {
+	mDec := func(dec string) *types.Decimal {
 		// all decimals will be precision 10, scale 5
-		d, err := decimal.NewFromString(dec)
+		d, err := types.ParseDecimal(dec)
 		require.NoError(t, err)
 
 		err = d.SetPrecisionAndScale(10, 5)
@@ -436,8 +435,8 @@ func Test_Cast(t *testing.T) {
 		return d
 	}
 
-	mDecArr := func(decimals ...string) []*decimal.Decimal {
-		var res []*decimal.Decimal
+	mDecArr := func(decimals ...string) []*types.Decimal {
+		var res []*types.Decimal
 		for _, dec := range decimals {
 			res = append(res, mDec(dec))
 		}
@@ -587,7 +586,7 @@ func Test_Cast(t *testing.T) {
 				eq(t, want, res.RawValue())
 			}
 
-			decimalType, err := types.NewDecimalType(10, 5)
+			decimalType, err := types.NewNumericType(10, 5)
 			require.NoError(t, err)
 
 			decArrType := decimalType.Copy()
@@ -800,7 +799,7 @@ func Test_Array(t *testing.T) {
 
 // this test tests setting null values to an array of different types
 func Test_ArrayNull(t *testing.T) {
-	decType, err := types.NewDecimalType(10, 5)
+	decType, err := types.NewNumericType(10, 5)
 	require.NoError(t, err)
 	decType.IsArray = true
 	for _, dt := range []*types.DataType{
@@ -829,16 +828,16 @@ func ptrArr[T any](arr []T) []*T {
 	return res
 }
 
-func mustDec(dec string) *decimal.Decimal {
-	d, err := decimal.NewFromString(dec)
+func mustDec(dec string) *types.Decimal {
+	d, err := types.ParseDecimal(dec)
 	if err != nil {
 		panic(err)
 	}
 	return d
 }
 
-func mustExplicitDecimal(dec string, precision, scale uint16) *decimal.Decimal {
-	d, err := decimal.NewExplicit(dec, precision, scale)
+func mustExplicitDecimal(dec string, precision, scale uint16) *types.Decimal {
+	d, err := types.NewDecimalExplicit(dec, precision, scale)
 	if err != nil {
 		panic(err)
 	}

--- a/node/engine/parse/antlr.go
+++ b/node/engine/parse/antlr.go
@@ -10,7 +10,6 @@ import (
 
 	antlr "github.com/antlr4-go/antlr/v4"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/core/types/validation"
 	"github.com/kwilteam/kwil-db/node/engine/parse/gen"
 )
@@ -287,13 +286,13 @@ func (s *schemaVisitor) VisitDecimal_literal(ctx *gen.Decimal_literalContext) an
 	// our decimal library can parse the decimal, so we simply pass it there
 	txt := ctx.GetText()
 
-	dec, err := decimal.NewFromString(txt)
+	dec, err := types.ParseDecimal(txt)
 	if err != nil {
 		s.errs.RuleErr(ctx, err, "invalid decimal literal: %s", txt)
 		return unknownExpression(ctx)
 	}
 
-	typ, err := types.NewDecimalType(dec.Precision(), dec.Scale())
+	typ, err := types.NewNumericType(dec.Precision(), dec.Scale())
 	if err != nil {
 		s.errs.RuleErr(ctx, err, "invalid decimal literal: %s", txt)
 		return unknownExpression(ctx)

--- a/node/engine/parse/ast.go
+++ b/node/engine/parse/ast.go
@@ -7,7 +7,6 @@ import (
 
 	antlr "github.com/antlr4-go/antlr/v4"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 )
 
 // this file contains the ASTs for SQL, DDL, and actions.
@@ -97,7 +96,7 @@ func literalToString(value any) (string, error) {
 		str.WriteString(fmt.Sprint(v))
 	case *types.Uint256:
 		str.WriteString(v.String())
-	case *decimal.Decimal:
+	case *types.Decimal:
 		str.WriteString(v.String())
 	case bool: // for bool type
 		if v {

--- a/node/engine/pg_generate/generate.go
+++ b/node/engine/pg_generate/generate.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/node/engine"
 	"github.com/kwilteam/kwil-db/node/engine/parse"
 )
@@ -1130,7 +1129,7 @@ func formatPGLiteral(value any) (string, error) {
 		str.WriteString(v.String())
 	case *types.Uint256:
 		str.WriteString(v.String())
-	case *decimal.Decimal:
+	case *types.Decimal:
 		str.WriteString(v.String())
 	case bool: // for bool type
 		if v {

--- a/node/pg/db_live_test.go
+++ b/node/pg/db_live_test.go
@@ -17,12 +17,10 @@ import (
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgtype"
+	"github.com/kwilteam/kwil-db/core/types"
+	"github.com/kwilteam/kwil-db/node/types/sql"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-
-	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
-	"github.com/kwilteam/kwil-db/node/types/sql"
 )
 
 func TestMain(m *testing.M) {
@@ -142,7 +140,7 @@ func TestQueryRowFunc(t *testing.T) {
 		reflect.TypeFor[*pgtype.Int8](),
 		reflect.TypeFor[*pgtype.Text](),
 		reflect.TypeFor[*[]uint8](),
-		reflect.TypeFor[*decimal.Decimal](),
+		reflect.TypeFor[*types.Decimal](),
 		reflect.TypeFor[*pgtype.Array[pgtype.Int8]](),
 		reflect.TypeFor[*types.Uint256](),
 		reflect.TypeFor[*types.Uint256Array](),
@@ -162,7 +160,7 @@ func TestQueryRowFunc(t *testing.T) {
 
 	// Then use QueryRowFunc with the scan vals.
 
-	wantDec, err := decimal.NewFromString("12.500") // numeric(x,3)!
+	wantDec, err := types.ParseDecimal("12.500") // numeric(x,3)!
 	require.NoError(t, err)
 	if wantDec.Scale() != 3 {
 		t.Fatalf("scale of decimal does not match column def: %v", wantDec)
@@ -291,7 +289,7 @@ func TestScanVal(t *testing.T) {
 	var ba []byte
 	var i8 pgtype.Int8
 	var txt pgtype.Text
-	var num decimal.Decimal // pgtype.Numeric
+	var num types.Decimal // pgtype.Numeric
 	var u256 types.Uint256
 
 	// want pointers to these slices for array types
@@ -302,7 +300,7 @@ func TestScanVal(t *testing.T) {
 	var ia pgtype.Array[pgtype.Int8]
 	var ta pgtype.Array[pgtype.Text]
 	var baa pgtype.Array[[]byte]
-	var na decimal.DecimalArray // pgtype.Array[pgtype.Numeric]
+	var na types.DecimalArray // pgtype.Array[pgtype.Numeric]
 	var u256a types.Uint256Array
 
 	wantScans := []any{&i8, &i8, &txt, &ba, &num, &u256,
@@ -351,11 +349,11 @@ func TestQueryRowFuncAny(t *testing.T) {
 		reflect.TypeFor[int64](),
 		reflect.TypeFor[string](),
 		reflect.TypeFor[[]byte](),
-		reflect.TypeFor[*decimal.Decimal](),
+		reflect.TypeFor[*types.Decimal](),
 		reflect.TypeFor[[]int64](),
 	}
-	mustDec := func(s string) *decimal.Decimal {
-		d, err := decimal.NewFromString(s)
+	mustDec := func(s string) *types.Decimal {
+		d, err := types.ParseDecimal(s)
 		require.NoError(t, err)
 		return d
 	}
@@ -864,8 +862,8 @@ func TestTypeRoundtrip(t *testing.T) {
 		},
 		{
 			typ:  "decimal(6,4)[]",
-			val:  decimal.DecimalArray{mustDecimal("12.4223"), mustDecimal("22.4425"), mustDecimal("23.7423")},
-			want: decimal.DecimalArray{mustDecimal("12.4223"), mustDecimal("22.4425"), mustDecimal("23.7423")},
+			val:  types.DecimalArray{mustDecimal("12.4223"), mustDecimal("22.4425"), mustDecimal("23.7423")},
+			want: types.DecimalArray{mustDecimal("12.4223"), mustDecimal("22.4425"), mustDecimal("23.7423")},
 		},
 		{
 			typ:  "uint256[]",
@@ -967,8 +965,8 @@ func TestTypeRoundtrip(t *testing.T) {
 }
 
 // mustDecimal panics if the string cannot be converted to a decimal.
-func mustDecimal(s string) *decimal.Decimal {
-	d, err := decimal.NewFromString(s)
+func mustDecimal(s string) *types.Decimal {
+	d, err := types.ParseDecimal(s)
 	if err != nil {
 		panic(err)
 	}
@@ -1053,12 +1051,12 @@ func Test_Changesets(t *testing.T) {
 			val2:      []byte("world"),
 			arrayVal2: [][]byte{[]byte("d"), []byte("e"), []byte("f")},
 		},
-		&changesetTestcase[*decimal.Decimal, decimal.DecimalArray]{
+		&changesetTestcase[*types.Decimal, types.DecimalArray]{
 			datatype:  "decimal(6,3)",
 			val:       mustDecimal("123.456"),
-			arrayVal:  decimal.DecimalArray{mustDecimal("123.456"), mustDecimal("123.456"), mustDecimal("123.456")},
+			arrayVal:  types.DecimalArray{mustDecimal("123.456"), mustDecimal("123.456"), mustDecimal("123.456")},
 			val2:      mustDecimal("123.457"),
-			arrayVal2: decimal.DecimalArray{mustDecimal("123.457"), mustDecimal("123.457"), mustDecimal("123.457")},
+			arrayVal2: types.DecimalArray{mustDecimal("123.457"), mustDecimal("123.457"), mustDecimal("123.457")},
 		},
 		&changesetTestcase[*types.UUID, types.UUIDArray]{
 			datatype:  "uuid",
@@ -1631,7 +1629,7 @@ func Test_ParseUnixTimestamp(t *testing.T) {
 	require.Len(t, res.Rows, 1)
 	require.Len(t, res.Rows[0], 1)
 
-	expected, err := decimal.NewFromString("1718114052.123456")
+	expected, err := types.ParseDecimal("1718114052.123456")
 	require.NoError(t, err)
 
 	require.EqualValues(t, expected, res.Rows[0][0])

--- a/node/pg/stats.go
+++ b/node/pg/stats.go
@@ -10,9 +10,7 @@ import (
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgtype"
-
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/node/types/sql"
 )
 
@@ -249,7 +247,7 @@ func colStats(ctx context.Context, qualifiedTable string, colInfo []ColInfo, db 
 					ins(stat, b, cmpBool)
 
 				case ColTypeNumeric: // use *decimal.Decimal in stats
-					var dec *decimal.Decimal
+					var dec *types.Decimal
 					switch v := val.(type) {
 					case *pgtype.Numeric:
 						if !v.Valid {
@@ -279,7 +277,7 @@ func colStats(ctx context.Context, qualifiedTable string, colInfo []ColInfo, db 
 							continue
 						}
 
-					case *decimal.Decimal:
+					case *types.Decimal:
 						if v.NaN() { // we're pretending this is NULL by our sql.Scanner's convetion
 							stat.NullCount++
 							continue
@@ -289,7 +287,7 @@ func colStats(ctx context.Context, qualifiedTable string, colInfo []ColInfo, db 
 							v = &v2
 						}
 						dec = v
-					case decimal.Decimal:
+					case types.Decimal:
 						if v.NaN() { // we're pretending this is NULL by our sql.Scanner's convetion
 							stat.NullCount++
 							continue
@@ -385,7 +383,7 @@ func cmpBool(a, b bool) int {
 	return 0 // false == false
 }
 
-func cmpDecimal(val, mm *decimal.Decimal) int {
+func cmpDecimal(val, mm *types.Decimal) int {
 	d, err := val.Cmp(mm)
 	if err != nil {
 		panic(fmt.Sprintf("%s: (nan decimal?) %v or %v", err, val, mm))

--- a/node/pg/system.go
+++ b/node/pg/system.go
@@ -14,9 +14,7 @@ import (
 
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgtype"
-
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/node/types/sql"
 )
 
@@ -261,7 +259,7 @@ func scanVal(ct ColType) any {
 		// pgtype.Numeric or decimal.Decimal would work. pgtype.Numeric is way
 		// easier to work with and instantiate, but using our types here helps
 		// test their scanners/valuers.
-		return new(decimal.Decimal)
+		return new(types.Decimal)
 	case ColTypeUINT256:
 		return new(types.Uint256)
 	case ColTypeFloat:
@@ -289,7 +287,7 @@ func scanArrayVal(ct ColType) any {
 	case ColTypeNumeric:
 		// pgArray is also simpler and more efficient, but as long as we
 		// explicitly define array types, we should test them.
-		return new(decimal.DecimalArray)
+		return new(types.DecimalArray)
 	case ColTypeUINT256:
 		return new(types.Uint256Array)
 	case ColTypeFloat:

--- a/node/services/jsonrpc/openrpc/reflect.go
+++ b/node/services/jsonrpc/openrpc/reflect.go
@@ -10,7 +10,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 )
 
 type MethodDefinition struct {
@@ -128,7 +127,7 @@ func typeToSchemaType(t reflect.Type) string {
 		return "string"
 	case reflect.TypeFor[types.Uint256](): // MarshalJSON also makes JSON string
 		return "string"
-	case reflect.TypeFor[decimal.Decimal](): // MarshalJSON also makes JSON string
+	case reflect.TypeFor[types.Decimal](): // MarshalJSON also makes JSON string
 		return "string"
 	case reflect.TypeFor[[]byte]():
 		// A regular []byte field is a base64 string.

--- a/node/utils/conv/conv.go
+++ b/node/utils/conv/conv.go
@@ -8,7 +8,6 @@ import (
 	"unicode/utf8"
 
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 )
 
 func String(a any) (string, error) {
@@ -222,9 +221,9 @@ func Uint256(a any) (*types.Uint256, error) {
 		return types.Uint256FromBig(b)
 	case string:
 		return types.Uint256FromString(a)
-	case *decimal.Decimal:
+	case *types.Decimal:
 		return types.Uint256FromString(a.String())
-	case decimal.Decimal:
+	case types.Decimal:
 		return types.Uint256FromString(a.String())
 	case int, int8, int16, int32, int64:
 		return types.Uint256FromString(fmt.Sprint(a))
@@ -243,23 +242,23 @@ func Uint256(a any) (*types.Uint256, error) {
 }
 
 // Decimal converts a value to a Decimal.
-func Decimal(a any) (*decimal.Decimal, error) {
+func Decimal(a any) (*types.Decimal, error) {
 	switch a := a.(type) {
-	case *decimal.Decimal:
+	case *types.Decimal:
 		return a, nil
 	case string:
-		return decimal.NewFromString(a)
+		return types.ParseDecimal(a)
 	case *types.Uint256:
-		return decimal.NewFromString(a.String())
+		return types.ParseDecimal(a.String())
 	case types.Uint256:
-		return decimal.NewFromString(a.String())
+		return types.ParseDecimal(a.String())
 	case int, int8, int16, int32, int64:
-		return decimal.NewFromString(fmt.Sprint(a))
+		return types.ParseDecimal(fmt.Sprint(a))
 	case fmt.Stringer:
-		return decimal.NewFromString(a.String())
+		return types.ParseDecimal(a.String())
 	case nil:
 		// return decimal.NewFromBigInt(big.NewInt(0), 0)
-		return decimal.NewFromString("0")
+		return types.ParseDecimal("0")
 	}
 
 	str, err := String(a)
@@ -267,5 +266,5 @@ func Decimal(a any) (*decimal.Decimal, error) {
 		return nil, err
 	}
 
-	return decimal.NewFromString(str)
+	return types.ParseDecimal(str)
 }

--- a/node/utils/conv/conv_test.go
+++ b/node/utils/conv/conv_test.go
@@ -5,7 +5,6 @@ import (
 	"testing"
 
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/core/types/decimal"
 	"github.com/kwilteam/kwil-db/node/utils/conv"
 	"github.com/stretchr/testify/require"
 )
@@ -327,7 +326,7 @@ func Test_Decimal(t *testing.T) {
 	tests := []struct {
 		name    string
 		arg     any
-		want    *decimal.Decimal
+		want    *types.Decimal
 		wantErr bool
 	}{
 		{
@@ -372,8 +371,8 @@ func Test_Decimal(t *testing.T) {
 	}
 }
 
-func mustDecimal(s string) *decimal.Decimal {
-	d, err := decimal.NewFromString(s)
+func mustDecimal(s string) *types.Decimal {
+	d, err := types.ParseDecimal(s)
 	if err != nil {
 		panic(err)
 	}
@@ -848,7 +847,7 @@ func TestDecimalAdditionalCases(t *testing.T) {
 	tests := []struct {
 		name    string
 		arg     any
-		want    *decimal.Decimal
+		want    *types.Decimal
 		wantErr bool
 	}{
 		{


### PR DESCRIPTION
Sorry, I should've split this up into separate PRs. It does 3 things:
1. It adds the ability to scan into values when using the Go client.
2. It moves the `decimal` package into `types`. It also renames some of the exported functions related to decimals to make it clear that they are for decimals (e.g. `NewExplicit` -> `NewDecimalExplicit`). Previously, it was clear that these were for decimals because they were in the decimals package, but now that is not the case.
3. It renames references to the Kuneiform's `decimal` type to `numeric`, to make it match Postgres more closely. This was actually a change I made in the new engine a while ago., there were just a few straggling things I hadn't updated. `decimal` still works as an alias to `numeric`.