### PR TITLE
Genesis checks shouldn't involve migration status

### DIFF
--- a/app/node/node.go
+++ b/app/node/node.go
@@ -122,6 +122,13 @@ func runNode(ctx context.Context, rootDir string, cfg *config.Config, autogen bo
 		}
 	}
 
+	// migration status defaults
+	if genConfig.Migration.IsMigration() {
+		genConfig.MigrationStatus = types.GenesisMigration
+	} else {
+		genConfig.MigrationStatus = types.NoActiveMigration
+	}
+
 	if err := genConfig.SanityChecks(); err != nil {
 		return fmt.Errorf("genesis configuration failed sanity checks: %w", err)
 	}

--- a/config/config.go
+++ b/config/config.go
@@ -247,7 +247,7 @@ func DefaultGenesisConfig() *GenesisConfig {
 		NetworkParameters: types.NetworkParameters{
 			Leader:           types.PublicKey{},
 			MaxBlockSize:     6 * 1024 * 1024,
-			JoinExpiry:       types.Duration(86400 * time.Second),
+			JoinExpiry:       types.Duration(7 * 24 * time.Hour), // 1 week
 			DisabledGasCosts: true,
 			MaxVotesPerTx:    200,
 			MigrationStatus:  types.NoActiveMigration,

--- a/core/types/params.go
+++ b/core/types/params.go
@@ -540,10 +540,6 @@ func (np *NetworkParameters) SanityChecks() error {
 		return errors.New("max bytes should be greater than 0")
 	}
 
-	if !np.MigrationStatus.Valid() {
-		return fmt.Errorf("migration status is invalid: %q", np.MigrationStatus)
-	}
-
 	return nil
 }
 

--- a/core/types/types.go
+++ b/core/types/types.go
@@ -256,7 +256,7 @@ type ConsensusParamUpdateProposal struct {
 type MigrationStatus string
 
 func (ms MigrationStatus) NoneActive() bool {
-	return ms == NoActiveMigration || ms == ""
+	return ms == NoActiveMigration
 }
 
 func (ms MigrationStatus) Active() bool {


### PR DESCRIPTION
fixes the node start issue:

```
❯ ./.build/kwild start -r .net2
Error: genesis configuration failed sanity checks: migration status is invalid: ""
❯
```