### PR TITLE
improve several kwild cmd issues with config parsing and error handling

### DIFF
--- a/app/key/gen.go
+++ b/app/key/gen.go
@@ -28,6 +28,9 @@ func GenCmd() *cobra.Command {
 		Long:    "The `gen` command generates a private key for use by validators.",
 		Example: genExample,
 		Args:    cobra.RangeArgs(0, 1),
+		// Override the root command's PersistentPreRunE, so that we don't
+		// try to read the config from a ~/.kwild directory
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
 		RunE: func(cmd *cobra.Command, args []string) error {
 			keyType := crypto.KeyTypeSecp256k1 // default with 0 args
 			if len(args) > 0 {

--- a/app/key/info.go
+++ b/app/key/info.go
@@ -33,6 +33,9 @@ func InfoCmd() *cobra.Command {
 		Long:    infoLong,
 		Example: infoExample,
 		Args:    cobra.MaximumNArgs(1),
+		// Override the root command's PersistentPreRunE, so that we don't
+		// try to read the config from a ~/.kwild directory
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
 		RunE: func(cmd *cobra.Command, args []string) error {
 			// if len(args) == 1, then the private key is passed as a hex string
 			// otherwise, it is passed as a file path

--- a/app/node/start.go
+++ b/app/node/start.go
@@ -16,7 +16,7 @@ func StartCmd() *cobra.Command {
 	var dbOwner string
 	cmd := &cobra.Command{
 		Use:               "start",
-		Short:             "Start the node (default command if none given)",
+		Short:             "Start the node",
 		Long:              "The `start` command starts the Kwil DB blockchain node.",
 		DisableAutoGenTag: true,
 		SilenceUsage:      true,

--- a/app/root.go
+++ b/app/root.go
@@ -61,18 +61,23 @@ func RootCmd() *cobra.Command {
 	display.BindOutputFormatFlag(cmd) // --output/-o
 
 	// There is a virtual "node" command grouping, but no actual "node" command yet.
-	cmd.AddCommand(node.StartCmd())
-	cmd.AddCommand(node.PrintConfigCmd())
+	cmd.AddCommand(node.StartCmd())       // needs merged config
+	cmd.AddCommand(node.PrintConfigCmd()) // needs merged config
 
+	// This group of command uses the merged config for fallback admin listen
+	// addr if the --rpcserver flag is not set.
 	cmd.AddCommand(rpc.NewAdminCmd())
 	cmd.AddCommand(validator.NewValidatorsCmd())
 	cmd.AddCommand(params.NewConsensusCmd())
-	cmd.AddCommand(setup.SetupCmd())
 	cmd.AddCommand(whitelist.WhitelistCmd())
+	cmd.AddCommand(block.NewBlockExecCmd())
+	cmd.AddCommand(migration.NewMigrationCmd())
+
+	cmd.AddCommand(setup.SetupCmd()) // only kinda needs merged config for `setup reset`
+
 	cmd.AddCommand(key.KeyCmd())
 	cmd.AddCommand(snapshot.NewSnapshotCmd())
-	cmd.AddCommand(migration.NewMigrationCmd())
-	cmd.AddCommand(block.NewBlockExecCmd())
+
 	cmd.AddCommand(seed.SeedCmd())
 	cmd.AddCommand(utils.NewCmdUtils())
 	cmd.AddCommand(verCmd.NewVersionCmd())

--- a/app/seed/seed.go
+++ b/app/seed/seed.go
@@ -25,6 +25,7 @@ func SeedCmd() *cobra.Command {
 		Short: "Run a network seeder",
 		Long:  "The `seed` command starts a peer seeder process to crawl and bootstrap the network. This does not use the kwild node config. It will bind to TCP port 6609, and store config and data in the specified directory.",
 		Args:  cobra.NoArgs,
+
 		RunE: func(cmd *cobra.Command, args []string) error {
 			logger := log.New(log.WithWriter(os.Stdout), log.WithFormat(log.FormatUnstructured),
 				log.WithName("SEEDER"))

--- a/app/setup/genesis.go
+++ b/app/setup/genesis.go
@@ -61,6 +61,9 @@ func GenesisCmd() *cobra.Command {
 			DisableDefaultCmd: true,
 		},
 		Args: cobra.NoArgs,
+		// Override the root command's PersistentPreRunE, so that we don't
+		// try to read the config from a ~/.kwild directory.
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
 		RunE: func(cmd *cobra.Command, args []string) error {
 			outDir, err := node.ExpandPath(output)
 			if err != nil {

--- a/app/setup/testnet.go
+++ b/app/setup/testnet.go
@@ -33,10 +33,14 @@ func TestnetCmd() *cobra.Command {
 	var outDir, dbOwner string
 
 	cmd := &cobra.Command{
+
 		Use:   "testnet",
 		Short: "Generate configuration for a new test network with multiple nodes",
 		Long: "The `testnet` command generates a configuration for a new test network with multiple nodes. " +
 			"For a configuration set that can be run on the same host, use the `--unique-ports` flag.",
+		// Override the root command's PersistentPreRunE, so that we don't
+		// try to read the config from a ~/.kwild directory
+		PersistentPreRunE: func(cmd *cobra.Command, args []string) error { return nil },
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return GenerateTestnetConfigs(&TestnetConfig{
 				RootDir:      outDir,

--- a/app/shared/display/format.go
+++ b/app/shared/display/format.go
@@ -183,7 +183,11 @@ func PrintCmd(cmd *cobra.Command, msg MsgFormatter) error {
 	return prettyPrint(wrappedMsg, OutputFormat(format), cmd.OutOrStdout(), cmd.OutOrStderr())
 }
 
-// PrintErr prints the error according to the commands output format flag.
+// PrintErr prints the error according to the commands output format flag. The
+// returned error is nil if the message it was printed successfully. Thus, this
+// function must ONLY be called from within a cobra.Command's RunE function or
+// or returned directly by the RunE function, NOT used to direct application
+// logic since the returned error no longer pertains to the initial error.
 func PrintErr(cmd *cobra.Command, err error) error {
 	outputFormat, err2 := getOutputFormat(cmd)
 	if err2 != nil {


### PR DESCRIPTION
Going through several small things that @KwilLuke mentioned yesterday

- some commands try to read `~/.kwild/config.toml` unnecessarily, leading to confusing errors if the file is invalid since it's really irrelevant to the command
- fix misuses of `display.PrintErr` and document proper use
- use the `conf.ActiveConfig`, which is the merged configuration in several commands instead of manually loading the toml file
- revise the `start` command's docs to reflect that it is no longer the default command
- `setup init` will error if the destination directory already exists.  Previous it ran with unpredictable results.