### PR TITLE
node: add SetValue and Value in tx context

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -71,6 +71,23 @@ type TxContext struct {
 	Caller string
 	// Authenticator is the authenticator used to sign the transaction.
 	Authenticator string
+	// values is a map of values that can be set and retrieved by extensions.
+	values map[string]any
+}
+
+func (t *TxContext) SetValue(s string, v any) {
+	if t.values == nil {
+		t.values = make(map[string]any)
+	}
+	t.values[s] = v
+}
+
+func (t *TxContext) Value(s string) (any, bool) {
+	if t.values == nil {
+		return nil, false
+	}
+	v, ok := t.values[s]
+	return v, ok
 }
 
 // EngineContext is a context that is passed to the engine when executing

--- a/common/common.go
+++ b/common/common.go
@@ -75,6 +75,8 @@ type TxContext struct {
 	values map[string]any
 }
 
+// SetValue sets a value in the transaction context that can
+// be retrieved later.
 func (t *TxContext) SetValue(s string, v any) {
 	if t.values == nil {
 		t.values = make(map[string]any)
@@ -82,6 +84,8 @@ func (t *TxContext) SetValue(s string, v any) {
 	t.values[s] = v
 }
 
+// Value retrieves a value from the transaction context.
+// If it does not exist, the second return value will be false.
 func (t *TxContext) Value(s string) (any, bool) {
 	if t.values == nil {
 		return nil, false


### PR DESCRIPTION
Adds the ability for extensions to attach arbitrary info to a transaction context, which can be referenced later