### PR TITLE
txapp: grant ownership to db owner is idempotent

### DIFF
--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -125,7 +125,7 @@ func (r *TxApp) GenesisInit(ctx context.Context, db sql.DB, genCfg *config.Genes
 				Hash:   initialHash,
 			},
 		},
-	}, db, "GRANT owner TO $user", map[string]any{
+	}, db, "GRANT IF NOT GRANTED owner TO $user", map[string]any{
 		"user": genCfg.DBOwner,
 	}, nil)
 	if err != nil {


### PR DESCRIPTION
This fixes a bug where a network that starts from a snapshot fails to start due to an owner already existing.
