### PR TITLE
node: use bootpeers in mocknet test instead of force connect

### DIFF
--- a/node/node_test.go
+++ b/node/node_test.go
@@ -37,7 +37,7 @@ import (
 
 var blackholeIP6 = net.ParseIP("100::")
 
-func newTestHost(t *testing.T, mn mock.Mocknet) ([]byte, host.Host) {
+func newTestHost(t *testing.T, mn mock.Mocknet) (p2pcrypto.PrivKey, host.Host) {
 	privKey, _, err := p2pcrypto.GenerateSecp256k1Key(rand.Reader)
 	if err != nil {
 		t.Fatalf("Failed to generate private key: %v", err)
@@ -62,11 +62,11 @@ func newTestHost(t *testing.T, mn mock.Mocknet) ([]byte, host.Host) {
 		t.Fatalf("Failed to add peer to mocknet: %v", err)
 	}
 
-	pkBytes, err := privKey.Raw()
-	if err != nil {
-		t.Fatalf("Failed to get private key bytes: %v", err)
-	}
-	return pkBytes, host
+	// pkBytes, err := privKey.Raw()
+	// if err != nil {
+	// 	t.Fatalf("Failed to get private key bytes: %v", err)
+	// }
+	return privKey, host
 }
 
 func makeTestHosts(t *testing.T, nNodes, nExtraHosts int, blockInterval time.Duration) ([]*Node, []host.Host, []*P2PService, mock.Mocknet) {
@@ -87,7 +87,8 @@ func makeTestHosts(t *testing.T, nNodes, nExtraHosts int, blockInterval time.Dur
 		pk, h := newTestHost(t, mn)
 		t.Logf("node host is %v", h.ID())
 
-		priv, err := crypto.UnmarshalSecp256k1PrivateKey(pk)
+		pkBts, _ := pk.Raw()
+		priv, err := crypto.UnmarshalSecp256k1PrivateKey(pkBts)
 		if err != nil {
 			t.Fatalf("Failed to unmarshal private key: %v", err)
 		}

--- a/node/statesync_test.go
+++ b/node/statesync_test.go
@@ -50,7 +50,8 @@ var (
 )
 
 func newTestStatesyncer(ctx context.Context, t *testing.T, mn mock.Mocknet, rootDir string, sCfg *config.StateSyncConfig) (host.Host, discovery.Discovery, *snapshotStore, *StateSyncService, crypto.PrivateKey, error) {
-	pkBts, h := newTestHost(t, mn)
+	priv, h := newTestHost(t, mn)
+	pkBts, _ := priv.Raw()
 	pk, err := crypto.UnmarshalSecp256k1PrivateKey(pkBts)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err


### PR DESCRIPTION
This makes `TestDualNodeMocket` use bootpeers like real apps rather than having the mocknet do it's `ConnectAllButSelf` magic.  Let's see if CI and my machine like this better.

More generally, we've started doing much more outside of the `Node` constructor and `Start`, so it might make sense to have these quick in-memory tests in some other node_test package that uses the server construction stuff in `app/node` directly so this is closer to reality.  This test came about before there was even an app using `Node`.