### PR TITLE
node: add block hash to BlockContext

### DIFF
--- a/common/context.go
+++ b/common/context.go
@@ -33,6 +33,8 @@ type BlockContext struct {
 	ChainContext *ChainContext
 	// Height gets the height of the current block.
 	Height int64
+	// Hash is the hash of the current block.
+	Hash types.Hash
 	// Timestamp is a timestamp of the current block, in seconds (UNIX epoch).
 	// It is set by the block proposer, and therefore may not be accurate.
 	// It should not be used for time-sensitive operations where incorrect

--- a/common/context.go
+++ b/common/context.go
@@ -34,6 +34,8 @@ type BlockContext struct {
 	// Height gets the height of the current block.
 	Height int64
 	// Hash is the hash of the current block.
+	// It can be empty if the block is the genesis block and
+	// no initial state hash was specified in the genesis configuration.
 	Hash types.Hash
 	// Timestamp is a timestamp of the current block, in seconds (UNIX epoch).
 	// It is set by the block proposer, and therefore may not be accurate.

--- a/node/block_processor/interfaces.go
+++ b/node/block_processor/interfaces.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 
 	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/config"
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/migrations"
 	"github.com/kwilteam/kwil-db/node/snapshotter"
@@ -40,7 +41,7 @@ type TxApp interface {
 	Finalize(ctx context.Context, db sql.DB, block *common.BlockContext) (approvedJoins, expiredJoins []*ktypes.AccountID, err error)
 	Commit() error
 	Rollback()
-	GenesisInit(ctx context.Context, db sql.DB, validators []*ktypes.Validator, genesisAccounts []*ktypes.Account, initialHeight int64, initialDBOwner string, chain *common.ChainContext) error
+	GenesisInit(ctx context.Context, db sql.DB, genesisConfig *config.GenesisConfig, chain *common.ChainContext) error
 	ApplyMempool(ctx *common.TxContext, db sql.DB, tx *ktypes.Transaction) error
 
 	Price(ctx context.Context, dbTx sql.DB, tx *ktypes.Transaction, chainContext *common.ChainContext) (*big.Int, error)

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -352,23 +352,7 @@ func (bp *BlockProcessor) InitChain(ctx context.Context) (int64, []byte, error) 
 
 	genCfg := bp.genesisParams
 
-	genesisAllocs := make([]*ktypes.Account, 0, len(genCfg.Allocs))
-	for _, acct := range genCfg.Allocs {
-		keyType, err := crypto.ParseKeyType(acct.KeyType)
-		if err != nil {
-			return -1, nil, fmt.Errorf("failed to parse key type %s: %w", acct.KeyType, err)
-		}
-
-		genesisAllocs = append(genesisAllocs, &ktypes.Account{
-			ID: &ktypes.AccountID{
-				Identifier: acct.ID.HexBytes,
-				KeyType:    keyType,
-			},
-			Balance: acct.Amount,
-		})
-	}
-
-	if err := bp.txapp.GenesisInit(ctx, genesisTx, genCfg.Validators, genesisAllocs, genCfg.InitialHeight, genCfg.DBOwner, bp.chainCtx); err != nil {
+	if err := bp.txapp.GenesisInit(ctx, genesisTx, genCfg, bp.chainCtx); err != nil {
 		return -1, nil, err
 	}
 
@@ -428,6 +412,7 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 		Timestamp:    req.Block.Header.Timestamp.Unix(),
 		ChainContext: bp.chainCtx,
 		Proposer:     req.Proposer,
+		Hash:         req.BlockID,
 	}
 
 	// Begin executing transactions. The chain context may be updated during the block execution.

--- a/node/block_processor/transactions_test.go
+++ b/node/block_processor/transactions_test.go
@@ -691,8 +691,7 @@ func (m *mockTxApp) Finalize(ctx context.Context, db sql.DB, block *common.Block
 	return nil, nil, nil
 }
 
-func (m *mockTxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, accounts []*types.Account,
-	initialHeight int64, dbowner string, chain *common.ChainContext) error {
+func (m *mockTxApp) GenesisInit(ctx context.Context, db sql.DB, _ *config.GenesisConfig, chain *common.ChainContext) error {
 	return nil
 }
 

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -964,7 +964,7 @@ func (d *dummyTxApp) Commit() error {
 
 func (d *dummyTxApp) Rollback() {}
 
-func (d *dummyTxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*ktypes.Validator, genesisAccounts []*ktypes.Account, initialHeight int64, dbOwner string, chain *common.ChainContext) error {
+func (d *dummyTxApp) GenesisInit(ctx context.Context, db sql.DB, _ *config.GenesisConfig, chain *common.ChainContext) error {
 	return nil
 }
 func (d *dummyTxApp) AccountInfo(ctx context.Context, dbTx sql.DB, identifier *ktypes.AccountID, pending bool) (balance *big.Int, nonce int64, err error) {

--- a/node/services/jsonrpc/usersvc/service.go
+++ b/node/services/jsonrpc/usersvc/service.go
@@ -724,9 +724,10 @@ func (svc *Service) txCtx(ctx context.Context, msg *types.CallMessage) (*common.
 	if err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorNodeInternal, "failed to get chain status: "+err.Error(), nil)
 	}
-	height, stamp := chainStat.Sync.BestBlockHeight, chainStat.Sync.BestBlockTime.Unix()
+	height, hash, stamp := chainStat.Sync.BestBlockHeight, chainStat.Sync.BestBlockHash, chainStat.Sync.BestBlockTime.Unix()
 	if chainStat.Sync.Syncing { // don't use known stale height and time stamp if node is syncing
 		height = -1
+		hash = types.Hash{}
 		stamp = -1
 	}
 
@@ -738,6 +739,7 @@ func (svc *Service) txCtx(ctx context.Context, msg *types.CallMessage) (*common.
 		BlockContext: &common.BlockContext{
 			Height:    height,
 			Timestamp: stamp,
+			Hash:      hash,
 		},
 	}, nil
 }

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -108,6 +108,11 @@ func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, genCfg *config.Genes
 		}
 	}
 
+	initialHash := types.Hash{}
+	if len(genCfg.StateHash) == types.HashLen {
+		copy(initialHash[:], genCfg.StateHash)
+	}
+
 	// we set an initial owner as the initial creator of schemas, roles, etc.
 	err := r.Engine.Execute(&common.EngineContext{
 		OverrideAuthz: true,
@@ -117,7 +122,7 @@ func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, genCfg *config.Genes
 			Signer: []byte("genesis"),
 			BlockContext: &common.BlockContext{
 				Height: genCfg.InitialHeight,
-				Hash:   types.Hash(genCfg.StateHash),
+				Hash:   initialHash,
 			},
 		},
 	}, db, "GRANT owner TO $user", map[string]any{

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -82,11 +82,10 @@ func NewTxApp(ctx context.Context, db sql.Executor, engine common.Engine, signer
 // and before any session is started.
 // It can assign the initial validator set and initial account balances.
 // It is only called once for a new chain.
-func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.Validator, genesisAccounts []*types.Account,
-	initialHeight int64, dbOwner string, chainCtx *common.ChainContext) error {
+func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, genCfg *config.GenesisConfig, chainCtx *common.ChainContext) error {
 
 	// Add Genesis Validators
-	for _, validator := range validators {
+	for _, validator := range genCfg.Validators {
 		err := r.Validators.SetValidatorPower(ctx, db, validator.Identifier, validator.KeyType, validator.Power)
 		if err != nil {
 			return err
@@ -94,8 +93,16 @@ func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.
 	}
 
 	// Fund Genesis Accounts
-	for _, account := range genesisAccounts {
-		err := r.Accounts.Credit(ctx, db, account.ID, account.Balance)
+	for _, alloc := range genCfg.Allocs {
+		keyType, err := crypto.ParseKeyType(alloc.KeyType)
+		if err != nil {
+			return err
+		}
+
+		err = r.Accounts.Credit(ctx, db, &types.AccountID{
+			Identifier: alloc.ID.HexBytes,
+			KeyType:    keyType,
+		}, alloc.Amount)
 		if err != nil {
 			return err
 		}
@@ -109,11 +116,12 @@ func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, validators []*types.
 			Caller: "genesis",
 			Signer: []byte("genesis"),
 			BlockContext: &common.BlockContext{
-				Height: initialHeight,
+				Height: genCfg.InitialHeight,
+				Hash:   types.Hash(genCfg.StateHash),
 			},
 		},
 	}, db, "GRANT owner TO $user", map[string]any{
-		"user": dbOwner,
+		"user": genCfg.DBOwner,
 	}, nil)
 	if err != nil {
 		return err


### PR DESCRIPTION
This PR adds block hash to BlockContext, as requested by @Yaiba.

It makes a minor refactor to pass in the genesis config to txapp. I felt this was appropriate because

1. We were pretty much just destructuring `config.GenesisConfig` into 5-6 args.
2. txapp already relied on the `config` package

I'm happy to change it back though, no strong opinion.
