### PR TITLE
fix rlp decode

### DIFF
--- a/core/types/serialize/encode.go
+++ b/core/types/serialize/encode.go
@@ -156,14 +156,6 @@ func Decode(bts []byte, v any) error {
 	return codec.Decode(val, v)
 }
 
-func DecodeWithEncodingType(bts []byte, v any, encodingType EncodingType) error {
-	codec, ok := encodings[encodingType]
-	if !ok {
-		return fmt.Errorf("unregistered encoding type: %d", encodingType)
-	}
-	return codec.Decode(bts, v)
-}
-
 // DecodeGeneric decodes the given serialized data into the given value. See
 // also Decode for use with an existing instance. This is generally no more
 // useful than Decode; it is syntactic sugar that requires no existing instance

--- a/extensions/resolutions/credit/credit.go
+++ b/extensions/resolutions/credit/credit.go
@@ -61,7 +61,7 @@ func (a *AccountCreditResolution) MarshalBinary() ([]byte, error) {
 // UnmarshalBinary unmarshals the AccountCreditResolution from binary.
 // It is the inverse of MarshalBinary, and uses the same serialization library.
 func (a *AccountCreditResolution) UnmarshalBinary(data []byte) error {
-	return serialize.DecodeWithEncodingType(data, a, rlp.EncodingTypeRLP)
+	return serialize.Decode(data, a)
 }
 
 // resolutionConfig defines the rules for the credit_account resolution.

--- a/node/migrations/changesets.go
+++ b/node/migrations/changesets.go
@@ -71,7 +71,7 @@ func (cs *changesetMigration) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary unmarshals the ChangesetMigration from a binary format.
 func (cs *changesetMigration) UnmarshalBinary(data []byte) error {
-	return serialize.DecodeWithEncodingType(data, cs, rlp.EncodingTypeRLP)
+	return serialize.Decode(data, cs)
 }
 
 // ChangesetMigrationResolution is the definition for changeset migration vote type in Kwil's voting system.

--- a/node/migrations/migrations.go
+++ b/node/migrations/migrations.go
@@ -64,7 +64,7 @@ func (md MigrationDeclaration) MarshalBinary() ([]byte, error) {
 
 // UnmarshalBinary unmarshals the MigrationDeclaration from a binary format.
 func (md *MigrationDeclaration) UnmarshalBinary(data []byte) error {
-	return serialize.DecodeWithEncodingType(data, md, rlp.EncodingTypeRLP)
+	return serialize.Decode(data, md)
 }
 
 // MigrationResolution is the definition for the network migration vote type in Kwil's

--- a/node/migrations/migrator.go
+++ b/node/migrations/migrator.go
@@ -454,7 +454,7 @@ func (bs BlockSpends) MarshalBinary() ([]byte, error) {
 var _ encoding.BinaryUnmarshaler = (*BlockSpends)(nil)
 
 func (bs *BlockSpends) UnmarshalBinary(bts []byte) error {
-	return serialize.DecodeWithEncodingType(bts, bs, rlp.EncodingTypeRLP)
+	return serialize.Decode(bts, bs)
 }
 
 type chunkWriter struct {

--- a/node/rlp/rlp.go
+++ b/node/rlp/rlp.go
@@ -11,7 +11,7 @@ import (
 )
 
 func init() {
-	serialize.RegisterCodec(rlpCodec)
+	serialize.RegisterCodec(Codec)
 }
 
 // RLP is still used in a few places in the node codebase, including
@@ -20,7 +20,7 @@ func init() {
 
 const EncodingTypeRLP = serialize.EncodingTypeCustom + 1
 
-var rlpCodec = &serialize.Codec{
+var Codec = &serialize.Codec{
 	Type: EncodingTypeRLP,
 	Name: "RLP",
 	Encode: func(val any) ([]byte, error) {


### PR DESCRIPTION
This fixes RLP decoding.   Decoding with the `seriailize` package gets the codec from a prefix in the `[]byte`.  It is not specified manually.  That is only for encoding.

Example RLP support, e.g. from an extension:

```go
package main

import (
	"bytes"

	"github.com/kwilteam/kwil-db/core/types/serialize"
	"github.com/kwilteam/kwil-db/node/rlp" // register RLP codec with serialize package
)

func main() {
	s := "hi"
	bts, err := serialize.EncodeWithEncodingType(s, rlp.EncodingTypeRLP)
	if err != nil {
		panic(err)
	}

	bts2, err := serialize.EncodeWithCodec(s, *rlp.Codec)
	if err != nil {
		panic(err)
	}

	if !bytes.Equal(bts, bts2) {
		panic("not equal")
	}

	var s2 string
	err = serialize.Decode(bts, &s2)
	if err != nil {
		panic(err)
	}

	println(s2) // "hi"
}
```
