### PR TITLE
Don't clear out resolutions from the votestore if the DB is restored …

### DIFF
--- a/node/consensus/blocksync.go
+++ b/node/consensus/blocksync.go
@@ -157,7 +157,7 @@ func (ce *ConsensusEngine) syncBlocksUntilHeight(ctx context.Context, startHeigh
 func (ce *ConsensusEngine) syncBlockWithRetry(ctx context.Context, height int64) error {
 	_, rawblk, ci, err := ce.getBlock(ctx, height)
 	if err != nil { // all kinds of errors?
-		return fmt.Errorf("error requesting block from network: height : %d, error: %w", height, err)
+		return err
 	}
 
 	return ce.applyBlock(ctx, rawblk, ci)
@@ -167,7 +167,7 @@ func (ce *ConsensusEngine) syncBlockWithRetry(ctx context.Context, height int64)
 func (ce *ConsensusEngine) syncBlock(ctx context.Context, height int64) error {
 	_, rawblk, ci, err := ce.blkRequester(ctx, height)
 	if err != nil { // all kinds of errors?
-		return fmt.Errorf("error requesting block from network: height : %d, error: %w", height, err)
+		return err
 	}
 
 	return ce.applyBlock(ctx, rawblk, ci)

--- a/node/consensus/engine.go
+++ b/node/consensus/engine.go
@@ -797,7 +797,6 @@ func (ce *ConsensusEngine) processCurrentBlock(ctx context.Context) error {
 	// otherwise rollback.
 	blkHash, rawBlk, ci, err := ce.getBlock(ctx, ce.state.blkProp.height)
 	if err != nil {
-		ce.log.Debug("Error requesting block from network", "height", ce.state.blkProp.height, "error", err)
 		return err
 	}
 

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -80,7 +80,7 @@ func TestSingleNodeMocknet(t *testing.T) {
 		valSetList = append(valSetList, &v)
 	}
 
-	ss := newSnapshotStore()
+	ss := newSnapshotStore(bs1)
 
 	_, vsReal, err := voting.NewResolutionStore(ctx, db1)
 	require.NoError(t, err)
@@ -103,7 +103,7 @@ func TestSingleNodeMocknet(t *testing.T) {
 	accounts, err := accounts.InitializeAccountStore(ctx, db1, log.DiscardLogger)
 	require.NoError(t, err)
 
-	migrator, err := migrations.SetupMigrator(ctx, db1, newSnapshotStore(), accounts, filepath.Join(root1, "migrations"), mparams, vsReal, log.New(log.WithName("MIGRATOR")))
+	migrator, err := migrations.SetupMigrator(ctx, db1, newSnapshotStore(bs1), accounts, filepath.Join(root1, "migrations"), mparams, vsReal, log.New(log.WithName("MIGRATOR")))
 	require.NoError(t, err)
 
 	signer := auth.GetNodeSigner(privKeys[0])
@@ -238,7 +238,7 @@ func TestDualNodeMocknet(t *testing.T) {
 	for _, v := range valSet {
 		valSetList = append(valSetList, &v)
 	}
-	ss := newSnapshotStore()
+	ss := newSnapshotStore(bs1)
 
 	genCfg := config.DefaultGenesisConfig()
 	genCfg.Leader = ktypes.PublicKey{PublicKey: privKeys[0].Public()}
@@ -264,7 +264,7 @@ func TestDualNodeMocknet(t *testing.T) {
 	}, accounts1, vstore1)
 	require.NoError(t, err)
 
-	migrator, err := migrations.SetupMigrator(ctx, db1, newSnapshotStore(), accounts1, filepath.Join(root1, "migrations"), mparams, vstore1, log.New(log.WithName("MIGRATOR")))
+	migrator, err := migrations.SetupMigrator(ctx, db1, newSnapshotStore(bs1), accounts1, filepath.Join(root1, "migrations"), mparams, vstore1, log.New(log.WithName("MIGRATOR")))
 	require.NoError(t, err)
 
 	bpl1 := log.New(log.WithName("BP1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured))
@@ -338,7 +338,7 @@ func TestDualNodeMocknet(t *testing.T) {
 	_, vstore2, err := voting.NewResolutionStore(ctx, db2)
 	require.NoError(t, err)
 
-	migrator2, err := migrations.SetupMigrator(ctx, db2, newSnapshotStore(), accounts2, filepath.Join(root2, "migrations"), mparams, vstore2, log.New(log.WithName("MIGRATOR")))
+	migrator2, err := migrations.SetupMigrator(ctx, db2, newSnapshotStore(bs2), accounts2, filepath.Join(root2, "migrations"), mparams, vstore2, log.New(log.WithName("MIGRATOR")))
 	require.NoError(t, err)
 
 	signer2 := auth.GetNodeSigner(privKeys[1])

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -111,7 +111,7 @@ func makeTestHosts(t *testing.T, nNodes, nExtraHosts int, blockInterval time.Dur
 			Statesync:   &defaultConfigSet.StateSync,
 			Mempool:     mempool.New(),
 			BlockStore:  bs,
-			Snapshotter: newSnapshotStore(),
+			Snapshotter: newSnapshotStore(bs),
 			Consensus:   ce,
 			BlockProc:   &dummyBP{},
 		}

--- a/test/specifications/validator_ops.go
+++ b/test/specifications/validator_ops.go
@@ -44,6 +44,16 @@ func ValidatorNodeJoinSpecification(ctx context.Context, t *testing.T, netops Va
 	assert.NoError(t, err)
 	assert.Equal(t, valCount, len(vals))
 }
+func ValidatorJoinStatusSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, joinerKey crypto.PrivateKey, valCount int) {
+	t.Log("Executing network node join status specification")
+
+	// Get Request status, #approvals = 0, #board = valCount
+	joiner := joinerKey.Public().Bytes()
+	joinStatus, err := netops.ValidatorJoinStatus(ctx, joiner, joinerKey.Type())
+	require.NoError(t, err)
+	assert.Equal(t, valCount, len(joinStatus.Board))
+	assert.Equal(t, 0, approvalCount(joinStatus))
+}
 
 func JoinExistingValidatorSpecification(ctx context.Context, t *testing.T, netops ValidatorOpsDsl, joinerKey crypto.PrivateKey) {
 	t.Log("Executing existing validator join specification")


### PR DESCRIPTION
…using a statesync snapshot

If the DB is restored from genesis snapshots during offline or ZDT migrations, the resolutions from the voting table should be cleared out especially the validator and migration resolutions as they are not applicable for the new network. However this should not be done for the statesync snapshots. (This is a regression from the changes I made yesterday)

This PR also adds a new integration test to test out unresolved resolutions in statesync snapshots

Also fixes incomplete statesync tests