### PR TITLE
restrict empty block production to 1 empty block per emptyBlockTimeout

### DIFF
--- a/app/migration/proposal_status.go
+++ b/app/migration/proposal_status.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"time"
 
 	"github.com/spf13/cobra"
 
@@ -53,7 +54,7 @@ func proposalStatusCmd() *cobra.Command {
 
 type MigrationStatus struct {
 	ProposalID *types.UUID
-	ExpiresAt  int64              `json:"expires_at"` // ExpiresAt is the block height at which the migration proposal expires
+	ExpiresAt  time.Time          `json:"expires_at"` // ExpiresAt is the block height at which the migration proposal expires
 	Board      []*types.AccountID `json:"board"`      // Board is the list of validators who are eligible to vote on the migration proposal
 	Approved   []bool             `json:"approved"`   // Approved is the list of bools indicating if the corresponding validator approved the migration proposal
 }
@@ -74,7 +75,7 @@ func (m *MigrationStatus) MarshalText() ([]byte, error) {
 	var msg bytes.Buffer
 	msg.WriteString("Migration Status:\n")
 	msg.WriteString(fmt.Sprintf("\tProposal ID: %s\n", m.ProposalID.String()))
-	msg.WriteString(fmt.Sprintf("\tExpires At: %d\n", m.ExpiresAt))
+	msg.WriteString(fmt.Sprintf("\tExpires At: %s\n", m.ExpiresAt.String()))
 	msg.WriteString(fmt.Sprintf("\tApprovals Received: %d (needed %d)\n", approved, needed))
 
 	for i := range m.Board {

--- a/app/node/build.go
+++ b/app/node/build.go
@@ -172,10 +172,10 @@ func buildDB(ctx context.Context, d *coreDependencies, closers *closeFuncs) *pg.
 		// 	adjustExpiration = true
 		// }
 
-		// err = migrations.CleanupResolutionsAfterMigration(d.ctx, db, adjustExpiration, startHeight)
-		// if err != nil {
-		// 	failBuild(err, "failed to cleanup resolutions after snapshot restore")
-		// }
+		err = migrations.CleanupResolutionsAfterMigration(d.ctx, db)
+		if err != nil {
+			failBuild(err, "failed to cleanup resolutions after snapshot restore")
+		}
 
 		if err = db.EnsureFullReplicaIdentityDatasets(d.ctx); err != nil {
 			failBuild(err, "failed enable full replica identity on user datasets")
@@ -404,6 +404,7 @@ func buildConsensusEngine(_ context.Context, d *coreDependencies, db *pg.DB,
 		Mempool:               mempool,
 		Logger:                d.logger.New("CONS"),
 		ProposeTimeout:        time.Duration(d.cfg.Consensus.ProposeTimeout),
+		EmptyBlockTimeout:     time.Duration(d.cfg.Consensus.EmptyBlockTimeout),
 		BlockProposalInterval: time.Duration(d.cfg.Consensus.BlockProposalInterval),
 		BlockAnnInterval:      time.Duration(d.cfg.Consensus.BlockAnnInterval),
 		BroadcastTxTimeout:    time.Duration(d.cfg.RPC.BroadcastTxTimeout),

--- a/app/params/status.go
+++ b/app/params/status.go
@@ -97,7 +97,7 @@ func (rs MsgResolutionStatus) MarshalText() ([]byte, error) {
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "%sID:         %s\n", rs.indent, rs.ResolutionID)
 	fmt.Fprintf(&buf, "%sType:       %s\n", rs.indent, rs.Type)
-	fmt.Fprintf(&buf, "%sExpiresAt:  %d\n", rs.indent, rs.ExpiresAt)
+	fmt.Fprintf(&buf, "%sExpiresAt:  %s\n", rs.indent, rs.ExpiresAt)
 	fmt.Fprintf(&buf, "%sBoard:      %s\n", rs.indent, rs.Board)
 	fmt.Fprintf(&buf, "%sApprovals:  %v\n", rs.indent, rs.Approved)
 	return buf.Bytes(), nil

--- a/app/setup/genesis.go
+++ b/app/setup/genesis.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/kwilteam/kwil-db/app/shared/display"
 	"github.com/kwilteam/kwil-db/config"
@@ -39,7 +40,7 @@ type genesisFlagConfig struct {
 	leader        string
 	dbOwner       string
 	maxBlockSize  int64
-	joinExpiry    int64
+	joinExpiry    time.Duration
 	maxVotesPerTx int64
 	genesisState  string
 }
@@ -109,7 +110,7 @@ func bindGenesisFlags(cmd *cobra.Command, cfg *genesisFlagConfig) {
 	cmd.Flags().StringVar(&cfg.leader, "leader", "", "public key of the block proposer")
 	cmd.Flags().StringVar(&cfg.dbOwner, "db-owner", "", "owner of the database")
 	cmd.Flags().Int64Var(&cfg.maxBlockSize, "max-block-size", 0, "maximum block size")
-	cmd.Flags().Int64Var(&cfg.joinExpiry, "join-expiry", 0, "Number of blocks before a join proposal expires")
+	cmd.Flags().DurationVar(&cfg.joinExpiry, "join-expiry", 0, "Number of blocks before a join proposal expires")
 	cmd.Flags().Int64Var(&cfg.maxVotesPerTx, "max-votes-per-tx", 0, "Maximum votes per transaction")
 	cmd.Flags().StringVar(&cfg.genesisState, "genesis-snapshot", "", "path to genesis state snapshot file")
 }
@@ -226,7 +227,7 @@ func mergeGenesisFlags(conf *config.GenesisConfig, cmd *cobra.Command, flagCfg *
 	}
 
 	if cmd.Flags().Changed("join-expiry") {
-		conf.JoinExpiry = flagCfg.joinExpiry
+		conf.JoinExpiry = types.Duration(flagCfg.joinExpiry)
 	}
 
 	if cmd.Flags().Changed("max-votes-per-tx") {

--- a/app/shared/bind/bind.go
+++ b/app/shared/bind/bind.go
@@ -13,8 +13,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/pflag"
 
-	"github.com/kwilteam/kwil-db/config"
 	"github.com/kwilteam/kwil-db/core/log"
+	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/pg"
 	"github.com/kwilteam/kwil-db/node/types"
 )
@@ -107,7 +107,7 @@ func SetFlagsFromStructTags(fs *pflag.FlagSet, cfg interface{}, nameTag, descTag
 		case time.Duration:
 			fs.Duration(flagName, vt, desc)
 			return
-		case config.Duration:
+		case ktypes.Duration:
 			fs.Duration(flagName, time.Duration(vt), desc)
 			return
 		case types.HexBytes:

--- a/app/validator/join-status.go
+++ b/app/validator/join-status.go
@@ -101,7 +101,7 @@ func (r *respValJoinStatus) MarshalText() ([]byte, error) {
 	var msg bytes.Buffer
 	msg.WriteString(fmt.Sprintf("Candidate: %s\n", r.Data.Candidate.String()))
 	msg.WriteString(fmt.Sprintf("Requested Power: %d\n", r.Data.Power))
-	msg.WriteString(fmt.Sprintf("Expiration Height: %d\n", r.Data.ExpiresAt))
+	msg.WriteString(fmt.Sprintf("Expiration Timestamp: %s\n", r.Data.ExpiresAt.String()))
 
 	msg.WriteString(fmt.Sprintf("%d Approvals Received (%d needed):\n", approved, needed))
 

--- a/app/validator/join-status_test.go
+++ b/app/validator/join-status_test.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/types"
@@ -59,6 +60,8 @@ func Test_respValJoinStatus_MarshalJSON(t *testing.T) {
 }
 
 func Test_respValJoinStatus_MarshalText(t *testing.T) {
+	now := time.Now()
+	nowStr := now.String()
 	tests := []struct {
 		name     string
 		response respValJoinStatus
@@ -70,7 +73,7 @@ func Test_respValJoinStatus_MarshalText(t *testing.T) {
 				Data: &types.JoinRequest{
 					Candidate: &types.AccountID{Identifier: []byte{0x12, 0x34}, KeyType: crypto.KeyTypeSecp256k1},
 					Power:     1000,
-					ExpiresAt: 5000,
+					ExpiresAt: now,
 					Board: []*types.AccountID{
 						{Identifier: []byte{0xAB, 0xCD}, KeyType: crypto.KeyTypeSecp256k1},
 						{Identifier: []byte{0xEF, 0x12}, KeyType: crypto.KeyTypeSecp256k1},
@@ -79,7 +82,7 @@ func Test_respValJoinStatus_MarshalText(t *testing.T) {
 					Approved: []bool{true, true, true},
 				},
 			},
-			want: "Candidate: AccountID{identifier = 1234, keyType = secp256k1}\nRequested Power: 1000\nExpiration Height: 5000\n3 Approvals Received (2 needed):\nValidator AccountID{identifier = abcd, keyType = secp256k1}, approved\nValidator AccountID{identifier = ef12, keyType = secp256k1}, approved\nValidator AccountID{identifier = 5678, keyType = secp256k1}, approved\n",
+			want: "Candidate: AccountID{identifier = 1234, keyType = secp256k1}\nRequested Power: 1000\nExpiration Timestamp: " + nowStr + "\n3 Approvals Received (2 needed):\nValidator AccountID{identifier = abcd, keyType = secp256k1}, approved\nValidator AccountID{identifier = ef12, keyType = secp256k1}, approved\nValidator AccountID{identifier = 5678, keyType = secp256k1}, approved\n",
 		},
 		{
 			name: "mixed approvals",
@@ -87,7 +90,7 @@ func Test_respValJoinStatus_MarshalText(t *testing.T) {
 				Data: &types.JoinRequest{
 					Candidate: &types.AccountID{Identifier: []byte{0xFF}, KeyType: crypto.KeyTypeSecp256k1},
 					Power:     500,
-					ExpiresAt: 1000,
+					ExpiresAt: now,
 					Board: []*types.AccountID{
 						{Identifier: []byte{0x11, 0x22}, KeyType: crypto.KeyTypeSecp256k1},
 						{Identifier: []byte{0x33, 0x44}, KeyType: crypto.KeyTypeSecp256k1},
@@ -95,7 +98,7 @@ func Test_respValJoinStatus_MarshalText(t *testing.T) {
 					Approved: []bool{true, false},
 				},
 			},
-			want: "Candidate: AccountID{identifier = ff, keyType = secp256k1}\nRequested Power: 500\nExpiration Height: 1000\n1 Approvals Received (2 needed):\nValidator AccountID{identifier = 1122, keyType = secp256k1}, approved\nValidator AccountID{identifier = 3344, keyType = secp256k1}, not approved\n",
+			want: "Candidate: AccountID{identifier = ff, keyType = secp256k1}\nRequested Power: 500\nExpiration Timestamp: " + nowStr + "\n1 Approvals Received (2 needed):\nValidator AccountID{identifier = 1122, keyType = secp256k1}, approved\nValidator AccountID{identifier = 3344, keyType = secp256k1}, not approved\n",
 		},
 	}
 

--- a/app/validator/list-join-requests.go
+++ b/app/validator/list-join-requests.go
@@ -77,7 +77,7 @@ func (r *respJoinList) MarshalText() ([]byte, error) {
 	msg.WriteString(fmt.Sprintf("Pending join requests (%d %s needed):\n", needed, approvalTerm))
 	msg.WriteString(" Candidate                                                        | Power | Approvals | Expiration\n")
 	msg.WriteString("------------------------------------------------------------------+-------+-----------+------------")
-	//ref spacing:    22cbbb666c26b2c1f42502df72c32de4d521138a1a2c96121d417a2f341a759c | 1     | 100	   | 100
+	//ref spacing:    22cbbb666c26b2c1f42502df72c32de4d521138a1a2c96121d417a2f341a759c | 1     | 100	   | 2025-01-21 11:01:49-0600 CST
 	for _, j := range r.Joins {
 		approvals := 0
 		for _, a := range j.Approved {
@@ -86,7 +86,7 @@ func (r *respJoinList) MarshalText() ([]byte, error) {
 			}
 		}
 
-		msg.WriteString(fmt.Sprintf("\n %s | % 5d | % 9d | %d", j.Candidate.String(), j.Power, approvals, j.ExpiresAt))
+		msg.WriteString(fmt.Sprintf("\n %s | % 5d | % 9d | %s", j.Candidate.String(), j.Power, approvals, j.ExpiresAt.String()))
 
 	}
 

--- a/app/validator/list-join-requests_test.go
+++ b/app/validator/list-join-requests_test.go
@@ -3,6 +3,7 @@ package validator
 import (
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/types"
@@ -24,24 +25,22 @@ func Test_respJoinList_MarshalJSON(t *testing.T) {
 							Identifier: []byte{0x12, 0x34},
 							KeyType:    crypto.KeyTypeEd25519,
 						},
-						Power:     100,
-						ExpiresAt: 900,
-						Board:     []*types.AccountID{{Identifier: []byte{0xAB, 0xCD}, KeyType: crypto.KeyTypeSecp256k1}},
-						Approved:  []bool{true},
+						Power:    100,
+						Board:    []*types.AccountID{{Identifier: []byte{0xAB, 0xCD}, KeyType: crypto.KeyTypeSecp256k1}},
+						Approved: []bool{true},
 					},
 					{
 						Candidate: &types.AccountID{
 							Identifier: []byte{0x56, 0x78},
 							KeyType:    crypto.KeyTypeSecp256k1,
 						},
-						Power:     200,
-						ExpiresAt: 1000,
-						Board:     []*types.AccountID{{Identifier: []byte{0xEF, 0x12}, KeyType: crypto.KeyTypeSecp256k1}},
-						Approved:  []bool{false},
+						Power:    200,
+						Board:    []*types.AccountID{{Identifier: []byte{0xEF, 0x12}, KeyType: crypto.KeyTypeSecp256k1}},
+						Approved: []bool{false},
 					},
 				},
 			},
-			want: `[{"candidate":{"identifier":"1234","key_type":1},"power":100,"expires_at":900,"board":[{"identifier":"abcd","key_type":0}],"approved":[true]},{"candidate":{"identifier":"5678","key_type":0},"power":200,"expires_at":1000,"board":[{"identifier":"ef12","key_type":0}],"approved":[false]}]`,
+			want: `[{"candidate":{"identifier":"1234","key_type":1},"power":100,"expires_at": "0001-01-01T00:00:00Z","board":[{"identifier":"abcd","key_type":0}],"approved":[true]},{"candidate":{"identifier":"5678","key_type":0},"power":200,"expires_at":"0001-01-01T00:00:00Z","board":[{"identifier":"ef12","key_type":0}],"approved":[false]}]`,
 		},
 		{
 			name: "empty joins",
@@ -59,14 +58,13 @@ func Test_respJoinList_MarshalJSON(t *testing.T) {
 							Identifier: []byte{0x12, 0x34},
 							KeyType:    crypto.KeyTypeEd25519,
 						},
-						Power:     150,
-						ExpiresAt: 1200,
-						Board:     []*types.AccountID{{Identifier: []byte{0xAB, 0xCD}, KeyType: crypto.KeyTypeSecp256k1}},
-						Approved:  []bool{true, false},
+						Power:    150,
+						Board:    []*types.AccountID{{Identifier: []byte{0xAB, 0xCD}, KeyType: crypto.KeyTypeSecp256k1}},
+						Approved: []bool{true, false},
 					},
 				},
 			},
-			want: `[{"candidate":{"identifier":"1234","key_type":1},"power":150,"expires_at":1200,"board":[{"identifier":"abcd","key_type":0}],"approved":[true,false]}]`,
+			want: `[{"candidate":{"identifier":"1234","key_type":1},"power":150,"expires_at": "0001-01-01T00:00:00Z","board":[{"identifier":"abcd","key_type":0}],"approved":[true,false]}]`,
 		},
 	}
 
@@ -80,6 +78,8 @@ func Test_respJoinList_MarshalJSON(t *testing.T) {
 }
 
 func Test_respJoinList_MarshalText(t *testing.T) {
+	now := time.Now()
+	nowStr := now.String()
 	tests := []struct {
 		name     string
 		response respJoinList
@@ -102,13 +102,13 @@ func Test_respJoinList_MarshalText(t *testing.T) {
 							KeyType:    crypto.KeyTypeEd25519,
 						},
 						Power:     100,
-						ExpiresAt: 1000,
+						ExpiresAt: now,
 						Board:     []*types.AccountID{{Identifier: []byte{0xAB}}},
 						Approved:  []bool{true},
 					},
 				},
 			},
-			want: "Pending join requests (1 approval needed):\n Candidate                                                        | Power | Approvals | Expiration\n------------------------------------------------------------------+-------+-----------+------------\n AccountID{identifier = 1234, keyType = ed25519} |   100 |         1 | 1000",
+			want: "Pending join requests (1 approval needed):\n Candidate                                                        | Power | Approvals | Expiration\n------------------------------------------------------------------+-------+-----------+------------\n AccountID{identifier = 1234, keyType = ed25519} |   100 |         1 | " + nowStr,
 		},
 		{
 			name: "multiple approvals needed",
@@ -120,7 +120,7 @@ func Test_respJoinList_MarshalText(t *testing.T) {
 							KeyType:    crypto.KeyTypeEd25519,
 						},
 						Power:     100,
-						ExpiresAt: 1000,
+						ExpiresAt: now,
 						Board: []*types.AccountID{
 							{Identifier: []byte{0xAB}},
 							{Identifier: []byte{0xCD}},
@@ -133,7 +133,7 @@ func Test_respJoinList_MarshalText(t *testing.T) {
 							Identifier: []byte{0x56, 0x78},
 						},
 						Power:     200,
-						ExpiresAt: 2000,
+						ExpiresAt: now,
 						Board: []*types.AccountID{
 							{Identifier: []byte{0xAB}},
 							{Identifier: []byte{0xCD}},
@@ -143,7 +143,7 @@ func Test_respJoinList_MarshalText(t *testing.T) {
 					},
 				},
 			},
-			want: "Pending join requests (2 approvals needed):\n Candidate                                                        | Power | Approvals | Expiration\n------------------------------------------------------------------+-------+-----------+------------\n AccountID{identifier = 1234, keyType = ed25519} |   100 |         2 | 1000\n AccountID{identifier = 5678, keyType = secp256k1} |   200 |         0 | 2000",
+			want: "Pending join requests (2 approvals needed):\n Candidate                                                        | Power | Approvals | Expiration\n------------------------------------------------------------------+-------+-----------+------------\n AccountID{identifier = 1234, keyType = ed25519} |   100 |         2 | " + nowStr + "\n AccountID{identifier = 5678, keyType = secp256k1} |   200 |         0 | " + nowStr,
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -260,6 +260,7 @@ func DefaultConfig() *Config {
 		},
 		Consensus: ConsensusConfig{
 			ProposeTimeout:        Duration(1000 * time.Millisecond),
+			EmptyBlockTimeout:     Duration(1 * time.Minute),
 			BlockProposalInterval: Duration(1 * time.Second),
 			BlockAnnInterval:      Duration(3 * time.Second),
 		},
@@ -356,7 +357,9 @@ type DBConfig struct {
 }
 
 type ConsensusConfig struct {
-	ProposeTimeout Duration `toml:"propose_timeout" comment:"timeout for proposing a block (applies to leader)"`
+	ProposeTimeout Duration `toml:"propose_timeout" comment:"minimum time to wait before proposing a block with transactions (applies to leader). If set to 0, the leader will propose a block as soon as it has transactions"`
+
+	EmptyBlockTimeout Duration `toml:"empty_block_timeout" comment:"timeout for proposing an empty block"`
 	// reannounce intervals
 
 	// BlockProposalInterval is the interval between block proposal reannouncements by the leader.

--- a/config/config.go
+++ b/config/config.go
@@ -339,17 +339,17 @@ type DBConfig struct {
 }
 
 type ConsensusConfig struct {
-	ProposeTimeout types.Duration `toml:"propose_timeout" comment:"minimum time to wait before proposing a block with transactions (applies to leader). If set to 0, the leader will propose a block as soon as it has transactions"`
+	ProposeTimeout types.Duration `toml:"propose_timeout" comment:"minimum duration to wait before proposing a block with transactions (applies to leader). This value can't be zero, if set to 0, default of 1 sec will be used for block production."`
 
-	EmptyBlockTimeout types.Duration `toml:"empty_block_timeout" comment:"timeout for proposing an empty block"`
-	// reannounce intervals
+	EmptyBlockTimeout types.Duration `toml:"empty_block_timeout" comment:"timeout for proposing an empty block. If set to 0, disables empty blocks, leader will wait indefinitely until transactions are available to produce a block."`
 
 	// BlockProposalInterval is the interval between block proposal reannouncements by the leader.
-	// This impacts the time it takes for an out-of-sync validator to receive the current block proposal,
+	// This affects the time it takes for an out-of-sync validator to receive the current block proposal,
 	// thereby impacting the block times. Default is 1 second.
 	BlockProposalInterval types.Duration `toml:"block_proposal_interval" comment:"interval between block proposal reannouncements by the leader"`
-	// BlockAnnInterval is the frequency with which the block commit messages are reannouncements by the leader,
-	// and votes reannounced by validators. Default is 3 second. This impacts the time it takes for an
+
+	// BlockAnnInterval is the frequency with which the block commit messages are reannounced by the leader,
+	// and votes reannounced by validators. Default is 3 seconds. This affects the time it takes for
 	// out-of-sync nodes to catch up with the latest block.
 	BlockAnnInterval types.Duration `toml:"block_ann_interval" comment:"interval between block commit reannouncements by the leader, and votes reannouncements by validators"`
 }

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/log"
+	"github.com/kwilteam/kwil-db/core/types"
 )
 
 // TestMarshalDuration ensures that a time.Duration can be marshaled and
@@ -19,10 +20,10 @@ import (
 // case for some reason **cough specs cough**.
 func TestMarshalDuration(t *testing.T) {
 	type td struct {
-		Duration Duration `koanf:"duration" toml:"duration"`
+		Duration types.Duration `koanf:"duration" toml:"duration"`
 	}
 	tt := td{
-		Duration: Duration(10 * time.Second),
+		Duration: types.Duration(10 * time.Second),
 	}
 	bts, err := gotoml.Marshal(tt)
 	if err != nil {
@@ -63,7 +64,7 @@ func TestConfigSaveAndLoad(t *testing.T) {
 					User:          "kwild",
 					Pass:          "kwild",
 					DBName:        "kwild",
-					ReadTxTimeout: Duration(45 * time.Second),
+					ReadTxTimeout: types.Duration(45 * time.Second),
 					MaxConns:      10,
 				},
 			},

--- a/core/types/chain/types.go
+++ b/core/types/chain/types.go
@@ -64,7 +64,7 @@ type Genesis struct {
 	MaxBlockSize int64 `json:"max_block_size"`
 	// JoinExpiry is the number of blocks after which the validators
 	// join request expires if not approved.
-	JoinExpiry int64 `json:"join_expiry"`
+	JoinExpiry types.Duration `json:"join_expiry"`
 	// DisabledGasCosts dictates whether gas costs are disabled.
 	DisabledGasCosts bool `json:"disabled_gas_costs"`
 	// MaxVotesPerTx is the maximum number of votes that can be included in a

--- a/core/types/params_test.go
+++ b/core/types/params_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -105,7 +106,7 @@ func TestParamUpdatesMarshalBinary(t *testing.T) {
 				ParamNameLeader:           newPubKey(),
 				ParamNameDBOwner:          "test_owner",
 				ParamNameMaxBlockSize:     int64(1000),
-				ParamNameJoinExpiry:       int64(3600),
+				ParamNameJoinExpiry:       Duration(10 * time.Second),
 				ParamNameDisabledGasCosts: true,
 				ParamNameMaxVotesPerTx:    int64(10),
 				ParamNameMigrationStatus:  MigrationStatus("pending"),

--- a/core/types/time.go
+++ b/core/types/time.go
@@ -1,0 +1,21 @@
+package types
+
+import "time"
+
+// Duration is a wrapper around time.Duration that implements text
+// (un)marshalling for the go-toml package to work with Go duration strings
+// instead of integers.
+type Duration time.Duration
+
+func (d Duration) MarshalText() ([]byte, error) {
+	return []byte(time.Duration(d).String()), nil
+}
+
+func (d *Duration) UnmarshalText(text []byte) error {
+	duration, err := time.ParseDuration(string(text))
+	if err != nil {
+		return err
+	}
+	*d = Duration(duration)
+	return nil
+}

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"time"
 
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
@@ -110,7 +111,7 @@ type ChainInfo struct {
 type JoinRequest struct {
 	Candidate *AccountID   `json:"candidate"`  // pubkey of the candidate validator
 	Power     int64        `json:"power"`      // the requested power
-	ExpiresAt int64        `json:"expires_at"` // the block height at which the join request expires
+	ExpiresAt time.Time    `json:"expires_at"` // the timestamp at which the join request expires
 	Board     []*AccountID `json:"board"`      // slice of pubkeys of all the eligible voting validators
 	Approved  []bool       `json:"approved"`   // slice of bools indicating if the corresponding validator approved
 }
@@ -253,7 +254,7 @@ func (e *VotableEvent) UnmarshalBinary(b []byte) error {
 type PendingResolution struct {
 	Type         string       `json:"type"`
 	ResolutionID *UUID        `json:"resolution_id"` // Resolution ID
-	ExpiresAt    int64        `json:"expires_at"`    // ExpiresAt is the block height at which the resolution expires
+	ExpiresAt    time.Time    `json:"expires_at"`    // ExpiresAt is the timestamp at which the resolution expires
 	Board        []*AccountID `json:"board"`         // Board is the list of validators who are eligible to vote on the resolution
 	Approved     []bool       `json:"approved"`      // Approved is the list of bools indicating if the corresponding validator approved the resolution
 }

--- a/extensions/resolutions/resolutions.go
+++ b/extensions/resolutions/resolutions.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math/big"
 	"strings"
+	"time"
 
 	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/types"
@@ -102,14 +103,11 @@ type ResolutionConfig struct {
 	// number must be a fraction between 0 and 1. If this field is
 	// nil, it will default to 2/3.
 	ConfirmationThreshold *big.Rat
-	// ExpirationPeriod is the amount of blocks that the resolution
-	// will be valid for before it expires. It is applied additively
-	// to the current block height when the resolution is proposed;
-	// if the current block height is 10 and the expiration height is
-	// 5, the resolution will expire at block 15. If this field is
-	// <1, it will default to 14400, which is approximately 1 day
-	// assuming 6 second blocks.
-	ExpirationPeriod int64
+	// ExpirationPeriod is the duration for which the resolution will
+	// be valid for before it expires. This is applied additively to the
+	// block timestamp in the header when the resolution is created.
+	// If not set, the resolution expiry is defaulted to 86400 secs (1 day)
+	ExpirationPeriod time.Duration
 	// ResolveFunc is a function that is called once a resolution has
 	// received a required number of votes, as defined by the
 	// ConfirmationThreshold. It is given a readwrite database
@@ -133,10 +131,10 @@ type Resolution struct {
 	// Type is the type of the resolution. It is used to determine
 	// the logic for the resolution.
 	Type string
-	// ExpirationHeight is the block height at which the resolution
-	// is set to expire, if it has not received the required number
-	// of votes.
-	ExpirationHeight int64
+	// Expiration is the timestamp at which the resolution is set to
+	// Expire.
+	Expiration time.Time
+	// Expiration          int64
 	// ApprovedPower is the total power of the voters that have
 	// approved the resolution.
 	ApprovedPower int64

--- a/node/block_processor/interfaces.go
+++ b/node/block_processor/interfaces.go
@@ -77,6 +77,12 @@ type EventStore interface {
 
 	// MarkBroadcasted marks list of events as broadcasted.
 	MarkBroadcasted(ctx context.Context, ids []*types.UUID) error
+
+	// HasEvents return true if there are any events to be broadcasted
+	HasEvents() bool
+
+	// records the events for which the resolutions have been created.
+	UpdateStats(deleteCnt int64)
 }
 
 var (

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -578,7 +578,9 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 	}
 
 	bp.log.Info("Executed Block", "height", req.Height, "blkHash", req.BlockID, "appHash", nextHash)
-	bp.log.Infoln("network param updates:", bp.chainCtx.NetworkUpdates)
+	if bp.chainCtx.NetworkUpdates != nil {
+		bp.log.Infoln("network param updates:", bp.chainCtx.NetworkUpdates)
+	}
 
 	return &ktypes.BlockExecResult{
 		TxResults:        txResults,

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -413,7 +413,7 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 	inMigration := bp.chainCtx.NetworkParameters.MigrationStatus == ktypes.MigrationInProgress
 	haltNetwork := bp.chainCtx.NetworkParameters.MigrationStatus == ktypes.MigrationCompleted
 
-	isLeader := bytes.Equal(bp.signer.CompactID(), req.Proposer.Bytes())
+	isLeader := bp.signer.PubKey().Equals(req.Proposer)
 
 	blockCtx := &common.BlockContext{
 		Height:       req.Height,

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -566,7 +566,6 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 	if err != nil {
 		return nil, fmt.Errorf("failed to compute the consensus updates hash: %w", err)
 	}
-	bp.log.Info("Consensus updates", "hash", paramUpdatesHash, "updates", bp.chainCtx.NetworkUpdates)
 
 	nextHash := bp.nextAppHash(stateHashes{
 		prevApp:      bp.appHash,
@@ -589,9 +588,9 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 		}
 	}
 
-	bp.log.Info("Executed Block", "height", req.Height, "blkHash", req.BlockID, "appHash", nextHash)
-	if bp.chainCtx.NetworkUpdates != nil {
-		bp.log.Infoln("network param updates:", bp.chainCtx.NetworkUpdates)
+	bp.log.Info("Executed Block", "height", req.Height, "blkID", req.BlockID, "appHash", nextHash, "numTxs", req.Block.Header.NumTxns)
+	if len(bp.chainCtx.NetworkUpdates) != 0 {
+		bp.log.Info("Consensus updates", "hash", paramUpdatesHash, "updates", bp.chainCtx.NetworkUpdates)
 	}
 
 	return &ktypes.BlockExecResult{
@@ -725,9 +724,9 @@ func (bp *BlockProcessor) Commit(ctx context.Context, req *ktypes.CommitRequest)
 	bp.clearBlockExecutionStatus() // TODO: not very sure where to clear this
 
 	// Announce final validators to subscribers
-	bp.announceValidators() // can be in goroutine?
+	bp.announceValidators() // can be in goroutine? no, because the modules state need to be updated by the next consensus round?
 
-	bp.log.Info("Committed Block", "height", req.Height, "appHash", req.AppHash.String())
+	bp.log.Debug("Committed Block", "height", req.Height, "appHash", req.AppHash.String())
 	return nil
 }
 

--- a/node/block_processor/transactions.go
+++ b/node/block_processor/transactions.go
@@ -206,6 +206,21 @@ func (bp *BlockProcessor) prepareBlockTransactions(ctx context.Context, txs []*t
 	return finalTxs, invalidTxs, nil
 }
 
+func (bp *BlockProcessor) HasEvents(ctx context.Context) (bool, error) {
+	readTx, err := bp.db.BeginReadTx(ctx)
+	if err != nil {
+		return false, err
+	}
+	defer readTx.Rollback(ctx)
+
+	events, err := getEvents(ctx, readTx)
+	if err != nil {
+		return false, err
+	}
+
+	return len(events) > 0, nil
+}
+
 // prepareValidatorVoteBodyTx authors the ValidatorVoteBody transaction to be included by the leader in the block.
 // It fetches the events which does not have resolutions yet and creates a validator vote body transaction.
 // The number of events to be included in a single transaction is limited either by MaxVotesPerTx or the maxTxSize

--- a/node/block_processor/transactions.go
+++ b/node/block_processor/transactions.go
@@ -206,19 +206,12 @@ func (bp *BlockProcessor) prepareBlockTransactions(ctx context.Context, txs []*t
 	return finalTxs, invalidTxs, nil
 }
 
-func (bp *BlockProcessor) HasEvents(ctx context.Context) (bool, error) {
-	readTx, err := bp.db.BeginReadTx(ctx)
-	if err != nil {
-		return false, err
-	}
-	defer readTx.Rollback(ctx)
+func (bp *BlockProcessor) HasEvents() bool {
+	return bp.events.HasEvents()
+}
 
-	events, err := getEvents(ctx, readTx)
-	if err != nil {
-		return false, err
-	}
-
-	return len(events) > 0, nil
+func (bp *BlockProcessor) UpdateStats(delectCnt int64) {
+	bp.events.UpdateStats(delectCnt)
 }
 
 // prepareValidatorVoteBodyTx authors the ValidatorVoteBody transaction to be included by the leader in the block.

--- a/node/block_processor/transactions_test.go
+++ b/node/block_processor/transactions_test.go
@@ -812,6 +812,13 @@ func (m *mockEventStore) MarkBroadcasted(ctx context.Context, ids []*types.UUID)
 	return nil
 }
 
+func (m *mockEventStore) HasEvents() bool {
+	return true
+}
+
+func (m *mockEventStore) UpdateStats(cnt int64) {
+}
+
 type mockValidatorStore struct {
 	valSet []*types.Validator
 }

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -148,6 +148,9 @@ func (ce *ConsensusEngine) executeBlock(ctx context.Context, blkProp *blockPropo
 		paramUpdates: results.ParamUpdates,
 	}
 
+	// reset the catchup timer as we have successfully processed a new block proposal
+	ce.catchupTicker.Reset(ce.catchupTimeout)
+
 	ce.log.Info("Executed block", "height", blkProp.height, "blkID", blkProp.blkHash, "numTxs", blkProp.blk.Header.NumTxns, "appHash", results.AppHash.String())
 	return nil
 }
@@ -196,6 +199,9 @@ func (ce *ConsensusEngine) commit(ctx context.Context) error {
 
 	// update the role of the node based on the final validator set at the end of the commit.
 	ce.updateValidatorSetAndRole()
+
+	// reset the catchup timer as we have successfully processed a new block proposal
+	ce.catchupTicker.Reset(ce.catchupTimeout)
 
 	ce.log.Info("Committed Block", "height", height, "hash", blkProp.blkHash.String(),
 		"appHash", appHash.String(), "updates", ce.state.blockRes.paramUpdates)

--- a/node/consensus/blocksync.go
+++ b/node/consensus/blocksync.go
@@ -203,8 +203,12 @@ func blkRetrier(ctx context.Context, maxRetries int64, fn func() error) error {
 
 	for {
 		err := fn()
-		if err == nil || errors.Is(err, types.ErrBlkNotFound) {
+		if err == nil {
 			return nil
+		}
+
+		if errors.Is(err, types.ErrBlkNotFound) {
+			return err
 		}
 
 		// fail after maxRetries retries

--- a/node/consensus/blocksync.go
+++ b/node/consensus/blocksync.go
@@ -17,35 +17,37 @@ import (
 // leading to a fork.
 func (ce *ConsensusEngine) doBlockSync(ctx context.Context) error {
 	if ce.role.Load() == types.RoleLeader {
-		// TODO: The validator set info that leader might have at the time it starts
-		// blocksync is outdated. And if the previous validators
-		if len(ce.validatorSet) == 1 {
-			return nil // we are the network
-		}
-		ce.log.Info("Starting block sync", "height", ce.state.lc.height)
-
-		// figure out the best height to sync with the network
-		// before starting to request blocks from the network.
-		bestHeight, err := ce.discoverBestHeight(ctx)
-		if err != nil {
-			return fmt.Errorf("failed to discover the network's best height: %w", err)
-		}
-
-		if bestHeight <= ce.state.lc.height {
-			// replay blocks from the network to catch up with the network.
-			ce.log.Info("Leader is up to date with the network", "height", ce.state.lc.height)
-
-			return nil
-		}
-
-		// replay blocks from the network to catch up with the network.
-		return ce.syncBlocksUntilHeight(ctx, ce.state.lc.height+1, bestHeight)
+		return ce.leaderBlockSync(ctx)
 	}
 
 	// Validators and sentry nodes can do best effort block sync
 	// and start the consensus engine at the latest height. If they
 	// are behind, they can catch up as they process blocks.
 	return ce.replayBlockFromNetwork(ctx)
+}
+
+func (ce *ConsensusEngine) leaderBlockSync(ctx context.Context) error {
+	if len(ce.validatorSet) == 1 {
+		return nil // we are the network
+	}
+
+	startHeight := ce.lastCommitHeight()
+	ce.log.Info("Starting block sync", "height", startHeight+1)
+
+	// figure out the best height to sync with the network
+	// before starting to request blocks from the network.
+	bestHeight, err := ce.discoverBestHeight(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to discover the network's best height: %w", err)
+	}
+
+	if bestHeight <= startHeight {
+		// replay blocks from the network to catch up with the network.
+		ce.log.Info("Leader is up to date with the network", "height", startHeight)
+		return nil
+	}
+
+	return ce.syncBlocksUntilHeight(ctx, startHeight+1, bestHeight)
 }
 
 func (ce *ConsensusEngine) discoverBestHeight(ctx context.Context) (int64, error) {
@@ -106,67 +108,92 @@ func (ce *ConsensusEngine) discoverBestHeight(ctx context.Context) (int64, error
 // replayBlockFromNetwork requests the next blocks from the network and processes it
 // until it catches up with its peers.
 func (ce *ConsensusEngine) replayBlockFromNetwork(ctx context.Context) error {
-	startHeight := ce.state.lc.height + 1
+	var startHeight, height int64
+	startHeight = ce.lastCommitHeight() + 1
+	height = startHeight
 	t0 := time.Now()
 
 	for {
-		ce.log.Info("Requesting block from network (replay mode)", "height", ce.state.lc.height+1)
-		_, rawblk, ci, err := ce.blkRequester(ctx, ce.state.lc.height+1)
-		if err != nil { // all kinds of errors?
-			ce.log.Info("Error requesting block from network", "height", ce.state.lc.height+1, "error", err)
-			break // no more blocks to sync from network.
+		if err := ce.syncBlock(ctx, height); err != nil {
+			ce.log.Info("block request from the network failed", "height", height, "error", err)
+			break
 		}
-
-		if ce.state.lc.height != 0 && ci != nil && ci.AppHash.IsZero() {
-			return nil
-		}
-
-		blk, err := ktypes.DecodeBlock(rawblk)
-		if err != nil {
-			return fmt.Errorf("failed to decode block: %w", err)
-		}
-
-		if err := ce.processAndCommit(ctx, blk, ci); err != nil {
-			return err
-		}
+		height++
 	}
 
-	ce.log.Info("Block sync completed", "startHeight", startHeight, "endHeight", ce.state.lc.height, "duration", time.Since(t0))
+	ce.log.Info("Block sync completed", "startHeight", startHeight, "endHeight", height, "duration", time.Since(t0))
 	return nil
 }
 
 // replayBlockFromNetwork requests the next blocks from the network and processes it
 // until it catches up with its peers.
 func (ce *ConsensusEngine) syncBlocksUntilHeight(ctx context.Context, startHeight, endHeight int64) error {
-
 	height := startHeight
 	t0 := time.Now()
 
 	for height <= endHeight {
-		// TODO: This is used in blocksync for leader, failure of fetching the block after certain retries should fail the node
-		_, rawblk, ci, err := ce.getBlock(ctx, height)
-		if err != nil { // all kinds of errors?
-			ce.log.Info("Error requesting block from network", "height", ce.state.lc.height+1, "error", err)
-			return fmt.Errorf("error requesting block from network: height : %d, error: %w", ce.state.lc.height+1, err)
-		}
-
-		if ce.state.lc.height != 0 && ci != nil && ci.AppHash.IsZero() {
-			return nil
-		}
-
-		blk, err := ktypes.DecodeBlock(rawblk)
-		if err != nil {
-			return fmt.Errorf("failed to decode block: %w", err)
-		}
-
-		if err := ce.processAndCommit(ctx, blk, ci); err != nil {
+		if err := ce.syncBlockWithRetry(ctx, height); err != nil {
 			return err
 		}
-
 		height++
 	}
 
 	ce.log.Info("Block sync completed", "startHeight", startHeight, "endHeight", endHeight, "duration", time.Since(t0))
+
+	return nil
+}
+
+func (ce *ConsensusEngine) syncBlock(ctx context.Context, height int64) error {
+	ce.log.Info("Requesting block from network (replay mode)", "height", height)
+
+	_, rawblk, ci, err := ce.blkRequester(ctx, height)
+	if err != nil {
+		return err
+	}
+
+	ce.state.mtx.Lock()
+	defer ce.state.mtx.Unlock()
+
+	if ce.state.lc.height != 0 && ci != nil && ci.AppHash.IsZero() {
+		return nil
+	}
+
+	blk, err := ktypes.DecodeBlock(rawblk)
+	if err != nil {
+		return fmt.Errorf("failed to decode block: %w", err)
+	}
+
+	if err := ce.processAndCommit(ctx, blk, ci); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// syncBlockWithRetry requests the network for the specified block and retries until the block
+// is received and applied to the db.
+func (ce *ConsensusEngine) syncBlockWithRetry(ctx context.Context, height int64) error {
+	_, rawblk, ci, err := ce.getBlock(ctx, height)
+	if err != nil { // all kinds of errors?
+		ce.log.Info("Error requesting block from network", "height", height, "error", err)
+		return fmt.Errorf("error requesting block from network: height : %d, error: %w", height, err)
+	}
+
+	ce.state.mtx.Lock()
+	defer ce.state.mtx.Unlock()
+
+	if ce.state.lc.height != 0 && ci != nil && ci.AppHash.IsZero() {
+		return nil
+	}
+
+	blk, err := ktypes.DecodeBlock(rawblk)
+	if err != nil {
+		return fmt.Errorf("failed to decode block: %w", err)
+	}
+
+	if err := ce.processAndCommit(ctx, blk, ci); err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/node/consensus/blocksync.go
+++ b/node/consensus/blocksync.go
@@ -116,7 +116,7 @@ func (ce *ConsensusEngine) replayBlockFromNetwork(ctx context.Context) error {
 	t0 := time.Now()
 
 	for {
-		if err := ce.syncBlock(ctx, height); err != nil {
+		if err := ce.syncBlockWithRetry(ctx, height); err != nil {
 			ce.log.Info("block request from the network failed", "height", height, "error", err)
 			break
 		}
@@ -143,18 +143,6 @@ func (ce *ConsensusEngine) syncBlocksUntilHeight(ctx context.Context, startHeigh
 	ce.log.Info("Block sync completed", "startHeight", startHeight, "endHeight", endHeight, "duration", time.Since(t0))
 
 	return nil
-}
-
-// syncBlock attempts to fetch the next block from peers and process it.
-func (ce *ConsensusEngine) syncBlock(ctx context.Context, height int64) error {
-	ce.log.Info("Requesting block from network (replay mode)", "height", height)
-
-	_, rawblk, ci, err := ce.blkRequester(ctx, height)
-	if err != nil {
-		return err
-	}
-
-	return ce.applyBlock(ctx, rawblk, ci)
 }
 
 // syncBlockWithRetry fetches the specified block from the network and keeps retrying until

--- a/node/consensus/engine.go
+++ b/node/consensus/engine.go
@@ -730,14 +730,14 @@ func (ce *ConsensusEngine) doCatchup(ctx context.Context) error {
 	t0 := time.Now()
 
 	if err := ce.processCurrentBlock(ctx); err != nil {
-		ce.log.Error("error during block processing in catchup", "height", startHeight+1, "error", err)
-		if err == types.ErrBlkNotFound {
+		if errors.Is(err, types.ErrBlkNotFound) {
 			return nil // retry again
 		}
+		ce.log.Error("error during block processing in catchup", "height", startHeight+1, "error", err)
 		return err
 	}
 
-	err := ce.replayBlockFromNetwork(ctx)
+	err := ce.replayBlockFromNetwork(ctx, ce.syncBlockWithRetry)
 	if err != nil {
 		return err
 	}

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -711,7 +711,7 @@ func TestValidatorStateMachine(t *testing.T) {
 						return false
 					}
 					return true
-				}, 6*time.Second, 100*time.Millisecond)
+				}, 6*time.Second, 500*time.Millisecond)
 			}
 		})
 	}
@@ -909,7 +909,7 @@ func TestCELeaderTwoNodesMajorityNacks(t *testing.T) {
 
 // MockBroadcasters
 func mockBlkRequester(ctx context.Context, height int64) (types.Hash, []byte, *ktypes.CommitInfo, error) {
-	return types.Hash{}, nil, nil, fmt.Errorf("not implemented")
+	return types.Hash{}, nil, nil, types.ErrBlkNotFound
 }
 
 func mockBlockPropBroadcaster(_ context.Context, blk *ktypes.Block) {}

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -164,6 +164,7 @@ func generateTestCEConfig(t *testing.T, nodes int, leaderDB bool) ([]*Config, ma
 			// ValidatorSet:          validatorSet,
 			Logger:                logger,
 			ProposeTimeout:        1 * time.Second,
+			EmptyBlockTimeout:     1 * time.Second,
 			BlockProposalInterval: 1 * time.Second,
 			BlockAnnInterval:      3 * time.Second,
 			BroadcastTxTimeout:    10 * time.Second,
@@ -993,6 +994,12 @@ func (m *mockEventStore) GetUnbroadcastedEvents(ctx context.Context) ([]*ktypes.
 	}
 	return ids, nil
 }
+
+func (m *mockEventStore) HasEvents() bool {
+	return true
+}
+
+func (m *mockEventStore) UpdateStats(cnt int64) {}
 
 type mockMigrator struct{}
 

--- a/node/consensus/follower.go
+++ b/node/consensus/follower.go
@@ -308,7 +308,6 @@ func (ce *ConsensusEngine) processAndCommit(ctx context.Context, blk *ktypes.Blo
 
 	ce.log.Info("Processing committed block", "height", blk.Header.Height, "hash", blkID, "appHash", ci.AppHash)
 	if err := ce.validateBlock(blk); err != nil {
-		// ce.log.Errorf("Error validating block: %v", err)
 		return err
 	}
 
@@ -331,12 +330,12 @@ func (ce *ConsensusEngine) processAndCommit(ctx context.Context, blk *ktypes.Blo
 	if !ce.state.blockRes.paramUpdates.Equals(ci.ParamUpdates) { // this is absorbed in apphash anyway, but helps diagnostics
 		haltR := fmt.Sprintf("processAndCommit: Incorrect ParamUpdates, halting the node. received: %s, computed: %s", ci.ParamUpdates, ce.state.blockRes.paramUpdates)
 		ce.haltChan <- haltR
-		return fmt.Errorf("paramUpdates mismatch, expected: %v, received: %v", ce.state.blockRes.paramUpdates, ci.ParamUpdates)
+		return errors.New(haltR)
 	}
 	if ce.state.blockRes.appHash != ci.AppHash { // do in acceptCommitInfo?
-		haltR := fmt.Sprintf("processAndCommit: Incorrect AppHash, halting the node. received: %s, computed: %s", ci.AppHash, ce.state.blockRes.appHash)
+		haltR := fmt.Sprintf("processAndCommit: AppHash mismatch, halting the node. expected: %s, received: %s", ce.state.blockRes.appHash, ci.AppHash)
 		ce.haltChan <- haltR
-		return fmt.Errorf("appHash mismatch, expected: %s, received: %s", ci.AppHash, ce.state.blockRes.appHash)
+		return errors.New(haltR)
 	}
 
 	// Commit the block if the appHash and commitInfo is valid

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -27,6 +27,7 @@ type Mempool interface {
 	Remove(txid types.Hash)
 	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
 	Store(types.Hash, *ktypes.Transaction)
+	TxsAvailable() bool
 }
 
 // BlockStore includes both txns and blocks
@@ -54,4 +55,5 @@ type BlockProcessor interface {
 	ConsensusParams() *ktypes.NetworkParameters
 
 	BlockExecutionStatus() *ktypes.BlockExecutionStatus
+	HasEvents(ctx context.Context) (bool, error)
 }

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -55,5 +55,5 @@ type BlockProcessor interface {
 	ConsensusParams() *ktypes.NetworkParameters
 
 	BlockExecutionStatus() *ktypes.BlockExecutionStatus
-	HasEvents(ctx context.Context) (bool, error)
+	HasEvents() bool
 }

--- a/node/consensus/leader.go
+++ b/node/consensus/leader.go
@@ -172,6 +172,8 @@ func (ce *ConsensusEngine) proposeBlock(ctx context.Context) error {
 		return err
 	}
 
+	ce.log.Info("Waiting for votes from the validators", "height", blkProp.height, "hash", blkProp.blkHash)
+
 	ce.state.votes[string(ce.pubKey.Bytes())] = &ktypes.VoteInfo{
 		AppHash:   &ce.state.blockRes.appHash,
 		AckStatus: ktypes.AckStatusAgree,
@@ -179,7 +181,6 @@ func (ce *ConsensusEngine) proposeBlock(ctx context.Context) error {
 	}
 
 	ce.processVotes(ctx)
-	ce.log.Info("Waiting for votes from the validators", "height", blkProp.height, "hash", blkProp.blkHash)
 	return nil
 }
 

--- a/node/consensus/updates_test.go
+++ b/node/consensus/updates_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/binary"
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -45,10 +46,24 @@ func TestParamUpdatesDeclaration_MarshalBinary(t *testing.T) {
 					types.ParamNameLeader:           types.PublicKey{PublicKey: pubkey},
 					types.ParamNameDBOwner:          "0x1234567890123456789012345678901234567890",
 					types.ParamNameDisabledGasCosts: false,
-					types.ParamNameJoinExpiry:       int64(444),
+					types.ParamNameJoinExpiry:       types.Duration(10 * time.Second),
 					types.ParamNameMigrationStatus:  types.MigrationCompleted,
 				},
 			},
+		},
+		{
+			name: "invalid expiry param updates",
+			declaration: ParamUpdatesDeclaration{
+				Description: "test update",
+				ParamUpdates: types.ParamUpdates{
+					types.ParamNameLeader:           types.PublicKey{PublicKey: pubkey},
+					types.ParamNameDBOwner:          "0x1234567890123456789012345678901234567890",
+					types.ParamNameDisabledGasCosts: false,
+					types.ParamNameJoinExpiry:       int64(10),
+					types.ParamNameMigrationStatus:  types.MigrationCompleted,
+				},
+			},
+			wantErr: true,
 		},
 	}
 

--- a/node/mempool/mempool.go
+++ b/node/mempool/mempool.go
@@ -128,3 +128,9 @@ func (mp *Mempool) RecheckTxs(ctx context.Context, fn CheckFn) {
 		}
 	}
 }
+
+func (mp *Mempool) TxsAvailable() bool {
+	mp.mtx.RLock()
+	defer mp.mtx.RUnlock()
+	return len(mp.txQ) > 0
+}

--- a/node/meta/meta_test.go
+++ b/node/meta/meta_test.go
@@ -5,6 +5,7 @@ package meta_test
 import (
 	"context"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 
@@ -53,7 +54,7 @@ func Test_NetworkParams(t *testing.T) {
 	param := &common.NetworkParameters{
 		Leader:           types.PublicKey{PublicKey: pubkey},
 		MaxBlockSize:     1000,
-		JoinExpiry:       100,
+		JoinExpiry:       types.Duration(100 * time.Second),
 		DisabledGasCosts: true,
 		MaxVotesPerTx:    100,
 	}

--- a/node/migrations/migrator.go
+++ b/node/migrations/migrator.go
@@ -669,7 +669,7 @@ func formatGenesisInfoFileName(mdir string) string {
 // - Remove all the pending migration, changeset, validator join and validator remove resolutions
 // - Fix the expiry heights of all the pending resolutions
 // (how to handle this for offline migrations? we have no way to know the last height of the old chain)
-func CleanupResolutionsAfterMigration(ctx context.Context, db sql.DB, adjustExpiration bool, snapshotHeight int64) error {
+func CleanupResolutionsAfterMigration(ctx context.Context, db sql.DB) error {
 	tx, err := db.BeginTx(ctx)
 	if err != nil {
 		return err
@@ -688,13 +688,8 @@ func CleanupResolutionsAfterMigration(ctx context.Context, db sql.DB, adjustExpi
 		return err
 	}
 
-	if adjustExpiration {
-		// Fix the expiry heights of all the pending resolutions
-		err = voting.ReadjustExpirations(ctx, tx, snapshotHeight)
-		if err != nil {
-			return err
-		}
-	}
+	// probably no need to adjust expirations, they should automatically be expired as we use timestamps
+	// unlike block heights in Kwil V1.0 where the heights get reset to 0
 
 	return tx.Commit(ctx)
 }

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -128,6 +128,7 @@ func TestSingleNodeMocknet(t *testing.T) {
 		BlockProcessor:        bp,
 		Logger:                log.New(log.WithName("CE1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured)),
 		ProposeTimeout:        1 * time.Second,
+		EmptyBlockTimeout:     1 * time.Second,
 		BlockProposalInterval: 1 * time.Second,
 		BlockAnnInterval:      3 * time.Second,
 		BroadcastTxTimeout:    15 * time.Second,
@@ -266,6 +267,7 @@ func TestDualNodeMocknet(t *testing.T) {
 		BlockStore:            bs1,
 		Logger:                log.New(log.WithName("CE1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured)),
 		ProposeTimeout:        1 * time.Second,
+		EmptyBlockTimeout:     1 * time.Second,
 		BlockProposalInterval: 1 * time.Second,
 		BlockAnnInterval:      3 * time.Second,
 		DB:                    db1,
@@ -335,6 +337,7 @@ func TestDualNodeMocknet(t *testing.T) {
 		BlockProcessor:        bp2,
 		Logger:                log.New(log.WithName("CE2"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured)),
 		ProposeTimeout:        1 * time.Second,
+		EmptyBlockTimeout:     1 * time.Second,
 		BlockProposalInterval: 1 * time.Second,
 		BlockAnnInterval:      3 * time.Second,
 		DB:                    db2,
@@ -508,6 +511,12 @@ func (m *mockEventStore) GetUnbroadcastedEvents(ctx context.Context) ([]*ktypes.
 	}
 	return ids, nil
 }
+
+func (m *mockEventStore) HasEvents() bool {
+	return true
+}
+
+func (m *mockEventStore) UpdateStats(cnt int64) {}
 
 // TODO: can test with real migrator
 /*type mockMigrator struct{}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -76,7 +76,7 @@ func makeTestHosts(t *testing.T, nNodes, nExtraHosts int, blockInterval time.Dur
 	})
 
 	defaultConfigSet := config.DefaultConfig()
-	defaultConfigSet.Consensus.ProposeTimeout = config.Duration(blockInterval)
+	defaultConfigSet.Consensus.ProposeTimeout = ktypes.Duration(blockInterval)
 
 	var nodes []*Node
 	var hosts []host.Host

--- a/node/services/jsonrpc/adminsvc/service.go
+++ b/node/services/jsonrpc/adminsvc/service.go
@@ -474,7 +474,7 @@ func (svc *Service) toPendingInfo(resolution *resolutions.Resolution, allVoters 
 			KeyType:    resolutionBody.PubKeyType,
 		},
 		Power:     resolutionBody.Power,
-		ExpiresAt: resolution.ExpirationHeight,
+		ExpiresAt: resolution.Expiration,
 		Board:     board,
 		Approved:  approvals,
 	}, nil
@@ -597,7 +597,7 @@ func (svc *Service) ResolutionStatus(ctx context.Context, req *adminjson.Resolut
 		Status: &ktypes.PendingResolution{
 			Type:         resolution.Type,
 			ResolutionID: req.ResolutionID,
-			ExpiresAt:    resolution.ExpirationHeight,
+			ExpiresAt:    resolution.Expiration,
 			Board:        board,
 			Approved:     approvals,
 		},

--- a/node/statesync_test.go
+++ b/node/statesync_test.go
@@ -165,7 +165,7 @@ func testSSConfig(enable bool, providers []string) *config.StateSyncConfig {
 	return &config.StateSyncConfig{
 		Enable:           enable,
 		TrustedProviders: providers,
-		DiscoveryTimeout: config.Duration(5 * time.Second),
+		DiscoveryTimeout: ktypes.Duration(5 * time.Second),
 		MaxRetries:       3,
 	}
 }

--- a/node/tx.go
+++ b/node/tx.go
@@ -16,9 +16,9 @@ import (
 
 var (
 	ErrNotFound    = errors.New("resource not available")
-	ErrTxNotFound  = errors.New("tx not available")
-	ErrBlkNotFound = errors.New("block not available")
-	ErrNoResponse  = errors.New("stream closed without response")
+	ErrTxNotFound  = types.ErrTxNotFound
+	ErrBlkNotFound = types.ErrBlkNotFound
+	ErrNoResponse  = types.ErrNoResponse
 )
 
 const (

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -162,6 +162,7 @@ func (r *TxApp) Execute(ctx *common.TxContext, db sql.DB, tx *types.Transaction)
 	// no need to error out if we cannot track the validator join approval
 	r.trackValidatorJoinApprovals(tx)
 
+	// track event count
 	return route.Execute(ctx, r, db, tx)
 }
 

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -319,7 +319,7 @@ func (r *TxApp) processVotes(ctx context.Context, db sql.DB, block *common.Block
 	}
 
 	// now we will expire resolutions
-	expired, err := getExpired(ctx, db, block.Height)
+	expired, err := getExpired(ctx, db, block.Timestamp)
 	if err != nil {
 		return nil, err
 	}

--- a/node/types/interfaces.go
+++ b/node/types/interfaces.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"time"
 
 	"github.com/kwilteam/kwil-db/core/types"
@@ -8,7 +9,12 @@ import (
 
 var ErrNotFound = types.ErrNotFound
 
-var HashBytes = types.HashBytes
+var (
+	HashBytes      = types.HashBytes
+	ErrTxNotFound  = errors.New("tx not available")
+	ErrBlkNotFound = errors.New("block not available")
+	ErrNoResponse  = errors.New("stream closed without response")
+)
 
 const HashLen = types.HashLen
 

--- a/node/voting/events.go
+++ b/node/voting/events.go
@@ -137,6 +137,10 @@ type EventStore struct {
 	eventWriter DB
 
 	writerMtx sync.Mutex // protects eventWriter, not applicable to read-only operations
+
+	// numEvents tracks the count of events added by the listeners
+	// which doesn't have resolutions yet.
+	numEvents int64
 }
 
 // NewEventStore will initialize the event and vote store with the provided DB
@@ -236,6 +240,7 @@ func (e *EventStore) Store(ctx context.Context, data []byte, eventType string) e
 	}
 	// fmt.Printf("inserted event new event: type %v, id %v\n", eventType, id)
 
+	e.numEvents++
 	return tx.Commit(ctx)
 }
 
@@ -344,6 +349,24 @@ func DeleteEvents(ctx context.Context, db sql.DB, ids ...*types.UUID) error {
 
 	_, err := db.Execute(ctx, deleteEvents, types.UUIDArray(ids).Bytes())
 	return err
+}
+
+func (e *EventStore) UpdateStats(deletedEvts int64) {
+	e.writerMtx.Lock()
+	defer e.writerMtx.Unlock()
+
+	if e.numEvents > deletedEvts {
+		e.numEvents -= deletedEvts
+	} else {
+		e.numEvents = 0
+	}
+}
+
+func (e *EventStore) HasEvents() bool {
+	e.writerMtx.Lock()
+	defer e.writerMtx.Unlock()
+
+	return e.numEvents > 0
 }
 
 // KV returns a kv store that is scoped to the given prefix.

--- a/node/voting/events.go
+++ b/node/voting/events.go
@@ -136,7 +136,9 @@ type EventStore struct {
 	// connection.
 	eventWriter DB
 
-	writerMtx sync.Mutex // protects eventWriter, not applicable to read-only operations
+	// protects eventWriter, not applicable to read-only operations
+	// also protects access to the numEvents
+	writerMtx sync.Mutex
 
 	// numEvents tracks the count of events added by the listeners
 	// which doesn't have resolutions yet.

--- a/node/voting/sql.go
+++ b/node/voting/sql.go
@@ -45,7 +45,7 @@ const (
 		body BYTEA, -- body is the actual resolution info
 		type BYTEA NOT NULL, -- type is the type of resolution
 		vote_body_proposer BYTEA, -- vote_body_proposer is the identifier of the node that supplied the vote body
-		expiration INT8 NOT NULL, -- expiration is the blockheight at which the resolution expires
+		expiration INT8 NOT NULL, -- expiration is the UNIX epoch time in secs at which the resolution expires
 		extra_vote_id BOOLEAN NOT NULL DEFAULT FALSE, -- If vote_body_proposer had sent VoteID before VoteBody, this is set to true
 		UNIQUE (id, type),
 		FOREIGN KEY(type) REFERENCES ` + votingSchemaName + `.resolution_types(id) ON UPDATE CASCADE ON DELETE CASCADE
@@ -150,9 +150,6 @@ const (
 	deleteResolution = `DELETE FROM ` + votingSchemaName + `.resolutions WHERE id = $1;`
 
 	deleteResolutionsByTypeSQL = `DELETE FROM ` + votingSchemaName + `.resolutions WHERE type = ANY($1);`
-
-	// Subtracts the start height from the expiration height of all resolutions.
-	readjustExpirationsSQL = `UPDATE ` + votingSchemaName + `.resolutions SET expiration = expiration - $1;`
 
 	// createResolutionType creates a resolution type
 	createResolutionType = `INSERT INTO ` + votingSchemaName + `.resolution_types (id, name) VALUES ($1, $2)

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kwilteam/kwil-db/config"
 	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/kwilteam/kwil-db/core/types"
 	ethdeposits "github.com/kwilteam/kwil-db/extensions/listeners/eth_deposits"
 	"github.com/kwilteam/kwil-db/test/setup"
 	"github.com/kwilteam/kwil-db/test/specifications"
@@ -163,7 +164,7 @@ func TestValidatorJoinExpirySpecification(t *testing.T) {
 				}),
 			},
 			ConfigureGenesis: func(genDoc *config.GenesisConfig) {
-				genDoc.JoinExpiry = 5 // 5 sec at 1block/sec
+				genDoc.JoinExpiry = types.Duration(5 * time.Second)
 			},
 			DBOwner: "0xabc",
 		},


### PR DESCRIPTION
This PR changes the behavior of the block production by the leader:

Configurations:
- `propose_timeout`: used to specify the minimum duration to wait before proposing a new block with transactions. If set to 0, the behavior will simulate the `--automine` feature in the hardhat/ganache where the leader produces a block the moment the transactions become available. 
- `empty_block_timeout`: The duration to wait before proposing an empty block. 
Thus with this change the block intervals can range from propose_timeout to empty_block_timeout depending on the availability of the transactions in the mempool. 

Updates the resolution infra to now use expiry in terms of timestamp rather than number of blocks. 

Also makes some performance improvements to the engine to improve the blocksync performance.



