### PR TITLE
autogen, peercount, logging updates

### DIFF
--- a/app/node/deps.go
+++ b/app/node/deps.go
@@ -65,7 +65,6 @@ type coreDependencies struct {
 	closers *closeFuncs // for clean close on failBuild
 
 	adminKey *tls.Certificate
-	// autogen  bool
 
 	logger           log.Logger
 	dbOpener         dbOpener

--- a/app/node/node.go
+++ b/app/node/node.go
@@ -318,7 +318,7 @@ func loadGenesisAndPrivateKey(rootDir string, autogen bool, dbOwner string) (pri
 		}
 		// If the genesis file exists and --autogen was used, disallow a genesis
 		// file with either multiple validators or a different leader the self.
-		if autogen && (len(genCfg.Validators) > 0 || !genCfg.Leader.PublicKey.Equals(privKey.Public())) {
+		if autogen && (len(genCfg.Validators) > 1 || !genCfg.Leader.PublicKey.Equals(privKey.Public())) {
 			return nil, nil, errors.New("cannot use --autogen with genesis config for a multi-node network")
 		}
 		return privKey, genCfg, nil

--- a/config/config.go
+++ b/config/config.go
@@ -255,9 +255,10 @@ func DefaultConfig() *Config {
 		LogFormat: log.FormatUnstructured,
 		LogOutput: []string{"stdout", "kwild.log"},
 		P2P: PeerConfig{
-			ListenAddress: "0.0.0.0:6600",
-			Pex:           true,
-			BootNodes:     []string{},
+			ListenAddress:     "0.0.0.0:6600",
+			Pex:               true,
+			BootNodes:         []string{},
+			TargetConnections: 20,
 		},
 		Consensus: ConsensusConfig{
 			ProposeTimeout:        types.Duration(1000 * time.Millisecond),
@@ -328,11 +329,12 @@ type Config struct {
 
 // PeerConfig corresponds to the [p2p] section of the config.
 type PeerConfig struct {
-	ListenAddress string   `toml:"listen" comment:"address in host:port format to listen on for P2P connections"`
-	Pex           bool     `toml:"pex" comment:"enable peer exchange"`
-	BootNodes     []string `toml:"bootnodes" comment:"bootnodes to connect to on startup"`
-	PrivateMode   bool     `toml:"private" comment:"operate in private mode using a node ID whitelist"`
-	Whitelist     []string `toml:"whitelist" comment:"allowed node IDs when in private mode"`
+	ListenAddress     string   `toml:"listen" comment:"address in host:port format to listen on for P2P connections"`
+	Pex               bool     `toml:"pex" comment:"enable peer exchange"`
+	BootNodes         []string `toml:"bootnodes" comment:"bootnodes to connect to on startup"`
+	PrivateMode       bool     `toml:"private" comment:"operate in private mode using a node ID whitelist"`
+	Whitelist         []string `toml:"whitelist" comment:"allowed node IDs when in private mode"`
+	TargetConnections int      `toml:"target_connections" comment:"target number of connections to maintain"`
 }
 
 type DBConfig struct {

--- a/contrib/docker/compose/kwil/docker-compose.yml
+++ b/contrib/docker/compose/kwil/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 volumes:
   pgkwil:
     driver: local
@@ -34,14 +32,13 @@ services:
     container_name: kwild-single
     image: kwild:latest
     build:
-      context: ../../../
-      dockerfile: ./build/package/docker/kwild.dockerfile
+      context: ../../../../../
+      dockerfile: ../../kwild.dockerfile
     ports:
       - "8484:8484"
       - "6600:6600"
     environment:
-      - LOG=${LOG:-cometbft.log}
-      - KWILD_HOME=/app/.kwild
+      - KWILD_ROOT=/app/.kwild
     volumes:
       - ./testnode/:/app/.kwild/
     depends_on:
@@ -53,14 +50,17 @@ services:
     command: |
       --autogen
       --root=/app/.kwild
+      --log-format=plain
       --log-level=debug
-      --app.admin-listen-addr=/tmp/admin.socket
-      --chain.p2p.external-address=tcp://0.0.0.0:26656
-      --chain.rpc.listen-addr=tcp://0.0.0.0:26657
-      --app.pg-db-host=172.5.100.3
-      --app.pg-db-port=5432
-      --app.pg-db-user=kwild
-      --app.pg-db-pass=kwild
+      --admin.listen=/tmp/kwild.socket
+      --rpc.listen=0.0.0.0:8484
+      --p2p.listen=0.0.0.0:6600
+      --consensus.propose-timeout=200ms
+      --consensus.empty-block-timeout=6s
+      --db.host=172.5.100.3
+      --db.port=5432
+      --db.user=kwild
+      --db.pass=kwild
     healthcheck:
       test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
       interval: 2s

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -576,7 +576,8 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 		}
 	}
 
-	bp.log.Info("Executed Block", "height", req.Height, "blkID", req.BlockID, "appHash", nextHash, "numTxs", req.Block.Header.NumTxns)
+	// The CE will log the same thing, so this is a Debug message.
+	bp.log.Debug("Executed Block", "height", req.Height, "blkID", req.BlockID, "appHash", nextHash, "numTxs", req.Block.Header.NumTxns)
 	if len(bp.chainCtx.NetworkUpdates) != 0 {
 		bp.log.Info("Consensus updates", "hash", paramUpdatesHash, "updates", bp.chainCtx.NetworkUpdates)
 	}

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -216,6 +216,10 @@ func (ce *ConsensusEngine) commit(ctx context.Context) error {
 	return nil
 }
 
+// nextState sets the lastCommit in state.lc from the current block proposal
+// execution and commit results, resets the other state fields such as block
+// proposal, block result, etc., and updates the status (stateInfo) to reflect
+// the block that was just committed.
 func (ce *ConsensusEngine) nextState() {
 	ce.state.lc = &lastCommit{
 		height:     ce.state.blkProp.height,

--- a/node/node.go
+++ b/node/node.go
@@ -208,7 +208,7 @@ func NewNode(cfg *Config, opts ...Option) (*Node, error) {
 		Logger:            logger.New("PEERS"),
 		Host:              host,
 		ChainID:           cfg.ChainID,
-		TargetConnections: 20,
+		TargetConnections: cfg.P2P.TargetConnections,
 		ConnGater:         wcg,
 		RequiredProtocols: RequiredStreamProtocols,
 	}

--- a/node/nogossip.go
+++ b/node/nogossip.go
@@ -223,6 +223,9 @@ func (n *Node) startTxAnns(ctx context.Context, reannouncePeriod time.Duration) 
 
 				const sendN = 20
 				txns := n.mp.PeekN(sendN)
+				if len(txns) == 0 {
+					return // from this anon func, not the goroutine!
+				}
 				n.log.Infof("re-announcing %d unconfirmed txns", len(txns))
 
 				for _, nt := range txns {

--- a/node/pg/repl.go
+++ b/node/pg/repl.go
@@ -210,8 +210,8 @@ func captureRepl(ctx context.Context, conn *pgconn.PgConn, startLSN uint64, comm
 			if err != nil {
 				return fmt.Errorf("ParsePrimaryKeepaliveMessage failed: %w", err)
 			}
-			logger.Debug("primary keepalive msg", "ServerWALEnd", pkm.ServerWALEnd.String(),
-				"ServerTime:", pkm.ServerTime.String(), "ReplyRequested:", pkm.ReplyRequested)
+			logger.Debug("primary keepalive msg", "ServerWALEnd", pkm.ServerWALEnd,
+				"ServerTime", pkm.ServerTime, "ReplyRequested", pkm.ReplyRequested)
 			if pkm.ServerWALEnd > clientXLogPos {
 				clientXLogPos = pkm.ServerWALEnd
 			}

--- a/node/types/interfaces.go
+++ b/node/types/interfaces.go
@@ -14,6 +14,7 @@ var (
 	ErrTxNotFound      = errors.New("tx not available")
 	ErrTxAlreadyExists = errors.New("transaction already exists")
 	ErrBlkNotFound     = errors.New("block not available")
+	ErrStillProcessing = errors.New("block still being executed")
 	ErrNoResponse      = errors.New("stream closed without response")
 )
 


### PR DESCRIPTION
This change primarily is cleanup and logging minimizations.  Part of this is avoiding endless spam of the warning `No connected peers and no known addresses to dial!` when running a single node network.  This lead to some `autogen` fixes.