### PR TITLE
rework cmd app errors, permit non-zero exit code and custom output

### DIFF
--- a/app/key/info.go
+++ b/app/key/info.go
@@ -68,11 +68,6 @@ func InfoCmd() *cobra.Command {
 			cmd.Usage()
 			return errors.New("must provide with the private key file or hex string")
 		},
-		// PostRunE: func(cmd *cobra.Command, args []string) error {
-		// 	cmdP := cmd.Parent()
-		// 	cmdP.SetContext(cmd.Context())
-		// 	return nil
-		// },
 	}
 
 	cmd.Flags().StringVarP(&privkeyFile, "key-file", "o", "", "file containing the private key to display")

--- a/app/key/info.go
+++ b/app/key/info.go
@@ -68,6 +68,11 @@ func InfoCmd() *cobra.Command {
 			cmd.Usage()
 			return errors.New("must provide with the private key file or hex string")
 		},
+		// PostRunE: func(cmd *cobra.Command, args []string) error {
+		// 	cmdP := cmd.Parent()
+		// 	cmdP.SetContext(cmd.Context())
+		// 	return nil
+		// },
 	}
 
 	cmd.Flags().StringVarP(&privkeyFile, "key-file", "o", "", "file containing the private key to display")

--- a/app/node/node.go
+++ b/app/node/node.go
@@ -188,8 +188,7 @@ func runNode(ctx context.Context, rootDir string, cfg *config.Config, autogen bo
 		}
 	}()
 
-	// ctxBuild, cancelBuild := context.WithCancel()
-	server := buildServer(context.Background(), d)
+	server := buildServer(ctx, d)
 
 	return server.Start(ctx)
 }

--- a/app/rpc/gen-auth-key.go
+++ b/app/rpc/gen-auth-key.go
@@ -63,7 +63,7 @@ func genAuthKeyCmd() *cobra.Command {
 			if err != nil {
 				return display.PrintErr(cmd, fmt.Errorf("failed to read cert file: %v", err))
 			}
-			return appendToFile(filepath.Join(rootDir, "clients.pem"), certText)
+			return display.PrintErr(cmd, appendToFile(filepath.Join(rootDir, "clients.pem"), certText))
 		},
 	}
 

--- a/app/shared/display/format.go
+++ b/app/shared/display/format.go
@@ -12,6 +12,7 @@ import (
 	"strings"
 
 	"github.com/kwilteam/kwil-db/app/shared"
+
 	"github.com/spf13/cobra"
 )
 
@@ -257,11 +258,6 @@ func PrintErr(cmd *cobra.Command, err error) error {
 	// context that we can check for in main. If Cobra did not prefix the error,
 	// we would not have to do this to achieve non-zero exit codes to the OS.
 	shared.SetCmdCtxErr(cmd, err)
-	// ctx := cmd.Context()
-	// if ctxErr, _ := ctx.Value(shared.CtxKeyCmdErr).(error); ctxErr != nil {
-	// 	ctx = context.WithValue(ctx, shared.CtxKeyCmdErr, errors.Join(err, ctxErr))
-	// 	cmd.SetContext(ctx)
-	// }
 
 	outputFormat, err2 := getOutputFormat(cmd)
 	if err2 != nil {

--- a/cmd/kwil-cli/cmds/root.go
+++ b/cmd/kwil-cli/cmds/root.go
@@ -46,6 +46,15 @@ func NewRootCmd() *cobra.Command {
 		},
 	}
 
+	// Pass any errors from the child command's context back to the root
+	// command's context. main or whatever can pull it out with
+	// shared.CmdCtxErr. Alternatively, this function could set the value in a
+	// *error that is returned with the Command, but that's more confusing.
+	rootCmd.PersistentPostRunE = func(child *cobra.Command, args []string) error {
+		shared.SetCmdCtxErr(rootCmd, shared.CmdCtxErr(child)) // more specific than cmd.SetContext(child.Context())
+		return nil
+	}
+
 	// Define the --debug enabled CLI debug mode (shared.Debugf output)
 	bind.BindDebugFlag(rootCmd)
 

--- a/cmd/kwil-cli/main.go
+++ b/cmd/kwil-cli/main.go
@@ -10,6 +10,7 @@ import (
 	// concerned with activation heights, it could need to use new functionality
 	// introduced by the consensus extensions.
 
+	"github.com/kwilteam/kwil-db/app/shared"
 	root "github.com/kwilteam/kwil-db/cmd/kwil-cli/cmds"
 	"github.com/kwilteam/kwil-db/cmd/kwil-cli/config"
 )
@@ -20,5 +21,13 @@ func main() {
 		config.PreRunPrintEffectiveConfig(root, nil) // only when --debug is set
 		os.Exit(-1)
 	}
+
+	// For a command / application error, which handle the output themselves, we
+	// detect those case where display.PrintErr() is called so that we can
+	// return a non-zero exit code, which is important for scripting etc.
+	if err := shared.CmdCtxErr(root); err != nil {
+		os.Exit(-1)
+	}
+
 	os.Exit(0)
 }

