### PR TITLE
ext(erc20rw): support list wallet rewards

### DIFF
--- a/contrib/docker/kwild.dockerfile
+++ b/contrib/docker/kwild.dockerfile
@@ -18,10 +18,10 @@ RUN chmod +x /app/dist/kwild /app/dist/kwil-cli
 
 FROM ubuntu:24.04
 WORKDIR /app
-RUN mkdir -p /var/run/kwil && chmod 777 /var/run/kwil 
+RUN mkdir -p /var/run/kwil && chmod 777 /var/run/kwil
 RUN apt update &&  apt install -y postgresql-client curl
 COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/dist/kwild ./kwild
 COPY --from=build /app/dist/kwil-cli ./kwil-cli
 EXPOSE 8484 6600
-ENTRYPOINT ["/app/kwild", "start"]
+ENTRYPOINT ["/app/kwild"]

--- a/node/exts/erc20reward/ext_test.go
+++ b/node/exts/erc20reward/ext_test.go
@@ -175,26 +175,26 @@ func Test_scaleDownUint256(t *testing.T) {
 //	})
 //
 //	// Vote reward batch. need to get original pending reward, then calculate root
-//	var latestBatch *EpochReward
-//	var pendingReward *PendingReward
+//	var latestBatch *Epoch
+//	var reward *Reward
 //	withTx(t, ctx, db, func(kApp *kcommon.App) {
 //		result, err := ext.Call(callCtx, kApp, "list_batches", []any{int64(100), int64(1)})
 //		require.NoError(t, err)
 //		assert.Len(t, result, 1)
-//		batches := result[0].([]*EpochReward)
+//		batches := result[0].([]*Epoch)
 //		assert.Len(t, batches, 1)
 //		latestBatch = batches[0]
 //		result, err = ext.Call(callCtx, kApp, "list_rewards", []any{latestBatch.StartHeight, latestBatch.EndHeight})
 //		assert.NoError(t, err)
 //		assert.Len(t, result, 1)
-//		pendingRewards := result[0].([]*PendingReward)
-//		assert.Len(t, pendingRewards, 1) // only one, since list_pending will aggregate
-//		pendingReward = pendingRewards[0]
-//		assert.Equal(t, "22", pendingReward.Amount.String())
+//		rewards := result[0].([]*Reward)
+//		assert.Len(t, rewards, 1) // only one, since list_pending will aggregate
+//		reward = rewards[0]
+//		assert.Equal(t, "22", reward.Amount.String())
 //	})
 //
-//	jsonMtree, rootHash, err := reward.GenRewardMerkleTree([]string{pendingReward.Recipient},
-//		[]string{pendingReward.Amount.String()}, rewardAddress, fmt.Sprintf("%d", latestBatch.EndHeight))
+//	jsonMtree, rootHash, err := reward.GenRewardMerkleTree([]string{reward.Recipient},
+//		[]string{reward.Amount.String()}, rewardAddress, fmt.Sprintf("%d", latestBatch.EndHeight))
 //	require.NoError(t, err)
 //	fmt.Println("jsonMtree:", jsonMtree)
 //	fmt.Printf("rootHash: %s, %d\n", rootHash, latestBatch.TotalRewards.BigInt())

--- a/node/exts/erc20reward/meta/ext.go
+++ b/node/exts/erc20reward/meta/ext.go
@@ -189,6 +189,7 @@ func (h *Erc20RewardMeta) unregister(ctx *kcommon.EngineContext, app *kcommon.Ap
 }
 
 // Map turns a []T1 to a []T2 using a mapping function.
+// TODO: maybe move to internal utils pkg
 func Map[T1, T2 any](s []T1, f func(T1) T2) []T2 {
 	r := make([]T2, len(s))
 	for i, v := range s {

--- a/node/exts/erc20reward/meta/sql.go
+++ b/node/exts/erc20reward/meta/sql.go
@@ -25,7 +25,7 @@ var (
 -- NOTE: We might need to store GnosisSafe address here as well.
 {%s}CREATE TABLE IF NOT EXISTS erc20rw_meta_contracts (
 	id UUID PRIMARY KEY,
-    chain_id INT8 NOT NULL, -- the chain ID of the contract.
+    chain_id INT8 NOT NULL, -- the chain ID of the contract. -- TODO: use Text for bigint
 	address TEXT NOT NULL, -- the reward escrow contract address.
 	nonce INT8 NOT NULL, -- the last known nonce of the contract
 	threshold INT8 NOT NULL,

--- a/node/exts/erc20reward/reward/mtree.go
+++ b/node/exts/erc20reward/reward/mtree.go
@@ -1,7 +1,6 @@
 package reward
 
 import (
-	"encoding/hex"
 	"fmt"
 	"math/big"
 
@@ -15,40 +14,7 @@ var (
 	MerkleLeafEncoding = []string{smt.SOL_ADDRESS, smt.SOL_UINT256, smt.SOL_ADDRESS, smt.SOL_BYTES32}
 )
 
-func GenRewardMerkleTree(users []string, amounts []string, contractAddress string, kwilBlockHash string) (string, string, error) {
-	if len(users) != len(amounts) {
-		return "", "", fmt.Errorf("users and amounts length not equal")
-	}
-
-	blockHash, _ := hex.DecodeString(kwilBlockHash)
-	var b32Hash [32]byte
-	copy(b32Hash[:], blockHash)
-
-	values := [][]interface{}{}
-	for i, v := range users {
-		values = append(values,
-			[]interface{}{
-				smt.SolAddress(v),
-				smt.SolNumber(amounts[i]),
-				smt.SolAddress(contractAddress),
-				b32Hash, // TODO: use bytes32
-			})
-	}
-
-	rewardTree, err := smt.Of(values, MerkleLeafEncoding)
-	if err != nil {
-		return "", "", fmt.Errorf("create reward tree error: %w", err)
-	}
-
-	dump, err := rewardTree.TreeMarshal()
-	if err != nil {
-		return "", "", fmt.Errorf("reward tree marshal error: %w", err)
-	}
-
-	return string(dump), hex.EncodeToString(rewardTree.GetRoot()), nil
-}
-
-func GenRewardMerkleTree2(users []string, amounts []*big.Int, contractAddress string, kwilBlockHash [32]byte) (string, []byte, error) {
+func GenRewardMerkleTree(users []string, amounts []*big.Int, contractAddress string, kwilBlockHash [32]byte) (string, []byte, error) {
 	if len(users) != len(amounts) {
 		return "", nil, fmt.Errorf("users and amounts length not equal")
 	}

--- a/node/exts/erc20reward/reward/mtree.go
+++ b/node/exts/erc20reward/reward/mtree.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"math/big"
 
+	"github.com/ethereum/go-ethereum/common"
 	smt "github.com/kwilteam/openzeppelin-merkle-tree-go/standard_merkle_tree"
 )
 
@@ -73,4 +74,24 @@ func GetMTreeProof(mtreeJson string, addr string) (root []byte, proof [][]byte, 
 	}
 
 	return nil, nil, nil, nil, "", fmt.Errorf("get proof error: %w", err)
+}
+
+func GetLeafAddresses(mtreeJson string) ([]string, error) {
+	t, err := smt.Load([]byte(mtreeJson))
+	if err != nil {
+		return nil, fmt.Errorf("load mtree error: %w", err)
+	}
+
+	addresses := make([]string, len(t.Entries()))
+
+	for i, v := range t.Entries() {
+		addr, ok := v.Value[0].(common.Address)
+		if !ok {
+			return nil, fmt.Errorf("internal bug: get leaf address error: %w", err)
+		}
+
+		addresses[i] = addr.String()
+	}
+
+	return addresses, nil
 }

--- a/node/exts/erc20reward/sql.go
+++ b/node/exts/erc20reward/sql.go
@@ -16,9 +16,9 @@ import (
 
 var (
 	sqlInitTableErc20rwRewards = `
--- erc20rw_rewards holds rewards that have been issued to users.
+-- rewards holds rewards that have been issued to users.
 -- The id is generated based on the recipient_amount_contractID.
-{%s}CREATE TABLE IF NOT EXISTS erc20rw_rewards (
+{%s}CREATE TABLE IF NOT EXISTS rewards (
 	id UUID PRIMARY KEY,
 	recipient TEXT NOT NULL,
 	amount NUMERIC(78,0) NOT NULL, -- allows uint256
@@ -28,11 +28,11 @@ var (
 
 	// TODO: maybe add safeTxHash? it'll give us a way to find the related EVM tx.
 	sqlInitTableErc20rwEpochs = `
--- erc20rw_epochs holds the epoch information.
+-- epochs holds the epoch information.
 -- An epoch is a group of rewards that are issued in a given time/block range.
 -- If no one votes for a epoch, it's fine, since each epoch using a unique safe_nonce, e.g., even
 -- the epoch got votes later for some reason, it won't succeed. BUT seems a trouble for Poster service
-{%s}CREATE TABLE IF NOT EXISTS erc20rw_epochs (
+{%s}CREATE TABLE IF NOT EXISTS epochs (
 	id UUID PRIMARY KEY,
     start_height int8 NOT NULL, -- the height of the first reward in this epoch. we need this in case a proposed epoch is wrong and no one votes for it.
 	end_height INT8 NOT NULL, -- the height of the last reward in this epoch.
@@ -47,10 +47,10 @@ var (
 );`
 
 	sqlInitTableErc20rwEpochVotes = `
--- erc20rw_epoch_votes holds signatures for a reward epoch that has
+-- epoch_votes holds signatures for a reward epoch that has
 -- not yet received enough signatures.
-{%s}CREATE TABLE IF NOT EXISTS erc20rw_epoch_votes (
-	epoch_id UUID NOT NULL REFERENCES %s.erc20rw_epochs(id) ON UPDATE CASCADE ON DELETE CASCADE,
+{%s}CREATE TABLE IF NOT EXISTS epoch_votes (
+	epoch_id UUID NOT NULL REFERENCES %s.epochs(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	signer_id UUID NOT NULL REFERENCES %s.erc20rw_meta_signers(id) ON UPDATE CASCADE ON DELETE CASCADE,
 	signature BYTEA NOT NULL,
 	created_at INT8 NOT NULL, -- kwil block height
@@ -58,77 +58,77 @@ var (
 );`
 
 	sqlInitTableErc20rwFinalizedRewards = `
--- erc20rw_finalized_rewards holds finalized rewards that have been finalized.
+-- finalized_rewards holds finalized rewards that have been finalized.
 -- A finalized reward is considered finalized on chain.
-{%s}CREATE TABLE IF NOT EXISTS erc20rw_finalized_rewards (
+{%s}CREATE TABLE IF NOT EXISTS finalized_rewards (
     id UUID PRIMARY KEY,
     voters TEXT[] NOT NULL, -- snapshot of the voters of the epoch
 	signatures BYTEA[] NOT NULL, -- snapshot of the signatures of the epoch
-    epoch_id UUID NOT NULL REFERENCES %s.erc20rw_epochs(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    epoch_id UUID NOT NULL REFERENCES %s.epochs(id) ON UPDATE CASCADE ON DELETE CASCADE,
     created_at INT8 NOT NULL
 );`
 
 	sqlInitTableRecipientReward = `
--- erc20rw_recipient_reward holds the epochs that recipients are in.
-{%s}CREATE TABLE IF NOT EXISTS erc20rw_recipient_reward (
+-- recipient_reward holds the epochs that recipients are in.
+{%s}CREATE TABLE IF NOT EXISTS recipient_reward (
 	recipient TEXT NOT NULL,
-	finalized_id UUID NOT NULL REFERENCES %s.erc20rw_finalized_rewards(id) ON UPDATE CASCADE ON DELETE CASCADE,
+	finalized_id UUID NOT NULL REFERENCES %s.finalized_rewards(id) ON UPDATE CASCADE ON DELETE CASCADE,
     PRIMARY KEY (recipient, finalized_id)
 );`
 
-	sqlNewReward = `{%s}INSERT INTO erc20rw_rewards (id, recipient, amount, contract_id, created_at) VALUES ($id, $recipient, $amount, $contract_id, $created_at);`
+	sqlNewReward = `{%s}INSERT INTO rewards (id, recipient, amount, contract_id, created_at) VALUES ($id, $recipient, $amount, $contract_id, $created_at);`
 
-	sqlSearchRewards = `SELECT * FROM %s.erc20rw_rewards WHERE created_at >= $start_height and created_at <= $end_height ORDER BY created_at ASC`
+	sqlSearchRewards = `SELECT * FROM %s.rewards WHERE created_at >= $start_height and created_at <= $end_height ORDER BY created_at ASC`
 
-	sqlNewEpoch = `{%s}INSERT INTO erc20rw_epochs
+	sqlNewEpoch = `{%s}INSERT INTO epochs
 (id, start_height, end_height, total_rewards, mtree_json, reward_root, safe_nonce, sign_hash, contract_id, block_hash, created_at)
 VALUES ($id, $start_height, $end_height, $total_rewards, $mtree_json, $reward_root, $safe_nonce, $sign_hash, $contract_id, $block_hash, $created_at)`
-	sqlGetEpochMtreeBySignhash = `SELECT mtree_json FROM %s.erc20rw_epochs WHERE sign_hash = $sign_hash`
-	sqlGetEpochBySignhash      = `SELECT * FROM %s.erc20rw_epochs WHERE sign_hash = $sign_hash`
+	sqlGetEpochMtreeBySignhash = `SELECT mtree_json FROM %s.epochs WHERE sign_hash = $sign_hash`
+	sqlGetEpochBySignhash      = `SELECT * FROM %s.epochs WHERE sign_hash = $sign_hash`
 	sqlListEpochWithVoters     = `select er.*, array_agg(s.address) as voters
-from %s.erc20rw_epochs as er
-left join %s.erc20rw_epoch_votes as ps on er.id = ps.epoch_id
+from %s.epochs as er
+left join %s.epoch_votes as ps on er.id = ps.epoch_id
 left join %s.erc20rw_meta_signers as s on ps.signer_id = s.id
 WHERE er.end_height > $after_height
 group by er.id, er.start_height, er.end_height, er.total_rewards, er.mtree_json, er.reward_root, er.safe_nonce, er.sign_hash, er.contract_id, er.block_hash, er.created_at
 ORDER BY er.end_height ASC limit $limit`
 
-	sqlVoteEpochBySignHash = `{%s}INSERT INTO erc20rw_epoch_votes (epoch_id, signer_id, signature, created_at)
-VALUES ((SELECT id FROM %s.erc20rw_epochs WHERE sign_hash = $sign_hash),
+	sqlVoteEpochBySignHash = `{%s}INSERT INTO epoch_votes (epoch_id, signer_id, signature, created_at)
+VALUES ((SELECT id FROM %s.epochs WHERE sign_hash = $sign_hash),
         (SELECT id FROM %s.erc20rw_meta_signers WHERE address = $signer_address and contract_id = $contract_id),
         $signature, $created_at)`
-	sqlCountEpochVotes   = `SELECT COUNT(*) FROM %s.erc20rw_epoch_votes WHERE epoch_id = (select id from %s.erc20rw_epochs WHERE sign_hash = $sign_hash)`
-	sqlGetVoteBySignHash = `SELECT * from %s.erc20rw_epoch_votes where
-epoch_id = (SELECT id FROM %s.erc20rw_epochs WHERE sign_hash = $sign_hash)
+	sqlCountEpochVotes   = `SELECT COUNT(*) FROM %s.epoch_votes WHERE epoch_id = (select id from %s.epochs WHERE sign_hash = $sign_hash)`
+	sqlGetVoteBySignHash = `SELECT * from %s.epoch_votes where
+epoch_id = (SELECT id FROM %s.epochs WHERE sign_hash = $sign_hash)
 and signer_id = (SELECT id FROM %s.erc20rw_meta_signers WHERE address = $signer_address and contract_id = $contract_id)`
 
 	sqlCreateFinalizedReward = `{%s}WITH
-epoch AS (SELECT * FROM %s.erc20rw_epochs WHERE sign_hash = $sign_hash),
-votes as (SELECT * FROM %s.erc20rw_epoch_votes WHERE epoch_id = (select id from epoch)),
+epoch AS (SELECT * FROM %s.epochs WHERE sign_hash = $sign_hash),
+votes as (SELECT * FROM %s.epoch_votes WHERE epoch_id = (select id from epoch)),
 sigs AS (SELECT ARRAY_AGG(signature) as signatures FROM votes),
 voters As (SELECT ARRAY_AGG(s.address) as voters FROM votes as vs join %s.erc20rw_meta_signers as s on vs.signer_id = s.id)
-INSERT INTO erc20rw_finalized_rewards (id, voters, signatures, epoch_id, created_at)
+INSERT INTO finalized_rewards (id, voters, signatures, epoch_id, created_at)
 VALUES ($rid,(SELECT voters from voters),(SELECT signatures from sigs),(select id from epoch), $created_at)`
 	sqlListFinalizedRewards = `SELECT fr.*, er.start_height, er.end_height, er.total_rewards, er.reward_root, er.safe_nonce, er.sign_hash, er.contract_id, er.block_hash
-FROM %s.erc20rw_finalized_rewards as fr
-join %s.erc20rw_epochs as er on er.id = fr.epoch_id
+FROM %s.finalized_rewards as fr
+join %s.epochs as er on er.id = fr.epoch_id
 WHERE end_height > $after_height ORDER BY end_height ASC limit $limit`
 	sqlListLatestFinalizedRewards = `SELECT fr.*, er.start_height, er.end_height, er.total_rewards, er.reward_root, er.safe_nonce, er.sign_hash, er.contract_id, er.block_hash
-FROM %s.erc20rw_finalized_rewards as fr
-join %s.erc20rw_epochs as er on er.id = fr.epoch_id
+FROM %s.finalized_rewards as fr
+join %s.epochs as er on er.id = fr.epoch_id
 ORDER by end_height DESC LIMIT $limit`
 	sqlGetFinalizedRewardByHash = `SELECT fr.*, er.start_height, er.end_height, er.total_rewards, er.reward_root, er.safe_nonce, er.sign_hash, er.contract_id, er.block_hash
-FROM %s.erc20rw_finalized_rewards as fr
-join %s.erc20rw_epochs as er on er.id = fr.epoch_id
+FROM %s.finalized_rewards as fr
+join %s.epochs as er on er.id = fr.epoch_id
 WHERE er.sign_hash = $sign_hash`
-	sqlGetEpochMtreeByFinalizedID = `SELECT e.mtree_json FROM %s.erc20rw_epochs as e
-JOIN %s.erc20rw_finalized_rewards as fr on fr.epoch_id = e.id
+	sqlGetEpochMtreeByFinalizedID = `SELECT e.mtree_json FROM %s.epochs as e
+JOIN %s.finalized_rewards as fr on fr.epoch_id = e.id
 WHERE fr.id = $id`
 
 	sqlGetWalletRewards = `SELECT e.mtree_json, mc.chain_id, mc.address, fr.created_at
-from %s.erc20rw_recipient_reward as re
-join %s.erc20rw_finalized_rewards as fr on fr.id = re.finalized_id
-join %s.erc20rw_epochs as e on e.id = fr.epoch_id
+from %s.recipient_reward as re
+join %s.finalized_rewards as fr on fr.id = re.finalized_id
+join %s.epochs as e on e.id = fr.epoch_id
 join %s.erc20rw_meta_contracts as mc on mc.id = e.contract_id
 where re.recipient = $recipient
 order by fr.created_at desc`
@@ -139,7 +139,7 @@ type EngineExecutor interface {
 	ExecuteWithoutEngineCtx(ctx context.Context, db sql.DB, statement string, params map[string]any, fn func(*kcommon.Row) error) error
 }
 
-// Reward is the data model of table erc20rw_rewards.
+// Reward is the data model of table rewards.
 type Reward struct {
 	ID         *types.UUID
 	Recipient  string
@@ -178,7 +178,7 @@ func (pr *Reward) UnpackTypes(decimalType *types.DataType) []pc.PrecompileValue 
 	}
 }
 
-// Epoch is the data model of table erc20rw_epochs.
+// Epoch is the data model of table epochs.
 type Epoch struct {
 	ID           *types.UUID
 	StartHeight  int64
@@ -243,7 +243,7 @@ func (br *Epoch) UnpackTypes(decimalType *types.DataType) []pc.PrecompileValue {
 	}
 }
 
-// FinalizedReward is the data model of table erc20rw_finalized_rewards.
+// FinalizedReward is the data model of table finalized_rewards.
 type FinalizedReward struct {
 	ID         *types.UUID
 	Voters     []string
@@ -393,15 +393,15 @@ type partialWalletReward struct {
 // GenRewardID generates a unique UUID for a reward. We need special handling
 // here because there could be multiple rewards to the same user with the same amount.
 func GenRewardID(recipient string, amount string, txID string, idx int) *types.UUID {
-	return types.NewUUIDV5([]byte(fmt.Sprintf("erc20rw_rewards_%v_%v_%v_%v", recipient, amount, txID, idx)))
+	return types.NewUUIDV5([]byte(fmt.Sprintf("rewards_%v_%v_%v_%v", recipient, amount, txID, idx)))
 }
 
 func GenBatchRewardID(endHeight int64, signHash []byte) *types.UUID {
-	return types.NewUUIDV5([]byte(fmt.Sprintf("erc20rw_epoch_%v_%x", endHeight, signHash)))
+	return types.NewUUIDV5([]byte(fmt.Sprintf("epoch_%v_%x", endHeight, signHash)))
 }
 
 func GenFinalizedRewardID(contractID *types.UUID, digest []byte) *types.UUID {
-	return types.NewUUIDV5([]byte(fmt.Sprintf("erc20rw_finalized_rewards_%v_%x", contractID.String(), digest)))
+	return types.NewUUIDV5([]byte(fmt.Sprintf("finalized_rewards_%v_%x", contractID.String(), digest)))
 }
 
 func IssueReward(ctx *kcommon.EngineContext, engine EngineExecutor, db sql.DB, ns string, pr *Reward) error {
@@ -718,7 +718,7 @@ func TryFinalizeEpochReward(ctx *kcommon.EngineContext, engine EngineExecutor, d
 		}
 
 		params := map[string]any{"$fid": rid}
-		createRecipientRewardSql := fmt.Sprintf(`{%s}INSERT INTO erc20rw_recipient_reward (recipient, finalized_id) VALUES `, ns)
+		createRecipientRewardSql := fmt.Sprintf(`{%s}INSERT INTO recipient_reward (recipient, finalized_id) VALUES `, ns)
 		for i, addr := range addrs {
 			if i > 0 {
 				createRecipientRewardSql += ","

--- a/test/_old/acceptance/docker-compose-dev.yml
+++ b/test/_old/acceptance/docker-compose-dev.yml
@@ -24,6 +24,7 @@ services:
     networks:
       - kwil-act-testnet
     command: |
+      start
       --root=/app/kwil
       --log-level=${LOG_LEVEL:-info}
       --log-format=plain

--- a/test/_old/acceptance/docker-compose.yml
+++ b/test/_old/acceptance/docker-compose.yml
@@ -22,6 +22,7 @@ services:
     networks:
       - kwil-act-testnet
     command: |
+      start
       --root=/app/kwil
       --log-level=${LOG_LEVEL:-info}
       --log-format=plain

--- a/test/_old/integration/docker-compose-dev.yml
+++ b/test/_old/integration/docker-compose-dev.yml
@@ -21,6 +21,7 @@ services:
       pg0:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -71,6 +72,7 @@ services:
       pg1:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -123,6 +125,7 @@ services:
       pg2:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-level=${LOG_LEVEL:-info}
       --log-format=plain
@@ -177,6 +180,7 @@ services:
       pg3:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -228,6 +232,7 @@ services:
       pg4:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -279,6 +284,7 @@ services:
         pg4:
           condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}

--- a/test/_old/integration/docker-compose-migration.yml.template
+++ b/test/_old/integration/docker-compose-migration.yml.template
@@ -22,6 +22,7 @@ services:
       new-pg0:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -73,6 +74,7 @@ services:
       new-pg1:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -124,6 +126,7 @@ services:
       new-pg2:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -176,6 +179,7 @@ services:
       new-pg3:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}

--- a/test/_old/integration/docker-compose.yml.template
+++ b/test/_old/integration/docker-compose.yml.template
@@ -22,6 +22,7 @@ services:
       pg0:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -74,6 +75,7 @@ services:
       pg1:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -126,6 +128,7 @@ services:
       pg2:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -162,7 +165,7 @@ services:
 
   # This node is used to test the scenario where new node join the network & sync the blocks
   # Removing the ext dependency as test-container docker compose creates a new project everytime we run
-  
+
   # docker compose, and the ext is defined in a seperate project, so service lookup is hard.
   node3:
     image: {{ .DockerImage }}
@@ -182,6 +185,7 @@ services:
       pg3:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -234,6 +238,7 @@ services:
       pg4:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}
@@ -286,6 +291,7 @@ services:
         pg5:
           condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --log-level=${LOG_LEVEL:-info}

--- a/test/setup/node-compose.yml.template
+++ b/test/setup/node-compose.yml.template
@@ -17,6 +17,7 @@
       {{ .PGServicePrefix }}{{ .NodeNumber }}:
         condition: service_healthy
     command: |
+      start
       --root=/app/kwil
       --log-format=plain
       --admin.listen=/tmp/kwild.socket


### PR DESCRIPTION
This pr support a new extension method "list_wallet_rewards", which returns `["chain","chain_id","contract","etherscan","created_at","param_recipient","param_amount","param_block_hash", "param_root", "param_proofs"]`;  to support this I created a table `erc20rw_recipient_reward` when finalize a epoch.

Also rename :
- `erc20rw_pending_reward` table to `erc20rw_rewards`
- `erc20rw_epoch_reward` table to `erc20rw_epochs`
- `erc20rw_pending_signatures` table to `erc20rw_epoch_votes`