### PR TITLE
propagate context to node constructor

### DIFF
--- a/app/node/build.go
+++ b/app/node/build.go
@@ -440,7 +440,7 @@ func buildNode(d *coreDependencies, mp *mempool.Mempool, bs *store.BlockStore,
 		DBConfig:    &d.cfg.DB,
 	}
 
-	node, err := node.NewNode(nc)
+	node, err := node.NewNode(d.ctx, nc)
 	if err != nil {
 		failBuild(err, "failed to create node")
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -144,7 +144,7 @@ type Node struct {
 
 // NewNode creates a new node. The config struct is for required configuration,
 // and the functional options for optional settings, like dependency overrides.
-func NewNode(cfg *Config, opts ...Option) (*Node, error) {
+func NewNode(ctx context.Context, cfg *Config, opts ...Option) (*Node, error) {
 	options := &options{}
 	for _, opt := range opts {
 		opt(options)
@@ -218,7 +218,6 @@ func NewNode(cfg *Config, opts ...Option) (*Node, error) {
 	}
 
 	mode := dht.ModeServer
-	ctx := context.Background()
 	dht, err := makeDHT(ctx, host, nil, mode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create DHT: %w", err)

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -151,7 +151,7 @@ func TestSingleNodeMocknet(t *testing.T) {
 		Statesync:   &defaultConfigSet.StateSync,
 		BlockProc:   &dummyBP{vals: valSetList},
 	}
-	node1, err := NewNode(cfg1, WithHost(h1))
+	node1, err := NewNode(context.Background(), cfg1, WithHost(h1))
 	if err != nil {
 		t.Fatalf("Failed to create Node 1: %v", err)
 	}
@@ -290,7 +290,7 @@ func TestDualNodeMocknet(t *testing.T) {
 		Statesync:   &defaultConfigSet.StateSync,
 		BlockProc:   &dummyBP{vals: valSetList},
 	}
-	node1, err := NewNode(cfg1, WithHost(h1))
+	node1, err := NewNode(context.Background(), cfg1, WithHost(h1))
 	if err != nil {
 		t.Fatalf("Failed to create Node 1: %v", err)
 	}
@@ -359,7 +359,7 @@ func TestDualNodeMocknet(t *testing.T) {
 		Statesync:   &defaultConfigSet.StateSync,
 		BlockProc:   &dummyBP{vals: valSetList},
 	}
-	node2, err := NewNode(cfg2, WithHost(h2))
+	node2, err := NewNode(context.Background(), cfg2, WithHost(h2))
 	if err != nil {
 		t.Fatalf("Failed to create Node 2: %v", err)
 	}

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -114,7 +114,7 @@ func makeTestHosts(t *testing.T, nNodes, nExtraHosts int, blockInterval time.Dur
 			Consensus:   ce,
 			BlockProc:   &dummyBP{},
 		}
-		node, err := NewNode(cfg, WithHost(h))
+		node, err := NewNode(context.Background(), cfg, WithHost(h))
 		if err != nil {
 			t.Fatalf("Failed to create Node 1: %v", err)
 		}


### PR DESCRIPTION
FYI @charithabandi. This fixes a minor bug with context propagation.