--- a/cmd/kwild/main.go
+++ b/cmd/kwild/main.go
@@ -8,6 +8,7 @@ import (
 	"syscall"
 
 	"github.com/kwilteam/kwil-db/app"
+	"github.com/kwilteam/kwil-db/app/shared"
 )
 
 func main() {
@@ -22,15 +23,16 @@ func main() {
 
 	rootCmd := app.RootCmd()
 
-	// Run "start" as the default command if none is given.
-	// cmd, _, err := rootCmd.Traverse(os.Args[1:])
-	// if err == nil && cmd.Use == rootCmd.Use && cmd.Flags().Parse(os.Args[1:]) != pflag.ErrHelp {
-	// 	// rewrite from "kwild <whatever...>" to "kwild start <whatever...>"
-	// 	args := append([]string{"start"}, os.Args[1:]...)
-	// 	rootCmd.SetArgs(args)
-	// }
-
-	if err := rootCmd.ExecuteContext(ctx); err != nil {
+	if err := rootCmd.ExecuteContext(ctx); err != nil { // command syntax error
 		os.Exit(-1)
 	}
+
+	// For a command / application error, which handle the output themselves, we
+	// detect those case where display.PrintErr() is called so that we can
+	// return a non-zero exit code, which is important for scripting etc.
+	if err := shared.CmdCtxErr(rootCmd); err != nil {
+		os.Exit(-1)
+	}
+
+	os.Exit(0)
 }

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -144,7 +144,7 @@ func TestSingleNodeMocknet(t *testing.T) {
 		KwilCfg: defaultConfigSet,
 		Logger:  log.New(log.WithName("P2P"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured)),
 	}
-	ps, err := NewP2PService(psCfg, h1)
+	ps, err := NewP2PService(ctx, psCfg, h1)
 	require.NoError(t, err)
 
 	log1 := log.New(log.WithName("NODE1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured))
@@ -296,7 +296,7 @@ func TestDualNodeMocknet(t *testing.T) {
 		KwilCfg: defaultConfigSet,
 		Logger:  log.New(log.WithName("P2P1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured)),
 	}
-	ps1, err := NewP2PService(psCfg1, h1)
+	ps1, err := NewP2PService(ctx, psCfg1, h1)
 	require.NoError(t, err)
 	err = ps1.Start(ctx)
 	require.NoError(t, err, "failed to start p2p service")
@@ -379,7 +379,7 @@ func TestDualNodeMocknet(t *testing.T) {
 		KwilCfg: defaultConfigSet,
 		Logger:  log.New(log.WithName("P2P2"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured)),
 	}
-	ps2, err := NewP2PService(psCfg2, h2)
+	ps2, err := NewP2PService(ctx, psCfg2, h2)
 	require.NoError(t, err)
 	err = ps2.Start(ctx)
 	require.NoError(t, err, "failed to start p2p service")

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -124,7 +124,7 @@ func makeTestHosts(t *testing.T, nNodes, nExtraHosts int, blockInterval time.Dur
 			Logger:  log.DiscardLogger,
 		}
 
-		ps, err := NewP2PService(psCfg, h)
+		ps, err := NewP2PService(context.Background(), psCfg, h)
 		if err != nil {
 			t.Fatalf("Failed to create P2PService: %v", err)
 		}

--- a/test/integration/kwild_test.go
+++ b/test/integration/kwild_test.go
@@ -711,17 +711,20 @@ func TestKwildPrivateNetworks(t *testing.T) {
 							nc.Configure = func(conf *config.Config) {
 								conf.P2P.PrivateMode = true
 							}
+							nc.NoHealthCheck = true
 						}),
 						setup.CustomNodeConfig(func(nc *setup.NodeConfig) {
 							nc.Configure = func(conf *config.Config) {
 								conf.P2P.PrivateMode = true
 							}
+							nc.NoHealthCheck = true
 							nc.Validator = false
 						}),
 						setup.CustomNodeConfig(func(nc *setup.NodeConfig) {
 							nc.Configure = func(conf *config.Config) {
 								conf.P2P.PrivateMode = true
 							}
+							nc.NoHealthCheck = true
 							nc.Validator = false
 						}),
 					},

--- a/test/setup/compose.go
+++ b/test/setup/compose.go
@@ -33,6 +33,7 @@ type nodeTemplate struct {
 	// the docker network. It will be appended with the NodeNumber to create the
 	// full hostname
 	NodeServicePrefix string
+	NoHealthCheck     bool
 	// PGServicePrefix is the name of the postgres service
 	PGServicePrefix string
 	// TestnetDir is the directory to use for the testnet
@@ -85,6 +86,7 @@ func generateCompose(dockerNetwork string, testnetDir string, nodeConfs []*NodeC
 			Network:            dockerNetwork,
 			NodeNumber:         i,
 			NodeServicePrefix:  nodePrefix,
+			NoHealthCheck:      nodeConf.NoHealthCheck,
 			PGServicePrefix:    pgPrefix,
 			TestnetDir:         testnetDir,
 			ExposedJSONRPCPort: 8484 + i + portsOffset,

--- a/test/setup/jsonrpc_cli_driver.go
+++ b/test/setup/jsonrpc_cli_driver.go
@@ -70,7 +70,7 @@ func cmd[T any](j *jsonRPCCLIDriver, ctx context.Context, res T, args ...string)
 		return fmt.Errorf("no output from command")
 	}
 
-	j.logFunc("Running Command ", `/app/kwil-cli `+strings.Join(args, " "), " with output ", buf.String())
+	j.logFunc("Running Command /app/kwil-cli " + strings.Join(args, " ") + " with output " + buf.String())
 
 	d := display.MessageReader[T]{
 		Result: res,

--- a/test/setup/node-compose.yml.template
+++ b/test/setup/node-compose.yml.template
@@ -28,7 +28,7 @@
       --db.user=kwild
       --db.pass=kwild
     healthcheck:
-      test: ["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]
+      test: {{ if .NoHealthCheck }}"true"{{ else }}["CMD", "curl", "--fail-with-body", "-s", "http://127.0.0.1:8484/api/v1/health/user"]{{ end}}
       interval: 2s
       timeout: 6s
       retries: 10

--- a/test/setup/node.go
+++ b/test/setup/node.go
@@ -96,7 +96,8 @@ func (n *NetworkConfig) ensureDefaults(t *testing.T) {
 type NodeConfig struct {
 	// OPTIONAL: DockerImage is the docker image to use
 	// By default, it is "kwild:latest"
-	DockerImage string
+	DockerImage   string
+	NoHealthCheck bool
 
 	// OPTIONAL: Validator is true if the node is a validator
 	// By default, it is true.


### PR DESCRIPTION
This changes how the command line apps handle errors to ensure we have non-zero exit codes to the OS/shell while also maintaining our own output format.  This is important for scripting among other things.

The problem with cobra is that if we return an error from say `RunE`, [cobra will insist on prefixing the error message](https://github.com/spf13/cobra/issues/2226) with a text like `Error: ` which is no good for reasons.  We can sorta set this prefix, but it's a somewhat flawed implementation whereby we always end up with at least two spaces prefixing the output we want.  This is why we have had the `shared/display.PrintErr` always eating the error, I believe.

We get around this issue by continuing to swallow the error, but storing the error in the command's context, and then in `main()` pulling it out and setting the exit code if it is not nil.  (we don't actually need the `error`, just a bool, but I include the whole thing for debugging).

Finally, this PR also resolves related issues with startup and shutdown:
- the `buildServer` function was receiving the background context (my bad) so we couldn't really cancel things like a peer dial that would have to timeout instead
- the `P2Pservice` initializer used a background context
- the bootnode loop in `(*P2PService).Start` always returned nil even if the context was cancelled and a peer connect returned a non-nil error.  This was logically done to allow the loop to `continue` to other peers, but if the context was cancelled, we need to abort startup.  Before this fix, it would go on to initialize other systems, eventually hitting one that cared about the context cancellation.