### PR TITLE
pg: decoding and selecting nulls in arrays (part 2)

### DIFF
--- a/core/types/decimal.go
+++ b/core/types/decimal.go
@@ -569,7 +569,13 @@ type DecimalArray []*Decimal
 func (da DecimalArray) Value() (driver.Value, error) {
 	var res []string
 	for _, d := range da {
-		res = append(res, d.String())
+		var val string
+		if d.dec.Form == apd.NaN {
+			val = `NULL`
+		} else {
+			val = d.dec.String()
+		}
+		res = append(res, val)
 	}
 
 	return res, nil

--- a/core/types/uuid.go
+++ b/core/types/uuid.go
@@ -136,6 +136,11 @@ func (u UUIDArray) Value() (driver.Value, error) {
 	// Postgres does not like []byte for uuid, so we convert to string
 	v := make([]string, len(u))
 	for i, ui := range u {
+		if ui == nil { // there's not a NULL uuid with uuid-ossp
+			return nil, errors.New("nil in UUID array not supported")
+			// v[i] = "00000000-0000-0000-0000-000000000000" // uuid_nil(), but we could do that
+			// continue
+		}
 		v[i] = ui.String()
 	}
 	return v, nil

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -838,7 +838,7 @@ func Test_Roundtrip(t *testing.T) {
 		{
 			name:     "bytea_array",
 			datatype: "BYTEA[]",
-			value:    append(ptrArr([]byte("hello"), []byte{}, []byte("world")), nil),
+			value:    [][]byte{[]byte("hello"), {}, []byte("world"), nil}, //  append(ptrArr([]byte("hello"), []byte{}, []byte("world")), nil),
 		},
 	}
 
@@ -929,9 +929,8 @@ func Test_Roundtrip(t *testing.T) {
 				for range csChan {
 				} // discard whatever precommit sends
 			}()
-			cid, err := tx.Precommit(ctx, csChan)
+			_, err = tx.Precommit(ctx, csChan)
 			require.NoError(t, err)
-			t.Logf("commit ID: %x", cid)
 
 			// err = tx.Commit(ctx)
 			// require.NoError(t, err)

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -796,8 +796,8 @@ func Test_Roundtrip(t *testing.T) {
 			value:    true,
 		},
 		{
-			name:     "decimal",
-			datatype: "DECIMAL(70,5)",
+			name:     "numeric",
+			datatype: "numeric(70,5)",
 			value:    mustExplicitDecimal("100.101", 70, 5),
 		},
 		{
@@ -818,7 +818,7 @@ func Test_Roundtrip(t *testing.T) {
 		{
 			name:     "text_array",
 			datatype: "TEXT[]",
-			value:    append(ptrArr("hello", "world", "NULL"), nil),
+			value:    append(ptrArr("hello", "", `"actualquotes"`, "world", "NULL"), nil),
 		},
 		{
 			name:     "bool_array",
@@ -826,8 +826,8 @@ func Test_Roundtrip(t *testing.T) {
 			value:    append(ptrArr(true, false), nil),
 		},
 		{
-			name:     "decimal_array",
-			datatype: "DECIMAL(70,5)[]",
+			name:     "numeric_array",
+			datatype: "numeric(70,5)[]",
 			value:    append([]*types.Decimal{mustExplicitDecimal("100.101", 70, 5), mustExplicitDecimal("200.202", 70, 5)}, nil),
 		},
 		{
@@ -838,7 +838,7 @@ func Test_Roundtrip(t *testing.T) {
 		{
 			name:     "bytea_array",
 			datatype: "BYTEA[]",
-			value:    append(ptrArr([]byte("hello"), []byte("world")), nil),
+			value:    append(ptrArr([]byte("hello"), []byte{}, []byte("world")), nil),
 		},
 	}
 

--- a/node/engine/interpreter/values_test.go
+++ b/node/engine/interpreter/values_test.go
@@ -541,14 +541,14 @@ func Test_Cast(t *testing.T) {
 			name:    "text-array",
 			val:     []string{"hello", "world"},
 			textArr: []string{"hello", "world"},
-			blobArr: []*[]byte{ptr([]byte("hello")), ptr([]byte("world"))},
+			blobArr: [][]byte{[]byte("hello"), []byte("world")},
 		},
 		{
 			name:    "text-array (uuid)",
 			val:     []string{"550e8400-e29b-41d4-a716-446655440000"},
 			uuidArr: []*types.UUID{mustUUID("550e8400-e29b-41d4-a716-446655440000")},
 			textArr: []string{"550e8400-e29b-41d4-a716-446655440000"},
-			blobArr: []*[]byte{ptr([]byte("550e8400-e29b-41d4-a716-446655440000"))},
+			blobArr: [][]byte{[]byte("550e8400-e29b-41d4-a716-446655440000")},
 		},
 		{
 			name:    "bool-array",
@@ -569,12 +569,12 @@ func Test_Cast(t *testing.T) {
 			val:     []*types.UUID{mustUUID("550e8400-e29b-41d4-a716-446655440000")},
 			uuidArr: []*types.UUID{mustUUID("550e8400-e29b-41d4-a716-446655440000")},
 			textArr: []string{"550e8400-e29b-41d4-a716-446655440000"},
-			blobArr: []*[]byte{ptr(mustUUID("550e8400-e29b-41d4-a716-446655440000").Bytes())},
+			blobArr: [][]byte{mustUUID("550e8400-e29b-41d4-a716-446655440000").Bytes()},
 		},
 		{
 			name:    "blob-array",
 			val:     [][]byte{[]byte("hello"), []byte("world"), nil},
-			blobArr: []*[]byte{ptr([]byte("hello")), ptr([]byte("world")), nil},
+			blobArr: [][]byte{[]byte("hello"), []byte("world"), nil},
 			textArr: []*string{ptr("hello"), ptr("world"), nil},
 		},
 		{
@@ -585,7 +585,7 @@ func Test_Cast(t *testing.T) {
 			boolArr:    make([]*bool, 2),
 			decimalArr: make([]*types.Decimal, 2),
 			uuidArr:    make([]*types.UUID, 2),
-			blobArr:    []*[]byte{nil, nil},
+			blobArr:    [][]byte{nil, nil},
 		},
 	}
 


### PR DESCRIPTION
Continuation of https://github.com/kwilteam/kwil-db/pull/1348, which resolved a crash in the collection of changesets from logical replication. 

```
The completes handling of NULL values in postgres arrays:

- The two functions that return []any (rather than scanning into
  caller-provided variables of a certain type), Execute and
  QueryRowFuncAny, now return []*T for any column that is an array.
  Previously arrays would be returned as []T, which would not permit
  identifying if the retrieved array cotained a NULL element.
  pgx always returned an array as a []any, which permitted this, but
  required type casting.  Handling of scalar columns is unchanged.

  There was no crash if an array had a NULL, but when returned back
  to go from e.g. Execute it would have the zero value for whatever
  type was contained in that array. This was incorrect. The roundtrip
  changeset tests now contain NULL values in the inserted arrays,
  and expect to retrieve slices of pointers. These are changes to the
  datatype's Decode function.

- Similar to the previous point, but in the "inferred" args type
  query mode, the encodeToPGType function that gets the OIDs as
  well as the corresponding `pgtype` type uses the datatype's
  EncodeInferred function. Similar changes were required for this
  to not crash with arrays containing NULL values.

- The changeset functions for a datatype, SerializeChangeset and
  DeserializeChangeset had issues with NULL values in arrays too.
  Previous changes fixed SerializeChangeset implementations.
  This fixes the DeserializeChangeset functions.

  Note that these two functions are somewhat misleadingly named.
  They are not intended to "match" and you cannot do a round trip.
  The serialize function is to read text data from postgres' logical
  replication stream and encode into a binary format, which is to be
  recognized by DeserializeChangeset. However, DeserializeChangeset
  does not go back to the postgres text format; it goes into a Go
  variable (an any return). These are intended to be provided to
  Execute functions when "applying" a changeset.
```

The second commit in the interpreter converts a `*[]byte` to a `[]byte` since slices are nilable, like pointers.

https://go.dev/ref/spec#The_zero_value

> When storage is allocated for a [variable](https://go.dev/ref/spec#Variables), either through a declaration or a call of new, or when a new value is created, either through a composite literal or a call of make, and no explicit initialization is provided, the variable or value is given a default value. Each element of such a variable or value is set to the zero value for its type: false for booleans, 0 for numeric types, "" for strings, and **nil for pointers, functions, interfaces, slices, channels, and maps**