### PR TITLE
add namespace manager

### DIFF
--- a/app/node/deps.go
+++ b/app/node/deps.go
@@ -17,7 +17,7 @@ import (
 // datasets in different postgresql "schema".
 type dbOpener func(ctx context.Context, dbName string, maxConns uint32) (*pg.DB, error)
 
-func newDBOpener(host, port, user, pass string) dbOpener {
+func newDBOpener(host, port, user, pass string, filterSchemas func(string) bool) dbOpener {
 	return func(ctx context.Context, dbName string, maxConns uint32) (*pg.DB, error) {
 		cfg := &pg.DBConfig{
 			PoolConfig: pg.PoolConfig{
@@ -66,9 +66,10 @@ type coreDependencies struct {
 	adminKey *tls.Certificate
 	// autogen  bool
 
-	logger     log.Logger
-	dbOpener   dbOpener
-	poolOpener poolOpener
+	logger           log.Logger
+	dbOpener         dbOpener
+	namespaceManager *namespaceManager
+	poolOpener       poolOpener
 }
 
 // closeFuncs holds a list of closers

--- a/app/node/deps.go
+++ b/app/node/deps.go
@@ -30,6 +30,7 @@ func newDBOpener(host, port, user, pass string, filterSchemas func(string) bool)
 				},
 				MaxConns: maxConns,
 			},
+			SchemaFilter: filterSchemas,
 		}
 		return pg.NewDB(ctx, cfg)
 	}

--- a/app/node/namespace_manager.go
+++ b/app/node/namespace_manager.go
@@ -71,6 +71,9 @@ func (n *namespaceManager) Ready() {
 // ListPostgresSchemasToDump returns an ordered list of postgres
 // schemas that should be included when exporting database state.
 func (n *namespaceManager) ListPostgresSchemasToDump() []string {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
 	res := make([]string, len(n.namespaces)+2)
 	res[0] = engine.InternalEnginePGSchema
 	res[1] = engine.InfoNamespace

--- a/app/node/namespace_manager.go
+++ b/app/node/namespace_manager.go
@@ -51,12 +51,13 @@ func (n *namespaceManager) Unlock() {
 // and for namespaces that are only views (e.g. "info")
 // If it is not ready, it panics.
 func (n *namespaceManager) Filter(ns string) bool {
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+
 	if !n.ready {
 		// this would indicate a bug in our startup process
 		panic("namespace manager not ready")
 	}
-	n.mu.RLock()
-	defer n.mu.RUnlock()
 	_, ok := n.namespaces[ns]
 	return ok
 }
@@ -73,6 +74,11 @@ func (n *namespaceManager) Ready() {
 func (n *namespaceManager) ListPostgresSchemasToDump() []string {
 	n.mu.RLock()
 	defer n.mu.RUnlock()
+
+	if !n.ready {
+		// this would indicate a bug in our startup process
+		panic("namespace manager not ready")
+	}
 
 	res := make([]string, len(n.namespaces)+2)
 	res[0] = engine.InternalEnginePGSchema

--- a/app/node/namespace_manager.go
+++ b/app/node/namespace_manager.go
@@ -1,0 +1,62 @@
+package node
+
+import "sync"
+
+func newNamespaceManager() *namespaceManager {
+	return &namespaceManager{
+		namespaces: make(map[string]struct{}),
+	}
+}
+
+// namespaceManager keeps track of namespaces in memory.
+// It is simply used as a way for the engine to communicate the set
+// of namespaces
+type namespaceManager struct {
+	mu sync.RWMutex
+	// ready is true if the manager is ready to be used.
+	// It is set after the engine has created and has read in to
+	// memory the set of namespaces.
+	ready      bool
+	namespaces map[string]struct{}
+}
+
+// RegisterNamespace registers a namespace with the manager
+func (n *namespaceManager) RegisterNamespace(ns string) {
+	n.namespaces[ns] = struct{}{}
+}
+
+// UnregisterNamespace unregisters a namespace with the manager
+func (n *namespaceManager) UnregisterAllNamespaces() {
+	n.namespaces = make(map[string]struct{})
+}
+
+// Lock locks the manager
+// It should be called before registering or unregistering namespaces
+func (n *namespaceManager) Lock() {
+	n.mu.Lock()
+}
+
+// Unlock unlocks the manager
+func (n *namespaceManager) Unlock() {
+	n.mu.Unlock()
+}
+
+// Filter returns true if the namespace is registered.
+// If it is not ready, it panics.
+func (n *namespaceManager) Filter(ns string) bool {
+	if !n.ready {
+		// this would indicate a bug in our startup process
+		panic("namespace manager not ready")
+	}
+	n.mu.RLock()
+	defer n.mu.RUnlock()
+	_, ok := n.namespaces[ns]
+	return ok
+}
+
+// Ready sets the manager to be ready
+func (n *namespaceManager) Ready() {
+	n.mu.Lock()
+	defer n.mu.Unlock()
+	n.ready = true
+}

--- a/app/node/node.go
+++ b/app/node/node.go
@@ -134,16 +134,19 @@ func runNode(ctx context.Context, rootDir string, cfg *config.Config, autogen bo
 		}
 	}
 
+	nsmgr := newNamespaceManager()
+
 	d := &coreDependencies{
-		ctx:        ctx,
-		rootDir:    rootDir,
-		adminKey:   tlsKeyPair,
-		cfg:        cfg,
-		genesisCfg: genConfig,
-		privKey:    privKey,
-		logger:     logger,
-		dbOpener:   newDBOpener(host, port, user, pass),
-		poolOpener: newPoolBOpener(host, port, user, pass),
+		ctx:              ctx,
+		rootDir:          rootDir,
+		adminKey:         tlsKeyPair,
+		cfg:              cfg,
+		genesisCfg:       genConfig,
+		privKey:          privKey,
+		logger:           logger,
+		dbOpener:         newDBOpener(host, port, user, pass, nsmgr.Filter),
+		namespaceManager: nsmgr,
+		poolOpener:       newPoolBOpener(host, port, user, pass),
 	}
 
 	// Catch any panic from buildServer. We use a panic based build failure

--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -13,7 +13,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
 	clientType "github.com/kwilteam/kwil-db/core/client/types"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/node/engine/interpreter"
+	"github.com/kwilteam/kwil-db/node/engine"
 
 	"github.com/spf13/cobra"
 )
@@ -184,7 +184,7 @@ func GetParamList(ctx context.Context,
 	query func(ctx context.Context, query string, args map[string]any) (*types.QueryResult, error),
 	namespace, action string) ([]NamedParameter, error) {
 	if namespace == "" {
-		namespace = interpreter.DefaultNamespace
+		namespace = engine.DefaultNamespace
 	}
 
 	res, err := query(ctx, "{info}SELECT parameter_names, parameter_types FROM actions WHERE namespace = $namespace AND name = $action", map[string]any{

--- a/cmd/kwil-cli/cmds/database/flags.go
+++ b/cmd/kwil-cli/cmds/database/flags.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/kwilteam/kwil-db/node/engine/interpreter"
+	"github.com/kwilteam/kwil-db/node/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +19,7 @@ const (
 // If the namespace flag is not set, returns wasSet as false.
 func getSelectedNamespace(cmd *cobra.Command) (namespace string, wasSet bool, err error) {
 	if !cmd.Flags().Changed(nameFlag) {
-		return interpreter.DefaultNamespace, false, nil
+		return engine.DefaultNamespace, false, nil
 	}
 
 	name, err := cmd.Flags().GetString(nameFlag)

--- a/cmd/kwil-cli/cmds/exec-action.go
+++ b/cmd/kwil-cli/cmds/exec-action.go
@@ -16,7 +16,7 @@ import (
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/helpers"
 	clientType "github.com/kwilteam/kwil-db/core/client/types"
 	"github.com/kwilteam/kwil-db/core/types"
-	"github.com/kwilteam/kwil-db/node/engine/interpreter"
+	"github.com/kwilteam/kwil-db/node/engine"
 	"github.com/spf13/cobra"
 )
 
@@ -349,7 +349,7 @@ func GetParamList(ctx context.Context,
 	query func(ctx context.Context, query string, args map[string]any) (*types.QueryResult, error),
 	namespace, action string) ([]NamedParameter, error) {
 	if namespace == "" {
-		namespace = interpreter.DefaultNamespace
+		namespace = engine.DefaultNamespace
 	}
 
 	res, err := query(ctx, "{info}SELECT parameter_names, parameter_types FROM actions WHERE namespace = $namespace AND name = $action", map[string]any{

--- a/node/engine/interpreter/context.go
+++ b/node/engine/interpreter/context.go
@@ -111,7 +111,7 @@ func (e *executionContext) getTable(namespace, tableName string) (*engine.Table,
 // These rules are not handled in the accessController because they are always
 // enforced, regardless of the roles and privileges of the caller.
 func (e *executionContext) checkNamespaceMutatbility() error {
-	if e.scope.namespace == infoNamespace {
+	if e.scope.namespace == engine.InfoNamespace {
 		return engine.ErrCannotMutateInfoNamespace
 	}
 

--- a/node/engine/interpreter/interpreter.go
+++ b/node/engine/interpreter/interpreter.go
@@ -486,7 +486,7 @@ func (i *baseInterpreter) execute(ctx *common.EngineContext, db sql.DB, statemen
 		}
 	}()
 
-	execCtx, err := i.newExecCtx(ctx, db, DefaultNamespace, toplevel)
+	execCtx, err := i.newExecCtx(ctx, db, engine.DefaultNamespace, toplevel)
 	if err != nil {
 		return err
 	}
@@ -564,7 +564,7 @@ func (i *baseInterpreter) call(ctx *common.EngineContext, db sql.DB, namespace, 
 	}
 
 	if namespace == "" {
-		namespace = DefaultNamespace
+		namespace = engine.DefaultNamespace
 	}
 	namespace = strings.ToLower(namespace)
 	action = strings.ToLower(action)
@@ -662,17 +662,12 @@ func (i *baseInterpreter) syncNamespaceManager() {
 	defer i.namespaceRegister.Unlock()
 	i.namespaceRegister.UnregisterAllNamespaces()
 	for ns := range i.namespaces {
-		if ns == infoNamespace {
+		if ns == engine.InfoNamespace {
 			continue
 		}
 		i.namespaceRegister.RegisterNamespace(ns)
 	}
 }
-
-const (
-	DefaultNamespace = "main"
-	infoNamespace    = "info"
-)
 
 var builtInExecutables = func() map[string]*executable {
 	execs := make(map[string]*executable)

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -2598,7 +2598,7 @@ func newTestDB() (*pg.DB, error) {
 // It is seeded with the default tables.
 
 func newTestInterp(t *testing.T, tx sql.DB, seeds []string, includeTestTables bool) *interpreter.ThreadSafeInterpreter {
-	interp, err := interpreter.NewInterpreter(context.Background(), tx, &common.Service{}, nil, nil)
+	interp, err := interpreter.NewInterpreter(context.Background(), tx, &common.Service{}, nil, nil, nil)
 	require.NoError(t, err)
 
 	engCtx := newEngineCtx(defaultCaller)

--- a/node/engine/interpreter/planner.go
+++ b/node/engine/interpreter/planner.go
@@ -1982,7 +1982,7 @@ func (i *interpreterPlanner) VisitDropNamespaceStatement(p0 *parse.DropNamespace
 			return fmt.Errorf(`%w: namespace "%s" does not exist`, engine.ErrNamespaceNotFound, p0.Namespace)
 		}
 
-		if p0.Namespace == DefaultNamespace || p0.Namespace == infoNamespace {
+		if p0.Namespace == engine.DefaultNamespace || p0.Namespace == engine.InfoNamespace {
 			return fmt.Errorf(`%w: "%s"`, engine.ErrCannotDropBuiltinNamespace, p0.Namespace)
 		}
 		if ns.namespaceType == namespaceTypeExtension {

--- a/node/engine/interpreter/sql_test.go
+++ b/node/engine/interpreter/sql_test.go
@@ -318,7 +318,7 @@ func Test_built_in_sql(t *testing.T) {
 			require.NoError(t, err)
 			defer tx.Rollback(ctx) // always rollback to avoid cleanup
 
-			interp, err := NewInterpreter(ctx, tx, &common.Service{}, nil, nil)
+			interp, err := NewInterpreter(ctx, tx, &common.Service{}, nil, nil, nil)
 			require.NoError(t, err)
 			_ = interp
 
@@ -374,7 +374,7 @@ func Test_Metadata(t *testing.T) {
 	err = precompiles.RegisterPrecompile("store_test", testSchemaExt)
 	require.NoError(t, err)
 
-	interp, err := NewInterpreter(ctx, tx, &common.Service{}, nil, nil)
+	interp, err := NewInterpreter(ctx, tx, &common.Service{}, nil, nil, nil)
 	require.NoError(t, err)
 	_ = interp
 
@@ -1164,7 +1164,7 @@ func Test_Transactionality(t *testing.T) {
 	require.NoError(t, err)
 	defer tx.Rollback(ctx) // always rollback to avoid cleanup
 
-	interp, err := NewInterpreter(ctx, tx, &common.Service{}, nil, nil)
+	interp, err := NewInterpreter(ctx, tx, &common.Service{}, nil, nil, nil)
 	require.NoError(t, err)
 	_ = interp
 

--- a/node/engine/interpreter/sql_test.go
+++ b/node/engine/interpreter/sql_test.go
@@ -1186,7 +1186,7 @@ func Test_Transactionality(t *testing.T) {
 	require.NoError(t, err)
 
 	// we will check that the first table was not created
-	_, ok := interp.i.namespaces[DefaultNamespace].tables["table1"]
+	_, ok := interp.i.namespaces[engine.DefaultNamespace].tables["table1"]
 	require.False(t, ok)
 
 	// fix the bug and continue

--- a/node/engine/types.go
+++ b/node/engine/types.go
@@ -188,3 +188,9 @@ type NamespaceRegister interface {
 	RegisterNamespace(ns string)
 	UnregisterAllNamespaces()
 }
+
+const (
+	DefaultNamespace       = "main"
+	InfoNamespace          = "info"
+	InternalEnginePGSchema = "kwild_engine"
+)

--- a/node/engine/types.go
+++ b/node/engine/types.go
@@ -181,3 +181,10 @@ const (
 	// A primary index cannot exist on a table that also has a primary key.
 	PRIMARY IndexType = "PRIMARY"
 )
+
+type NamespaceRegister interface {
+	Lock()
+	Unlock()
+	RegisterNamespace(ns string)
+	UnregisterAllNamespaces()
+}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -182,7 +182,7 @@ func (tc SchemaTest) Run(ctx context.Context, opts *Options) error {
 					Logger:      logger,
 					LocalConfig: &config.Config{},
 					Identity:    []byte("node"),
-				}, accs, votes)
+				}, accs, votes, nil)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
As discussed, I have added a way for other parts of Kwil to read the current set of namespaces.

Something worth noting is that namespaces can be read in the middle of a block, so it is not transactional within the engine (e.g. if a block has 10 txs, and a namespace is created in tx 1 of 10, the system will see it before the other 9 txs commit).

This can be fixed, but it requires writing to the manager at a higher level (in block processor)
