### PR TITLE
leader election

### DIFF
--- a/app/params/status.go
+++ b/app/params/status.go
@@ -52,8 +52,7 @@ func showUpdateProposalCmd() *cobra.Command {
 				return display.PrintErr(cmd, fmt.Errorf("proposal not found"))
 			}
 			prop := updateProps[propIdx]
-
-			return display.PrintCmd(cmd, msgUpdateResolutionStatus{
+			return display.PrintCmd(cmd, MsgUpdateResolutionStatus{
 				ResStatus: MsgResolutionStatus{PendingResolution: *status, indent: "\t"},
 				Proposal:  prop,
 			})
@@ -61,12 +60,12 @@ func showUpdateProposalCmd() *cobra.Command {
 	}
 }
 
-type msgUpdateResolutionStatus struct {
+type MsgUpdateResolutionStatus struct {
 	ResStatus MsgResolutionStatus                 `json:"status"`
 	Proposal  *types.ConsensusParamUpdateProposal `json:"proposal"`
 }
 
-func (urs msgUpdateResolutionStatus) MarshalText() ([]byte, error) {
+func (urs MsgUpdateResolutionStatus) MarshalText() ([]byte, error) {
 	rsStr, err := urs.ResStatus.MarshalText()
 	if err != nil {
 		return nil, err
@@ -82,8 +81,8 @@ func (urs msgUpdateResolutionStatus) MarshalText() ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
-func (urs msgUpdateResolutionStatus) MarshalJSON() ([]byte, error) {
-	type alias msgUpdateResolutionStatus
+func (urs MsgUpdateResolutionStatus) MarshalJSON() ([]byte, error) {
+	type alias MsgUpdateResolutionStatus
 	return json.Marshal(alias(urs))
 }
 

--- a/app/setup/reset.go
+++ b/app/setup/reset.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/kwilteam/kwil-db/app/custom"
 	"github.com/kwilteam/kwil-db/app/node/conf"
@@ -68,37 +67,42 @@ func ResetCmd() *cobra.Command {
 
 			if all {
 				// remove the blockstore if all is set
-				chainDir := filepath.Join(rootDir, "blockstore")
+				chainDir := config.BlockstoreDir(rootDir)
 				if err := os.RemoveAll(chainDir); err != nil {
 					return err
 				}
 				fmt.Printf("Blockstore directory removed: %s\n", chainDir)
 
 				// remove rcvd_snaps if exists
-				snapDir := filepath.Join(rootDir, "rcvd_snaps")
+				snapDir := config.ReceivedSnapshotsDir(rootDir)
 				if err := os.RemoveAll(snapDir); err != nil {
 					return err
 				}
 				fmt.Printf("Statesync snapshots directory removed: %s\n", snapDir)
 
 				// remove snapshots if exists
-				snapDir = filepath.Join(rootDir, "snapshots")
+				snapDir = config.LocalSnapshotsDir(rootDir)
 				if err := os.RemoveAll(snapDir); err != nil {
 					return err
 				}
 				fmt.Println("Snapshots directory removed", snapDir)
 
 				// remove the migrations directory
-				migrationsDir := filepath.Join(rootDir, "migrations")
+				migrationsDir := config.MigrationDir(rootDir)
 				if err := os.RemoveAll(migrationsDir); err != nil {
 					return err
 				}
 				fmt.Println("Migrations directory removed", migrationsDir)
 
 				// remove genesis state file if exists
-				genesisFile := filepath.Join(rootDir, "genesis-state.sql.gz")
+				genesisFile := config.GenesisStateFileName(rootDir)
 				os.Remove(genesisFile) // ignore error
 				fmt.Println("Genesis state file removed", genesisFile)
+
+				// leader.json file if exists
+				leaderFile := config.LeaderUpdatesFilePath(rootDir)
+				os.Remove(leaderFile) // ignore error
+				fmt.Println("Leader file removed", leaderFile)
 			}
 
 			return nil

--- a/app/validator/cmd.go
+++ b/app/validator/cmd.go
@@ -24,6 +24,7 @@ func NewValidatorsCmd() *cobra.Command {
 		removeCmd(),
 		leaveCmd(),
 		listJoinRequestsCmd(),
+		promoteCmd(),
 	)
 
 	rpc.BindRPCFlags(validatorsCmd)

--- a/app/validator/promote.go
+++ b/app/validator/promote.go
@@ -1,0 +1,78 @@
+package validator
+
+import (
+	"encoding/json"
+	"fmt"
+	"strconv"
+
+	"github.com/kwilteam/kwil-db/app/rpc"
+	"github.com/kwilteam/kwil-db/app/shared/display"
+	"github.com/kwilteam/kwil-db/config"
+	"github.com/spf13/cobra"
+)
+
+var (
+	promoteExample = `# Promote a new leader starting from block height 1000
+kwild validators promote 02c57268fc884fa88425c7e5c19d3af263d1c64dd8b8f3f8c0fb31bb622d1fdab8#secp256k1 1000`
+
+	promoteLong = `This command promotes a new leader starting from the specified block height. If the majority of validators agree, the new leader will be promoted from the given height. It is crucial for the validator being promoted to also promote themselves, otherwise, they will not propose a block when required. The specified height must not be an already committed block height, or the command will be rejected. This command will create or update the leader-updates.json file in the node's root directory, and when these updates are applied by the node at the specified height, the file will be deleted.`
+)
+
+func promoteCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "replace-leader <candidate> <height>",
+		Short:   "Promote a validator to leader starting from the specified height.",
+		Long:    promoteLong,
+		Example: promoteExample,
+		Args:    cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			ctx := cmd.Context()
+
+			clt, err := rpc.AdminSvcClient(ctx, cmd)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			pubKey, keyType, err := config.DecodePubKeyAndType(args[0])
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			height, err := strconv.ParseInt(args[1], 10, 64)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			err = clt.Promote(ctx, pubKey, keyType, height)
+			if err != nil {
+				return display.PrintErr(cmd, err)
+			}
+
+			return display.PrintCmd(cmd, promoteStatus{
+				Height: height,
+				PubKey: args[0],
+			})
+		},
+	}
+
+	return cmd
+}
+
+type promoteStatus struct {
+	Height int64  `json:"height"`
+	PubKey string `json:"pubkey"`
+}
+
+func (ps promoteStatus) MarshalText() ([]byte, error) {
+	return []byte(fmt.Sprintf("Node will start accepting proposals from %s from height %d.\nThe new leader and majority of the validators must run this command for the leader replacement to be successful.", ps.PubKey, ps.Height)), nil
+}
+
+func (ps promoteStatus) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Height int64  `json:"height"`
+		PubKey string `json:"pubkey"`
+	}{
+		Height: ps.Height,
+		PubKey: ps.PubKey,
+	})
+}

--- a/config/folders.go
+++ b/config/folders.go
@@ -11,24 +11,25 @@ const (
 // Top-level directory structure for the Server's systems. These are not user
 // configurable.
 const (
-	abciDirName    = "abci" // cometBFT node's root folder
-	signingDirName = "signing"
-
-	// ABCIInfoSubDirName is deprecated, only used to migrate old kv state
-	// (meta) data into the main DB's kwild_chain schema (internal/abci/meta).
-	abciInfoSubDirName = "info" // e.g. abci/info for kv state data
-
 	configFileName    = "config.toml"
 	migrationsDirName = "migrations"
+	blockstoreDirName = "blockstore"
 
 	// receivedSnapshotsDirName is the directory where snapshots are received
 	receivedSnapshotsDirName = "received_snapshots"
 	// LocalSnapshots is the directory where snapshots taken by the local node are stored
-	localSnapshotsDirName = "local_snapshots"
+	localSnapshotsDirName = "snapshots"
 
 	genesisStateFileName = "genesis-state.sql.gz"
 	genesisFileName      = "genesis.json"
+
+	leaderUpdatesFileName = "leader-updates.json"
 )
+
+// BlockstoreDir returns the blockstore directory in the root directory.
+func BlockstoreDir(rootDir string) string {
+	return filepath.Join(rootDir, blockstoreDirName)
+}
 
 // GenesisStateFileName returns the genesis state file in the root directory.
 func GenesisStateFileName(rootDir string) string {
@@ -43,21 +44,6 @@ func ReceivedSnapshotsDir(rootDir string) string {
 // LocalSnapshotsDir returns the directory where snapshots taken by the local node are stored
 func LocalSnapshotsDir(rootDir string) string {
 	return filepath.Join(rootDir, localSnapshotsDirName)
-}
-
-// ABCIDir returns the directory where the ABCI node's data is stored
-func ABCIDir(rootDir string) string {
-	return filepath.Join(rootDir, abciDirName)
-}
-
-// ABCIInfoDir returns the directory where the ABCI node's info is stored
-func ABCIInfoDir(rootDir string) string {
-	return filepath.Join(ABCIDir(rootDir), abciInfoSubDirName)
-}
-
-// SigningDir returns the directory where the ABCI node's signing keys are stored
-func SigningDir(rootDir string) string {
-	return filepath.Join(rootDir, signingDirName)
 }
 
 // ConfigFilePath returns the path to the config file
@@ -76,4 +62,8 @@ func GenesisFilePath(rootDir string) string {
 
 func NodeKeyFilePath(rootDir string) string {
 	return filepath.Join(rootDir, NodeKeyFileName)
+}
+
+func LeaderUpdatesFilePath(rootDir string) string {
+	return filepath.Join(rootDir, leaderUpdatesFileName)
 }

--- a/core/rpc/client/admin/admin.go
+++ b/core/rpc/client/admin/admin.go
@@ -14,6 +14,7 @@ type AdminClient interface {
 	Join(ctx context.Context) (types.Hash, error)
 	JoinStatus(ctx context.Context, pubkey []byte, pubKeyType crypto.KeyType) (*types.JoinRequest, error)
 	Leave(ctx context.Context) (types.Hash, error)
+	Promote(ctx context.Context, publicKey []byte, pubKeyType crypto.KeyType, height int64) error
 	ListValidators(ctx context.Context) ([]*types.Validator, error)
 	Peers(ctx context.Context) ([]*adminTypes.PeerInfo, error)
 	Remove(ctx context.Context, publicKey []byte, pubKeyType crypto.KeyType) (types.Hash, error)

--- a/core/rpc/client/admin/jsonrpc/client.go
+++ b/core/rpc/client/admin/jsonrpc/client.go
@@ -131,6 +131,17 @@ func (cl *Client) Remove(ctx context.Context, publicKey []byte, pubKeyType crypt
 	return res.TxHash, err
 }
 
+// Promote promotes a validator to a leader at the specified height.
+func (cl *Client) Promote(ctx context.Context, publicKey []byte, pubKeyType crypto.KeyType, height int64) error {
+	cmd := &adminjson.PromoteRequest{
+		PubKey:     publicKey,
+		PubKeyType: pubKeyType,
+		Height:     height,
+	}
+	res := &adminjson.PromoteResponse{}
+	return cl.CallMethod(ctx, string(adminjson.MethodValPromote), cmd, res)
+}
+
 // Status gets the node's status, such as it's name, chain ID, versions, sync
 // status, best block info, and validator identity.
 func (cl *Client) Status(ctx context.Context) (*adminTypes.Status, error) {

--- a/core/rpc/json/admin/commands.go
+++ b/core/rpc/json/admin/commands.go
@@ -56,3 +56,9 @@ type AbortBlockExecRequest struct {
 	Height int64    `json:"height"`
 	Txs    []string `json:"txs"`
 }
+
+type PromoteRequest struct {
+	PubKey     []byte         `json:"pubkey"`
+	PubKeyType crypto.KeyType `json:"pubkey_type"`
+	Height     int64          `json:"height"`
+}

--- a/core/rpc/json/admin/methods.go
+++ b/core/rpc/json/admin/methods.go
@@ -17,6 +17,7 @@ const (
 	MethodValJoinStatus     jsonrpc.Method = "admin.val_join_status"
 	MethodValList           jsonrpc.Method = "admin.val_list"
 	MethodValListJoins      jsonrpc.Method = "admin.val_list_joins"
+	MethodValPromote        jsonrpc.Method = "admin.val_promote"
 	MethodAddPeer           jsonrpc.Method = "admin.add_peer"
 	MethodRemovePeer        jsonrpc.Method = "admin.remove_peer"
 	MethodListPeers         jsonrpc.Method = "admin.list_peers"

--- a/core/rpc/json/admin/responses.go
+++ b/core/rpc/json/admin/responses.go
@@ -109,3 +109,5 @@ type BlockExecStatusResponse struct {
 }
 
 type AbortBlockExecResponse struct{}
+
+type PromoteResponse struct{}

--- a/core/types/params.go
+++ b/core/types/params.go
@@ -608,3 +608,15 @@ func (np NetworkParameters) String() string {
 		&np.Leader, np.MaxBlockSize, np.JoinExpiry,
 		np.DisabledGasCosts, np.MaxVotesPerTx, np.MigrationStatus)
 }
+
+func (np *NetworkParameters) Hash() Hash {
+	hasher := NewHasher()
+	hasher.Write(np.Leader.Bytes())
+	binary.Write(hasher, SerializationByteOrder, np.MaxBlockSize)
+	binary.Write(hasher, SerializationByteOrder, np.JoinExpiry)
+	binary.Write(hasher, SerializationByteOrder, np.DisabledGasCosts)
+	binary.Write(hasher, SerializationByteOrder, np.MaxVotesPerTx)
+	hasher.Write([]byte(np.MigrationStatus))
+
+	return hasher.Sum(nil)
+}

--- a/core/types/params_test.go
+++ b/core/types/params_test.go
@@ -85,13 +85,6 @@ func TestSetParamNames(t *testing.T) {
 	}
 }
 
-/*func acctIDForPubKey(pub crypto.PublicKey) AccountID {
-	return AccountID{
-		Identifier: pub.Bytes(),
-		KeyType:    pub.Type(),
-	}
-}*/
-
 func TestParamUpdatesMarshalBinary(t *testing.T) {
 	_, pub, err := crypto.GenerateSecp256k1Key(nil)
 	if err != nil {

--- a/node/consensus.go
+++ b/node/consensus.go
@@ -210,10 +210,6 @@ func (n *Node) announceBlkProp(ctx context.Context, blk *ktypes.Block) {
 func (n *Node) blkPropStreamHandler(s network.Stream) {
 	defer s.Close()
 
-	// if n.role.Load() == types.RoleLeader {
-	// 	return
-	// }
-
 	var prop blockProp
 	_, err := prop.ReadFrom(s)
 	if err != nil {

--- a/node/consensus/updates.go
+++ b/node/consensus/updates.go
@@ -36,7 +36,7 @@ func init() {
 }
 
 var ParamUpdatesResolution = resolutions.ResolutionConfig{
-	ConfirmationThreshold: big.NewRat(2, 3),
+	ConfirmationThreshold: big.NewRat(1, 2),   // > 50%
 	ExpirationPeriod:      7 * 24 * time.Hour, // 1 week
 	ResolveFunc: func(ctx context.Context, app *common.App, resolution *resolutions.Resolution, block *common.BlockContext) error {
 		// a resolution with an invalid body should be rejected before this

--- a/node/engine/parse/gen/kuneiform_lexer.go
+++ b/node/engine/parse/gen/kuneiform_lexer.go
@@ -4,9 +4,10 @@ package gen
 
 import (
 	"fmt"
-	"github.com/antlr4-go/antlr/v4"
 	"sync"
 	"unicode"
+
+	"github.com/antlr4-go/antlr/v4"
 )
 
 // Suppress unused import error

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -3,6 +3,7 @@ package node
 import (
 	"context"
 
+	"github.com/kwilteam/kwil-db/core/crypto"
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/consensus"
 	"github.com/kwilteam/kwil-db/node/snapshotter"
@@ -19,7 +20,7 @@ type ConsensusEngine interface {
 	AcceptProposal(height int64, blkID, prevBlkID types.Hash, leaderSig []byte, timestamp int64) bool
 	NotifyBlockProposal(blk *ktypes.Block)
 
-	AcceptCommit(height int64, blkID types.Hash, ci *types.CommitInfo, leaderSig []byte) bool
+	AcceptCommit(height int64, blkID types.Hash, hdr *ktypes.BlockHeader, ci *types.CommitInfo, leaderSig []byte) bool
 	NotifyBlockCommit(blk *ktypes.Block, ci *types.CommitInfo)
 
 	NotifyACK(validatorPK []byte, ack types.AckRes)
@@ -35,6 +36,9 @@ type ConsensusEngine interface {
 
 	ConsensusParams() *ktypes.NetworkParameters
 	CancelBlockExecution(height int64, txIDs []types.Hash) error
+
+	// PromoteLeader is used to promote a validator to leader starting from the specified height
+	PromoteLeader(leader crypto.PublicKey, height int64) error
 }
 
 type BlockProcessor interface {

--- a/node/node.go
+++ b/node/node.go
@@ -116,7 +116,6 @@ type Node struct {
 	P2PService
 
 	// cfg
-	pex    bool
 	pubkey crypto.PublicKey
 	dir    string
 	// pf *prefetch
@@ -159,7 +158,6 @@ func NewNode(cfg *Config, opts ...Option) (*Node, error) {
 	node := &Node{
 		log:     logger,
 		pubkey:  pubkey,
-		pex:     cfg.P2P.Pex,
 		mp:      cfg.Mempool,
 		bki:     cfg.BlockStore,
 		ce:      cfg.Consensus,
@@ -575,6 +573,10 @@ func (n *Node) ConsensusParams() *ktypes.NetworkParameters {
 
 func (n *Node) AbortBlockExecution(height int64, txIDs []types.Hash) error {
 	return n.ce.CancelBlockExecution(height, txIDs)
+}
+
+func (n *Node) PromoteLeader(candidate crypto.PublicKey, height int64) error {
+	return n.ce.PromoteLeader(candidate, height)
 }
 
 func (n *Node) Role() types.Role {

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -137,7 +137,8 @@ func TestSingleNodeMocknet(t *testing.T) {
 		BroadcastTxTimeout:    15 * time.Second,
 		DB:                    db1,
 	}
-	ce1 := consensus.New(ceCfg1)
+	ce1, err := consensus.New(ceCfg1)
+	require.NoError(t, err)
 	defaultConfigSet := config.DefaultConfig()
 
 	psCfg := &P2PServiceConfig{
@@ -296,7 +297,8 @@ func TestDualNodeMocknet(t *testing.T) {
 		DB:                    db1,
 		BlockProcessor:        bp1,
 	}
-	ce1 := consensus.New(ceCfg1)
+	ce1, err := consensus.New(ceCfg1)
+	require.NoError(t, err)
 	defaultConfigSet := config.DefaultConfig()
 	log1 := log.New(log.WithName("NODE1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured))
 
@@ -368,7 +370,8 @@ func TestDualNodeMocknet(t *testing.T) {
 		BlockAnnInterval:      3 * time.Second,
 		DB:                    db2,
 	}
-	ce2 := consensus.New(ceCfg2)
+	ce2, err := consensus.New(ceCfg2)
+	require.NoError(t, err)
 
 	log2 := log.New(log.WithName("NODE2"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured))
 
@@ -588,22 +591,3 @@ func (m *mockEventStore) HasEvents() bool {
 }
 
 func (m *mockEventStore) UpdateStats(cnt int64) {}
-
-// TODO: can test with real migrator
-/*type mockMigrator struct{}
-
-func (m *mockMigrator) NotifyHeight(ctx context.Context, block *common.BlockContext, db migrations.Database) error {
-	return nil
-}
-
-func (m *mockMigrator) StoreChangesets(height int64, changes <-chan any) error {
-	return nil
-}
-
-func (m *mockMigrator) PersistLastChangesetHeight(ctx context.Context, tx sql.Executor) error {
-	return nil
-}
-
-func (m *mockMigrator) GetMigrationMetadata(ctx context.Context, status ktypes.MigrationStatus) (*ktypes.MigrationMetadata, error) {
-	return nil, nil
-}*/

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -215,7 +215,7 @@ func createTestBlock(height int64, numTxns int) (*ktypes.Block, types.Hash) {
 		txns[i] = newTx(uint64(i), "bob", strconv.FormatInt(height, 10)+strconv.Itoa(i)+
 			strings.Repeat("data", 1000))
 	}
-	blk := ktypes.NewBlock(height, types.Hash{2, 3, 4}, types.Hash{6, 7, 8}, types.Hash{5, 5, 5},
+	blk := ktypes.NewBlock(height, types.Hash{2, 3, 4}, types.Hash{6, 7, 8}, types.Hash{5, 5, 5}, types.HashBytes([]byte("params")),
 		time.Unix(1729723553+height, 0), txns)
 	return blk, fakeAppHash(height)
 }
@@ -300,7 +300,7 @@ func (ce *dummyCE) AcceptProposal(height int64, blkID, prevBlkID types.Hash, lea
 	return !ce.rejectProp
 }
 
-func (ce *dummyCE) AcceptCommit(height int64, blkID types.Hash, ci *types.CommitInfo, leaderSig []byte) bool {
+func (ce *dummyCE) AcceptCommit(height int64, blkID types.Hash, hdr *ktypes.BlockHeader, ci *types.CommitInfo, leaderSig []byte) bool {
 	return !ce.rejectCommit
 }
 
@@ -376,6 +376,10 @@ func (ce *dummyCE) Start(ctx context.Context, fns consensus.BroadcastFns, peerFn
 	ce.blkRequester = fns.BlkRequester
 	ce.stateResetter = fns.RstStateBroadcaster
 
+	return nil
+}
+
+func (f *dummyCE) PromoteLeader(leader crypto.PublicKey, height int64) error {
 	return nil
 }
 

--- a/node/protocol_test.go
+++ b/node/protocol_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"math"
 	"testing"
+	"time"
 
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/types"
@@ -22,8 +23,24 @@ func TestBlockAnnMsg_MarshalUnmarshal(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "empty message with commitInfo",
+			name: "empty message without commitInfo",
 			msg: &blockAnnMsg{
+				Header:     nil,
+				CommitInfo: &types.CommitInfo{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty message with commitInfo, without header",
+			msg: &blockAnnMsg{
+				CommitInfo: &types.CommitInfo{},
+			},
+			wantErr: true,
+		},
+		{
+			name: "empty message with header and commitInfo",
+			msg: &blockAnnMsg{
+				Header:     &ktypes.BlockHeader{},
 				CommitInfo: &types.CommitInfo{},
 			},
 			wantErr: false,
@@ -43,6 +60,7 @@ func TestBlockAnnMsg_MarshalUnmarshal(t *testing.T) {
 			msg: &blockAnnMsg{
 				Height: 100,
 				Hash:   [32]byte{1, 2, 3},
+				Header: &ktypes.BlockHeader{},
 				CommitInfo: &types.CommitInfo{
 					AppHash: ktypes.Hash{1, 2, 3},
 				},
@@ -58,8 +76,28 @@ func TestBlockAnnMsg_MarshalUnmarshal(t *testing.T) {
 				CommitInfo: &types.CommitInfo{
 					AppHash: ktypes.Hash{1, 2, 3},
 				},
+				Header: &ktypes.BlockHeader{},
 			},
 			wantErr: false, // leaderSig verified at higher level
+		},
+		{
+			name: "valid payload",
+			msg: &blockAnnMsg{
+				Height: 100,
+				Hash:   [32]byte{1, 2, 3},
+				Header: &ktypes.BlockHeader{
+					Height:            100,
+					NumTxns:           0,
+					Timestamp:         time.Now(),
+					PrevAppHash:       ktypes.Hash{1, 2, 3},
+					ValidatorSetHash:  ktypes.Hash{1, 2, 3},
+					NetworkParamsHash: ktypes.Hash{1, 2, 3},
+				},
+				CommitInfo: &types.CommitInfo{
+					AppHash: ktypes.Hash{1, 2, 3},
+				},
+				LeaderSig: []byte{7, 8, 9},
+			},
 		},
 	}
 

--- a/node/store/memstore/memstore_test.go
+++ b/node/store/memstore/memstore_test.go
@@ -44,7 +44,7 @@ func createTestBlock(_ *testing.T, height int64, numTxns int) (*ktypes.Block, ty
 		txns[i] = rawTx
 	}
 	blk := ktypes.NewBlock(height, types.Hash{2, 3, 4}, types.Hash{6, 7, 8}, types.Hash{5, 5, 5},
-		time.Unix(1729723553+height, 0), txs)
+		types.Hash{5, 5, 5}, time.Unix(1729723553+height, 0), txs)
 	return blk, fakeAppHash(height)
 }
 

--- a/node/store/store_test.go
+++ b/node/store/store_test.go
@@ -83,7 +83,7 @@ func createTestBlock(_ *testing.T, height int64, numTxns int) (*ktypes.Block, ty
 		txns[i] = rawTx
 	}
 	blk := ktypes.NewBlock(height, types.Hash{2, 3, 4}, types.Hash{6, 7, 8}, types.Hash{5, 5, 5},
-		time.Unix(1729723553+height, 0), txs)
+		types.Hash{5, 5, 5}, time.Unix(1729723553+height, 0), txs)
 	return blk, fakeAppHash(height), txns
 }
 
@@ -240,7 +240,7 @@ func TestBlockStore_HaveTx(t *testing.T) {
 func TestBlockStore_StoreWithNoTransactions(t *testing.T) {
 	bs, _ := setupTestBlockStore(t)
 	block := ktypes.NewBlock(1, types.Hash{2, 3, 4}, types.Hash{6, 7, 8}, types.Hash{},
-		time.Unix(1729723553, 0), []*ktypes.Transaction{})
+		types.Hash{5, 5, 5}, time.Unix(1729723553, 0), []*ktypes.Transaction{})
 	appHash := fakeAppHash(1)
 
 	err := bs.Store(block, &types.CommitInfo{AppHash: appHash})
@@ -347,7 +347,7 @@ func TestBlockStore_StoreWithLargeTransactions(t *testing.T) {
 	}
 
 	block := ktypes.NewBlock(1, types.Hash{2, 3, 4}, types.Hash{6, 7, 8}, types.Hash{},
-		time.Unix(1729723553, 0), []*ktypes.Transaction{largeTx, otherTx})
+		types.Hash{5, 5, 5}, time.Unix(1729723553, 0), []*ktypes.Transaction{largeTx, otherTx})
 	appHash := fakeAppHash(1)
 
 	err = bs.Store(block, &types.CommitInfo{AppHash: appHash})
@@ -454,7 +454,7 @@ func TestLargeBlockStore(t *testing.T) {
 		}
 
 		// Create and store block
-		block := ktypes.NewBlock(height, prevHash, prevAppHash, types.Hash{}, time.Now(), txns)
+		block := ktypes.NewBlock(height, prevHash, prevAppHash, types.Hash{}, types.Hash{}, time.Now(), txns)
 		appHash := types.HashBytes([]byte(fmt.Sprintf("app-%d", height)))
 		err = bs.Store(block, &types.CommitInfo{AppHash: appHash})
 		if err != nil {
@@ -570,7 +570,7 @@ func TestBlockStore_StoreResultsEmptyBlock(t *testing.T) {
 	bs, _ := setupTestBlockStore(t)
 
 	block := ktypes.NewBlock(1, types.Hash{2, 3, 4}, types.Hash{6, 7, 8}, types.Hash{},
-		time.Unix(1729723553, 0), []*ktypes.Transaction{})
+		types.Hash{5, 5, 5}, time.Unix(1729723553, 0), []*ktypes.Transaction{})
 	appHash := fakeAppHash(1)
 
 	err := bs.Store(block, &types.CommitInfo{AppHash: appHash})


### PR DESCRIPTION
This PR introduces a way to update leader if the current leader is offline and the chain is halted because of offline leader.

`kwild validators promote <leaderCandidate> <height>`
In scenarios where leader is offline, there are multiple ways you can recover the chain. 

1. Fix the leader and bring the leader back up. 
2. If leader is not fixable or network doesn't want the previous leader, network should decide on the next leader and at least majority of the validators should promote the new candidate at the halt height using the above command for the new leader to take over and start proposing blocks. If majority of validators don't promote the same leader, the chain can end up in a broken state where different validators treat different nodes as the leader, so this command should be used with caution and to be used in scenarios when the chain is halted due to leader being offline and other methods (using param update resolutions) for changing the leader. 