### PR TITLE
accouts: composite primary key over id and id_type

### DIFF
--- a/core/crypto/keys.go
+++ b/core/crypto/keys.go
@@ -76,6 +76,14 @@ func ParseKeyType(s string) (KeyType, error) {
 	return "", fmt.Errorf("unknown key type: %s", s)
 }
 
+func ParseKeyTypeID(id uint32) (KeyType, error) {
+	kt, ok := encodingIDs[id]
+	if !ok {
+		return "", fmt.Errorf("unknown key type ID: %d", id)
+	}
+	return kt, nil
+}
+
 func UnmarshalPublicKey(b []byte, kt KeyType) (PublicKey, error) {
 	kd, ok := keyTypes[kt]
 	if !ok {


### PR DESCRIPTION
This makes no functional or user visible changes, but it does alter how the account store tables work.

With

```json
"alloc": [
    {
      "id": "0xAfFDC06cF34aFD7D5801A13d48C92AD39609901D",
      "key_type": "secp256k1",
      "amount": 10000000000000000000000000000000000000000000
    }
  ],
```

we had

```
# table kwild_accts.accounts ;
┌─[ RECORD 1 ]──────────────────────────────────────────────────────────────────────────────┐
│ identifier │ \x14000000affdc06cf34afd7d5801a13d48c92ad39609901d09000000736563703235366b31 │
│ balance    │ 10000000000000000000000000000000000000000000                                 │
│ nonce      │ 0                                                                            │
└────────────┴──────────────────────────────────────────────────────────────────────────────┘
```

With this change we have

```
 # table kwild_accts.accounts ;
┌─[ RECORD 1 ]──────────────────────────────────────────────┐
│ identifier │ \xaffdc06cf34afd7d5801a13d48c92ad39609901d   │
│ id_type    │ 0                                            │
│ balance    │ 10000000000000000000000000000000000000000000 │
│ nonce      │ 0                                            │
└────────────┴──────────────────────────────────────────────┘
```

So more compact and readable for debugging.

This didn't take very long to do, so open to any suggestions even if it means something completely different.