### PR TITLE
added type aliases for encode

### DIFF
--- a/core/types/encoded_value_test.go
+++ b/core/types/encoded_value_test.go
@@ -85,22 +85,6 @@ func TestEncodedValue_EdgeCases(t *testing.T) {
 		assert.Error(t, err)
 	})
 
-	t.Run("encode/decode uint256 array", func(t *testing.T) {
-		u1 := Uint256FromInt(123)
-		u2 := Uint256FromInt(456)
-		arr := Uint256Array{u1, u2}
-
-		ev, err := EncodeValue(arr)
-		require.NoError(t, err)
-
-		decoded, err := ev.Decode()
-		require.NoError(t, err)
-
-		decodedArr, ok := decoded.(Uint256Array)
-		require.True(t, ok)
-		assert.Equal(t, arr, decodedArr)
-	})
-
 	t.Run("encode/decode decimal array", func(t *testing.T) {
 		d1, _ := ParseDecimal("100")
 		d2, _ := ParseDecimal("200")

--- a/core/types/payloads.go
+++ b/core/types/payloads.go
@@ -636,6 +636,16 @@ func (e *EncodedValue) Decode() (any, error) {
 		}
 	}
 
+	if e.Type.Name == NullType.Name {
+		if e.Type.IsArray {
+			return nil, fmt.Errorf("cannot decode array of type 'null'")
+		}
+		if e.Data == nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("expected nil data for type 'null'")
+	}
+
 	typeName, ok := typeAlias[e.Type.Name]
 	if !ok {
 		return nil, fmt.Errorf(`unknown type "%s"`, e.Type.Name)
@@ -646,8 +656,6 @@ func (e *EncodedValue) Decode() (any, error) {
 
 		// postgres requires arrays to be of the correct type, not of []any
 		switch typeName {
-		case NullType.Name:
-			return nil, fmt.Errorf("cannot decode array of type 'null'")
 		case TextType.Name:
 			arr := make([]string, 0, len(e.Data))
 			for _, elem := range e.Data {
@@ -731,12 +739,6 @@ func (e *EncodedValue) Decode() (any, error) {
 		return arrAny, nil
 	}
 
-	if typeName == NullType.Name {
-		if e.Data == nil {
-			return nil, nil
-		}
-		return nil, fmt.Errorf("expected nil data for type 'null'")
-	}
 	if len(e.Data) != 1 {
 		return nil, fmt.Errorf("expected 1 element, got %d", len(e.Data))
 	}

--- a/core/types/payloads.go
+++ b/core/types/payloads.go
@@ -636,17 +636,22 @@ func (e *EncodedValue) Decode() (any, error) {
 		}
 	}
 
+	typeName, ok := typeAlias[e.Type.Name]
+	if !ok {
+		return nil, fmt.Errorf(`unknown type "%s"`, e.Type.Name)
+	}
+
 	if e.Type.IsArray {
 		var arrAny any
 
 		// postgres requires arrays to be of the correct type, not of []any
-		switch e.Type.Name {
+		switch typeName {
 		case NullType.Name:
 			return nil, fmt.Errorf("cannot decode array of type 'null'")
 		case TextType.Name:
 			arr := make([]string, 0, len(e.Data))
 			for _, elem := range e.Data {
-				dec, err := decodeScalar(elem, e.Type.Name, true)
+				dec, err := decodeScalar(elem, typeName, true)
 				if err != nil {
 					return nil, err
 				}
@@ -657,7 +662,7 @@ func (e *EncodedValue) Decode() (any, error) {
 		case IntType.Name:
 			arr := make([]int64, 0, len(e.Data))
 			for _, elem := range e.Data {
-				dec, err := decodeScalar(elem, e.Type.Name, true)
+				dec, err := decodeScalar(elem, typeName, true)
 				if err != nil {
 					return nil, err
 				}
@@ -668,7 +673,7 @@ func (e *EncodedValue) Decode() (any, error) {
 		case BlobType.Name:
 			arr := make([][]byte, 0, len(e.Data))
 			for _, elem := range e.Data {
-				dec, err := decodeScalar(elem, e.Type.Name, true)
+				dec, err := decodeScalar(elem, typeName, true)
 				if err != nil {
 					return nil, err
 				}
@@ -679,7 +684,7 @@ func (e *EncodedValue) Decode() (any, error) {
 		case UUIDType.Name:
 			arr := make(UUIDArray, 0, len(e.Data))
 			for _, elem := range e.Data {
-				dec, err := decodeScalar(elem, e.Type.Name, true)
+				dec, err := decodeScalar(elem, typeName, true)
 				if err != nil {
 					return nil, err
 				}
@@ -690,7 +695,7 @@ func (e *EncodedValue) Decode() (any, error) {
 		case BoolType.Name:
 			arr := make([]bool, 0, len(e.Data))
 			for _, elem := range e.Data {
-				dec, err := decodeScalar(elem, e.Type.Name, true)
+				dec, err := decodeScalar(elem, typeName, true)
 				if err != nil {
 					return nil, err
 				}
@@ -701,7 +706,7 @@ func (e *EncodedValue) Decode() (any, error) {
 		case Uint256Type.Name:
 			arr := make(Uint256Array, 0, len(e.Data))
 			for _, elem := range e.Data {
-				dec, err := decodeScalar(elem, e.Type.Name, true)
+				dec, err := decodeScalar(elem, typeName, true)
 				if err != nil {
 					return nil, err
 				}
@@ -712,7 +717,7 @@ func (e *EncodedValue) Decode() (any, error) {
 		case NumericStr:
 			arr := make(DecimalArray, 0, len(e.Data))
 			for _, elem := range e.Data {
-				dec, err := decodeScalar(elem, e.Type.Name, true)
+				dec, err := decodeScalar(elem, typeName, true)
 				if err != nil {
 					return nil, err
 				}
@@ -721,19 +726,22 @@ func (e *EncodedValue) Decode() (any, error) {
 			}
 			arrAny = arr
 		default:
-			return nil, fmt.Errorf("unknown type `%s`", e.Type.Name)
+			return nil, fmt.Errorf("unknown type `%s`", typeName)
 		}
 		return arrAny, nil
 	}
 
-	if e.Type.Name == NullType.Name {
-		return nil, nil
+	if typeName == NullType.Name {
+		if e.Data == nil {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("expected nil data for type 'null'")
 	}
 	if len(e.Data) != 1 {
 		return nil, fmt.Errorf("expected 1 element, got %d", len(e.Data))
 	}
 
-	return decodeScalar(e.Data[0], e.Type.Name, false)
+	return decodeScalar(e.Data[0], typeName, false)
 }
 
 // EncodeValue encodes a value to its detected type.


### PR DESCRIPTION
In v0.10, we rename `blob` and `decimal` to be `bytea` and `numeric`. We still allow `blob` and `decimal`, they are simply aliased to `bytea` and `numeric`. We were not representing this aliasing in value decoding. This PR fixes that.