### PR TITLE
Start connect backoff

### DIFF
--- a/app/node/node.go
+++ b/app/node/node.go
@@ -238,7 +238,7 @@ func (s *server) Start(ctx context.Context) error {
 
 	// start node (p2p)
 	group.Go(func() error {
-		if err := s.node.Start(groupCtx, s.cfg.P2P.BootNodes...); err != nil {
+		if err := s.node.Start(groupCtx); err != nil {
 			if errors.Is(err, context.Canceled) {
 				s.log.Infof("Shutdown signaled. Cancellation details: [%v]", err)
 			} else {

--- a/node/node.go
+++ b/node/node.go
@@ -243,31 +243,17 @@ func (n *Node) Start(ctx context.Context, bootpeers ...string) error {
 		return err
 	}
 
-	bootpeersMA, err := peers.ConvertPeersToMultiAddr(bootpeers)
-	if err != nil {
-		return err
-	}
-
-	// connect to bootstrap peers, if any.
-	//
-	// NOTE: it may be preferable to simply add to Host's peer store here and
-	// let PeerMan manage connections.
-	for i, peer := range bootpeersMA {
-		peerInfo, err := makePeerAddrInfo(peer)
-		if err != nil {
-			n.log.Warnf("invalid bootnode address %v from setting %v", peer, bootpeers[i])
-			continue
-		}
-		if err = n.checkPeerProtos(ctx, peerInfo.ID); err != nil {
+	// Check protocol support for connected peers, which were established
+	// earlier during P2PService startup.
+	for i, peer := range n.peers() {
+		if err = n.checkPeerProtos(ctx, peer); err != nil {
 			n.log.Warnf("WARNING: peer does not support required protocols %v: %v", bootpeers[i], err)
-			if err = n.host.Network().ClosePeer(peerInfo.ID); err != nil {
+			if err = n.host.Network().ClosePeer(peer); err != nil {
 				n.log.Errorf("failed to disconnect from %v: %v", peer, err)
 			}
 			// n.host.Peerstore().RemovePeer()
 			continue
 		}
-		n.log.Infof("Connected to bootstrap peer %v", bootpeers[i])
-		// n.host.ConnManager().TagPeer(peerID, "validatorish", 1)
 	} // else would use persistent peer store (address book)
 
 	for _, val := range n.bp.GetValidators() {
@@ -308,12 +294,6 @@ func (n *Node) Start(ctx context.Context, bootpeers ...string) error {
 			}
 		}
 	}()
-
-	// // Attempt statesync if enabled
-	// if err := n.doStatesync(ctx); err != nil {
-	// 	cancel()
-	// 	return err
-	// }
 
 	if err := n.startAckGossip(ctx, ps); err != nil {
 		cancel()
@@ -796,7 +776,7 @@ func connectPeer(ctx context.Context, addr string, host host.Host) (*peer.AddrIn
 	// This will be used during connection and stream creation by libp2p.
 	// host.Peerstore().AddAddrs(info.ID, info.Addrs, peerstore.PermanentAddrTTL)
 
-	return info, host.Connect(ctx, *info)
+	return info, peers.CompressDialError(host.Connect(ctx, *info))
 }
 
 // TODO: this is WRONG considering paths like ~user. We should rewrite this

--- a/node/node.go
+++ b/node/node.go
@@ -234,7 +234,7 @@ func (n *Node) ID() string {
 
 // Start begins tx and block gossip, connects to any bootstrap peers, and begins
 // peer discovery.
-func (n *Node) Start(ctx context.Context, bootpeers ...string) error {
+func (n *Node) Start(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -245,9 +245,9 @@ func (n *Node) Start(ctx context.Context, bootpeers ...string) error {
 
 	// Check protocol support for connected peers, which were established
 	// earlier during P2PService startup.
-	for i, peer := range n.peers() {
+	for _, peer := range n.peers() {
 		if err = n.checkPeerProtos(ctx, peer); err != nil {
-			n.log.Warnf("WARNING: peer does not support required protocols %v: %v", bootpeers[i], err)
+			n.log.Warnf("WARNING: peer does not support required protocols %v: %v", peer, err)
 			if err = n.host.Network().ClosePeer(peer); err != nil {
 				n.log.Errorf("failed to disconnect from %v: %v", peer, err)
 			}

--- a/node/opts.go
+++ b/node/opts.go
@@ -1,24 +1,14 @@
 package node
 
-import (
-	"github.com/libp2p/go-libp2p/core/host"
-)
-
 type options struct {
 	// dependency overrides
-	host host.Host
+	// host host.Host
 	// bs   types.BlockStore
 	// mp   types.MemPool
 	// ce   ConsensusEngine
 }
 
-type Option func(*options)
-
-func WithHost(host host.Host) Option {
-	return func(o *options) {
-		o.host = host
-	}
-}
+type Option func(*options) // NOTHING PRESENTLY!
 
 /*func WithBlockStore(bs types.BlockStore) Option {
 	return func(o *options) {

--- a/node/peers/backoff.go
+++ b/node/peers/backoff.go
@@ -1,0 +1,129 @@
+package peers
+
+import (
+	"math"
+	"math/rand"
+	"time"
+)
+
+type backoffer struct {
+	maxAttempts int
+	baseDelay   time.Duration
+	maxDelay    time.Duration
+	jitter      bool
+
+	attempts int
+	last     time.Time // could just be next really...
+}
+
+// newBackoffer creates a new exponential backoff helper. The first attempts
+// delay is 0. The first try() always returns true, or the first next() always
+// return the Duration 0. This type's methods are not safe for concurrent use.
+func newBackoffer(maxAttempts int, baseDelay, maxDelay time.Duration, jitter bool) *backoffer {
+	return &backoffer{
+		maxAttempts: maxAttempts,
+		baseDelay:   baseDelay,
+		maxDelay:    maxDelay,
+		jitter:      jitter,
+	}
+}
+
+// goTime is a helper function to return the next time to try a request. It does
+// not increment the attempt counter. Instead, use try() or next(), which both
+// increment the attempt counter.
+func (b *backoffer) goTime() time.Time {
+	var jitter time.Duration
+	if b.jitter {
+		jitter = time.Duration(rand.Int63n(int64(b.baseDelay)))
+	}
+	delay := min(b.maxDelay, jitter+b.baseDelay*(1<<(b.attempts-1)))
+	return b.last.Add(delay)
+}
+
+// try returns true if an attempt should be made. This only increments the
+// attempt counter if it returns true. The first call always returns true.
+//
+// Use this method when making attempts from a pool of multiple resources, and
+// searching for a resource that is ready. Use next() and maxedOut() when
+// waiting on a single resource in a loop.
+func (b *backoffer) try() bool {
+	now := time.Now()
+	if b.attempts == 0 {
+		b.last = now
+		b.attempts++
+		return true
+	}
+	if b.attempts >= b.maxAttempts {
+		return false
+	}
+
+	okTime := b.goTime()
+
+	okToTry := now.After(okTime)
+	if okToTry {
+		b.attempts++
+		b.last = now
+	}
+	return okToTry
+}
+
+// next gives the time for the next attempt. Calling this is an attempt (it is
+// increments the attempt counter). This should be used in a loop with
+// `time.After`, in conjunction with maxedOut() to break the loop when the
+// maximum attempts have been reached (or track attempts in the loop).
+func (b *backoffer) next() time.Duration {
+	// this is an attempt
+	b.last = time.Now()
+	b.attempts++
+
+	if b.attempts == 1 {
+		return 0
+	}
+
+	okTime := b.goTime()
+
+	return max(0, time.Until(okTime))
+}
+
+func (b *backoffer) tries() int {
+	return b.attempts
+}
+
+// maxedOut returns true if the maximum number of attempts has been reached.
+func (b *backoffer) maxedOut() bool {
+	return b.attempts >= b.maxAttempts
+}
+
+// calculateBackoffTTL computes total backoff time with jitter for n retries
+// (base 2). This is used when adding a peer to the peerstore so that the TTL
+// used by libp2p for removing the peer matches our own connect retry logic with
+// exponential backoff.
+// 2sec base, 1hr max, 58 retries should be close to 48 hrs
+func calculateBackoffTTL(baseDelay, maxDelay time.Duration, retries int, jitter bool) time.Duration {
+	var totalBackoff time.Duration
+
+	// 63 - log2 of basedelay is the max exp before overflow
+	maxExp := int(63 - math.Ceil(math.Log2(float64(baseDelay))))
+
+	for i := range retries {
+		delay := baseDelay * (1 << min(i, maxExp)) // baseDelay * 2^i
+		if delay < 0 {                             // catch overflow
+			return time.Duration(math.MaxInt64)
+		}
+
+		// Add average jitter: baseDelay / 2 to approximate the average impact.
+		delayWithJitter := delay
+		if jitter {
+			avgJitter := baseDelay / 2
+			delayWithJitter = delay + avgJitter
+		}
+
+		cappedDelay := min(delayWithJitter, maxDelay)
+		totalBackoff += cappedDelay
+		if totalBackoff < 0 { // catch overflow
+			return time.Duration(math.MaxInt64)
+		}
+	}
+
+	return totalBackoff
+}

--- a/node/peers/backoff_test.go
+++ b/node/peers/backoff_test.go
@@ -1,0 +1,183 @@
+package peers
+
+import (
+	"testing"
+	"time"
+)
+
+func TestBackoffer(t *testing.T) {
+	tests := []struct {
+		name         string
+		maxAttempts  int
+		attemptDelay time.Duration
+		baseDelay    time.Duration
+		sequence     []bool
+	}{
+		{
+			name:         "first attempt always succeeds",
+			maxAttempts:  3,
+			attemptDelay: 20 * time.Millisecond,
+			baseDelay:    20 * time.Millisecond,
+			sequence:     []bool{true},
+		},
+		{
+			name:         "max attempts reached",
+			maxAttempts:  3,
+			attemptDelay: 2 * time.Millisecond,
+			baseDelay:    1 * time.Millisecond,
+			sequence:     []bool{true, true, true, false, false},
+		},
+		{
+			name:         "respects backoff delay",
+			maxAttempts:  5,
+			attemptDelay: 30 * time.Millisecond,
+			baseDelay:    50 * time.Millisecond,
+			sequence:     []bool{true, false, true, false, true},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			b := &backoffer{
+				maxAttempts: tt.maxAttempts,
+				baseDelay:   tt.baseDelay,
+				maxDelay:    time.Minute,
+				// no jitter in these tests
+			}
+
+			for i, expected := range tt.sequence {
+				if i > 0 {
+					// Sleep a variable amount based on the attempt number
+					time.Sleep(tt.attemptDelay * time.Duration(i))
+				}
+
+				result := b.try()
+				if result != expected {
+					t.Errorf("attempt %d: got %v, want %v", i+1, result, expected)
+				}
+			}
+		})
+	}
+}
+
+func TestBackofferJitter(t *testing.T) {
+	// first with no jitter
+	b := newBackoffer(8, 50*time.Millisecond, time.Minute, false)
+
+	t0 := time.Now()
+	for range 3 {
+		for !b.try() {
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	totalDelayNoJitter := time.Since(t0)
+
+	// again with jitter enabled, should be longer in total
+	b = newBackoffer(8, 50*time.Millisecond, time.Minute, true)
+	t0 = time.Now()
+	for range 3 {
+		for !b.try() {
+			time.Sleep(5 * time.Millisecond)
+		}
+	}
+	totalDelayJitter := time.Since(t0)
+
+	// total delay with jitter should be longer than without
+	if totalDelayJitter < totalDelayNoJitter {
+		t.Errorf("total delay with jitter (%v) should be longer than without jitter (%v)", totalDelayJitter, totalDelayNoJitter)
+	}
+	t.Log(totalDelayJitter - totalDelayNoJitter)
+}
+
+func TestCalculateBackoffTTL(t *testing.T) {
+	tests := []struct {
+		name      string
+		base      time.Duration
+		max       time.Duration
+		retries   int
+		jitter    bool
+		expected  time.Duration
+		checkFunc func(t *testing.T, result time.Duration)
+	}{
+		{
+			name:     "zero retries",
+			base:     time.Second,
+			max:      time.Hour,
+			retries:  0,
+			jitter:   false,
+			expected: 0,
+		},
+		{
+			name:     "single retry no jitter",
+			base:     time.Second,
+			max:      time.Hour,
+			retries:  1,
+			jitter:   false,
+			expected: time.Second,
+		},
+		{
+			name:     "multiple retries with max cap",
+			base:     time.Minute,
+			max:      2 * time.Minute,
+			retries:  3,
+			jitter:   false,
+			expected: 5 * time.Minute,
+			checkFunc: func(t *testing.T, result time.Duration) {
+				if result > 6*time.Minute {
+					t.Errorf("backoff exceeded expected maximum: got %v", result)
+				}
+			},
+		},
+		{
+			name:    "jitter impact verification",
+			base:    time.Second,
+			max:     time.Hour,
+			retries: 4,
+			jitter:  true,
+			checkFunc: func(t *testing.T, result time.Duration) {
+				noJitterResult := calculateBackoffTTL(time.Second, time.Hour, 4, false)
+				if result <= noJitterResult {
+					t.Errorf("expected jitter to increase total backoff time: with=%v, without=%v", result, noJitterResult)
+				}
+			},
+		},
+		{
+			name:    "max delay boundary",
+			base:    time.Minute,
+			max:     5 * time.Minute,
+			retries: 5,
+			jitter:  false,
+			checkFunc: func(t *testing.T, result time.Duration) {
+				if result > 25*time.Minute {
+					t.Errorf("backoff exceeded maximum delay boundary: got %v", result)
+				}
+			},
+		},
+		{
+			name:    "large retry count",
+			base:    time.Second,
+			max:     time.Hour,
+			retries: 63,
+			jitter:  false,
+			checkFunc: func(t *testing.T, result time.Duration) {
+				if result < time.Hour*10 {
+					t.Errorf("expected large backoff for high retry count: got %v", result)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := calculateBackoffTTL(tt.base, tt.max, tt.retries, tt.jitter)
+
+			if tt.expected > 0 && result != tt.expected {
+				t.Errorf("calculateBackoffTTL() = %v, want %v", result, tt.expected)
+			}
+
+			if tt.checkFunc != nil {
+				tt.checkFunc(t, result)
+			}
+		})
+	}
+}

--- a/node/statesync.go
+++ b/node/statesync.go
@@ -109,7 +109,8 @@ func NewStateSyncService(ctx context.Context, cfg *StatesyncConfig) (*StateSyncS
 		return nil, err
 	}
 
-	// provide stream handler for snapshot catalogs requests and chunk requests
+	// provide stream handler for snapshot catalogs requests and chunk requests.
+	// This is replaced by the Node's handler when it comes up.
 	ss.host.SetStreamHandler(ProtocolIDBlockHeight, ss.blkGetHeightRequestHandler)
 	if err := ss.Bootstrap(ctx); err != nil {
 		return nil, err


### PR DESCRIPTION
This makes the startup peer connection (handled by `maintainMinPeers`) use exponential backoff on a per-peer basis, just like the reconnect logic started when a peer disconnects (initiated by the `network.Notifiee`)

This also fixes the regression with the `network.Notifiee` being de-registered from the Host.

Finally, this has the `P2PService` register dummy stream handlers for all of the "required" protocol IDs.  They are replaced with the actual handlers in `Node`  startup when the CE is ready to take over.