### PR TITLE
fix(contrib): add missing subcmd to docker-compose

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,7 +129,7 @@ configuration changes. Start it by running the following from the
 `deployments/compose/kwil` folder in the repository:
 
 ```sh
-cd deployments/compose/kwil
+cd contrib/docker/compose/kwil
 docker compose up --build -d
 ```
 

--- a/contrib/docker/compose/kwil/docker-compose.yml
+++ b/contrib/docker/compose/kwil/docker-compose.yml
@@ -21,7 +21,7 @@ services:
       - pgkwil:/var/lib/postgresql/data
     networks:
       kwilnet0:
-        ipv4_address: 172.5.100.3
+        ipv4_address: 172.5.200.3
     healthcheck:
       test: ["CMD-SHELL", "pg_isready"]
       interval: 2s
@@ -32,8 +32,8 @@ services:
     container_name: kwild-single
     image: kwild:latest
     build:
-      context: ../../../../../
-      dockerfile: ../../kwild.dockerfile
+      context: ../../../../
+      dockerfile: contrib/docker/kwild.dockerfile
     ports:
       - "8484:8484"
       - "6600:6600"
@@ -46,8 +46,9 @@ services:
         condition: service_healthy
     networks:
       kwilnet0:
-        ipv4_address: 172.5.100.2
+        ipv4_address: 172.5.200.2
     command: |
+      start
       --autogen
       --root=/app/.kwild
       --log-format=plain
@@ -55,9 +56,9 @@ services:
       --admin.listen=/tmp/kwild.socket
       --rpc.listen=0.0.0.0:8484
       --p2p.listen=0.0.0.0:6600
-      --consensus.propose-timeout=200ms
-      --consensus.empty-block-timeout=6s
-      --db.host=172.5.100.3
+      --consensus.propose-timeout=1s
+      --consensus.empty-block-timeout=1s
+      --db.host=172.5.200.3
       --db.port=5432
       --db.user=kwild
       --db.pass=kwild
@@ -73,4 +74,4 @@ networks:
     ipam:
       driver: default
       config:
-        - subnet: 172.5.100.0/23
+        - subnet: 172.5.200.0/23

--- a/contrib/docker/kwild.debug.dockerfile
+++ b/contrib/docker/kwild.debug.dockerfile
@@ -28,4 +28,4 @@ COPY --from=build /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/
 COPY --from=build /app/dist/kwild ./kwild
 COPY --from=build /app/dist/kwil-cli ./kwil-cli
 EXPOSE 40000 8484 6600
-ENTRYPOINT ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/app/kwild", "start", "--"]
+ENTRYPOINT ["/dlv", "--listen=:40000", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "/app/kwild", "--"]

--- a/test/nodes/spamd/dockerfile
+++ b/test/nodes/spamd/dockerfile
@@ -8,12 +8,12 @@ COPY . .
 
 WORKDIR /app/test/nodes/spamd
 RUN CGO_ENABLED=0 go build -v  -ldflags -extldflags=-static -o /app/dist/spamd
-RUN chmod +x /app/dist/spamd 
+RUN chmod +x /app/dist/spamd
 RUN /app/dist/spamd -v
 
 FROM kwild:latest
 WORKDIR /app
 COPY --from=build /app/dist/spamd ./kwild
-RUN chmod +x ./kwild 
+RUN chmod +x ./kwild
 EXPOSE 8484 6600
-ENTRYPOINT ["/app/kwild", "start"]
+ENTRYPOINT ["/app/kwild"]


### PR DESCRIPTION
This fix the contrib/docker/compose/docker-compose to use subcmd