### PR TITLE
remove duplicate auth/sig type from CallMessage

### DIFF
--- a/core/types/message.go
+++ b/core/types/message.go
@@ -41,7 +41,7 @@ type CallMessage struct {
 	// RPCs, in which case the Challenge field of the call body is also set.
 	// Note that this was historically called Signature, which was an
 	// *auth.Signature struct, but it is now a []byte that represents just the
-	// signature data since the signature is already in the AuthType field.
+	// signature data since the type is already in the AuthType field above.
 	SignatureData []byte `json:"signature"`
 }
 

--- a/core/types/message.go
+++ b/core/types/message.go
@@ -36,10 +36,13 @@ type CallMessage struct {
 	// Sender is the public key of the sender
 	Sender HexBytes `json:"sender"`
 
-	// Signature is the sender's signature of the serialized call body. This is
-	// only set when using authenticated call RPCs, in which case the Challenge
-	// field of the call body is also set.
-	Signature *auth.Signature `json:"signature"`
+	// SignatureData is the content of is the sender's signature of the
+	// serialized call body. This is only set when using authenticated call
+	// RPCs, in which case the Challenge field of the call body is also set.
+	// Note that this was historically called Signature, which was an
+	// *auth.Signature struct, but it is now a []byte that represents just the
+	// signature data since the signature is already in the AuthType field.
+	SignatureData []byte `json:"signature"`
 }
 
 const callMsgToSignTmplV0 = `Kwil view call.
@@ -99,7 +102,7 @@ func CreateCallMessage(ac *ActionCall, challenge []byte, signer auth.Signer) (*C
 			return nil, err
 		}
 
-		msg.Signature = sig
+		msg.SignatureData = sig.Data
 	}
 
 	return msg, nil

--- a/core/types/message_test.go
+++ b/core/types/message_test.go
@@ -23,7 +23,7 @@ func TestCreateCallMessage(t *testing.T) {
 		require.NotNil(t, msg.Body)
 		require.NotEmpty(t, msg.Body.Payload)
 		require.Empty(t, msg.Body.Challenge)
-		require.Empty(t, msg.Signature)
+		require.Empty(t, msg.SignatureData)
 		require.Empty(t, msg.AuthType)
 		require.Empty(t, msg.Sender)
 	})
@@ -45,7 +45,7 @@ func TestCreateCallMessage(t *testing.T) {
 		require.NotNil(t, msg)
 		require.Equal(t, mockSigner.authType, msg.AuthType)
 		require.Equal(t, mockSigner.identity, []byte(msg.Sender))
-		require.Empty(t, msg.Signature)
+		require.Empty(t, msg.SignatureData)
 	})
 
 	t.Run("create call message with invalid action call", func(t *testing.T) {
@@ -77,7 +77,7 @@ func TestCreateCallMessage(t *testing.T) {
 		require.NoError(t, err)
 		require.NotNil(t, msg)
 		require.Equal(t, challenge, msg.Body.Challenge)
-		require.NotNil(t, msg.Signature)
+		require.NotNil(t, msg.SignatureData)
 		require.Equal(t, mockSigner.authType, msg.AuthType)
 		require.Equal(t, mockSigner.identity, []byte(msg.Sender))
 	})

--- a/node/services/jsonrpc/usersvc/service.go
+++ b/node/services/jsonrpc/usersvc/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/core/crypto"
+	"github.com/kwilteam/kwil-db/core/crypto/auth"
 	"github.com/kwilteam/kwil-db/core/log"
 	jsonrpc "github.com/kwilteam/kwil-db/core/rpc/json"
 	userjson "github.com/kwilteam/kwil-db/core/rpc/json/user"
@@ -752,22 +753,20 @@ func (svc *Service) authenticate(msg *types.CallMessage, sigTxt string) *jsonrpc
 	// the signature on the serialized call message that include the challenge.
 
 	// The message must have a sig, sender, and challenge.
-	if msg.Signature == nil || len(msg.Sender) == 0 {
+	if len(msg.SignatureData) == 0 || len(msg.Sender) == 0 {
 		return jsonrpc.NewError(jsonrpc.ErrorCallChallengeNotFound, "signed call message with challenge required", nil)
 	}
 	if len(msg.Body.Challenge) != 32 {
 		return jsonrpc.NewError(jsonrpc.ErrorInvalidCallChallenge, "incorrect challenge data length", nil)
 	}
-	// The call message sender must be interpreted consistently with
-	// signature verification, so ensure the auth types match.
-	if msg.AuthType != msg.Signature.Type {
-		return jsonrpc.NewError(jsonrpc.ErrorMismatchCallAuthType, "different authentication schemes in signature and caller", nil)
-	}
 	// Ensure we issued the message's challenge.
 	if err := svc.verifyCallChallenge([32]byte(msg.Body.Challenge)); err != nil {
 		return err
 	}
-	err := authExt.VerifySignature(msg.Sender, []byte(sigTxt), msg.Signature)
+	err := authExt.VerifySignature(msg.Sender, []byte(sigTxt), &auth.Signature{
+		Data: msg.SignatureData,
+		Type: msg.AuthType,
+	})
 	if err != nil {
 		return jsonrpc.NewError(jsonrpc.ErrorInvalidCallSignature, "invalid signature on call message", nil)
 	}

--- a/node/services/jsonrpc/usersvc/service.go
+++ b/node/services/jsonrpc/usersvc/service.go
@@ -710,7 +710,7 @@ func (r *rowReader) read(row *common.Row) error {
 func (svc *Service) txCtx(ctx context.Context, msg *types.CallMessage) (*common.TxContext, *jsonrpc.Error) {
 	signer := msg.Sender
 	caller := "" // string representation of sender, if signed.  Otherwise, empty string
-	if signer != nil && msg.AuthType != "" {
+	if len(signer) > 0 && msg.AuthType != "" {
 		var err error
 		caller, err = authExt.GetIdentifier(msg.AuthType, signer)
 		if err != nil {


### PR DESCRIPTION
For testing and review.  Dont' merge unless tested with kwil-js
Convo with @KwilLuke:
https://kwilteam.slack.com/archives/C05RZNFKNJD/p1737575798988009