### PR TITLE
engine: fix extension startup during migration

### DIFF
--- a/app/node/namespace_manager.go
+++ b/app/node/namespace_manager.go
@@ -102,7 +102,7 @@ func UserNamespaces(ctx context.Context, db DB) ([]string, error) {
 	}
 	defer tx.Rollback(ctx)
 
-	res, err := tx.Execute(ctx, "select name from kwild_engine.namespaces where type='USER'")
+	res, err := tx.Execute(ctx, "select name from kwild_engine.namespaces")
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute query: %w", err)
 	}

--- a/app/setup/genesis.go
+++ b/app/setup/genesis.go
@@ -42,7 +42,6 @@ type genesisFlagConfig struct {
 	maxBlockSize  int64
 	joinExpiry    time.Duration
 	maxVotesPerTx int64
-	genesisState  string
 }
 
 func GenesisCmd() *cobra.Command {
@@ -135,20 +134,18 @@ func bindGenesisFlags(cmd *cobra.Command, cfg *genesisFlagConfig) {
 	cmd.Flags().Int64Var(&cfg.maxBlockSize, maxBlockSizeFlag, 0, "maximum block size")
 	cmd.Flags().DurationVar(&cfg.joinExpiry, joinExpiryFlag, 0, "Number of blocks before a join proposal expires")
 	cmd.Flags().Int64Var(&cfg.maxVotesPerTx, maxVotesPerTxFlag, 0, "Maximum votes per transaction")
-	cmd.Flags().StringVar(&cfg.genesisState, genesisSnapshotFlag, "", "path to genesis state snapshot file")
 }
 
 const (
-	chainIDFlag         = "chain-id"
-	validatorsFlag      = "validator"
-	allocsFlag          = "alloc"
-	withGasFlag         = "with-gas"
-	leaderFlag          = "leader"
-	dbOwnerFlag         = "db-owner"
-	maxBlockSizeFlag    = "max-block-size"
-	joinExpiryFlag      = "join-expiry"
-	maxVotesPerTxFlag   = "max-votes-per-tx"
-	genesisSnapshotFlag = "genesis-snapshot"
+	chainIDFlag       = "chain-id"
+	validatorsFlag    = "validator"
+	allocsFlag        = "alloc"
+	withGasFlag       = "with-gas"
+	leaderFlag        = "leader"
+	dbOwnerFlag       = "db-owner"
+	maxBlockSizeFlag  = "max-block-size"
+	joinExpiryFlag    = "join-expiry"
+	maxVotesPerTxFlag = "max-votes-per-tx"
 )
 
 // mergeGenesisFlags merges the genesis configuration flags with the given configuration.
@@ -273,14 +270,6 @@ func mergeGenesisFlags(conf *config.GenesisConfig, cmd *cobra.Command, flagCfg *
 
 	if cmd.Flags().Changed(maxVotesPerTxFlag) {
 		conf.MaxVotesPerTx = flagCfg.maxVotesPerTx
-	}
-
-	if cmd.Flags().Changed(genesisSnapshotFlag) {
-		hash, err := appHashFromSnapshotFile(flagCfg.genesisState)
-		if err != nil {
-			return nil, err
-		}
-		conf.StateHash = hash
 	}
 
 	return conf, nil

--- a/app/setup/init.go
+++ b/app/setup/init.go
@@ -122,8 +122,6 @@ func InitCmd() *cobra.Command {
 
 				stateFile := config.GenesisStateFileName(outDir)
 
-				fmt.Println("statefile", stateFile)
-
 				if err := utils.CopyFile(genesisState, stateFile); err != nil {
 					return display.PrintErr(cmd, err)
 				}

--- a/app/setup/init.go
+++ b/app/setup/init.go
@@ -112,14 +112,17 @@ func InitCmd() *cobra.Command {
 				cfg.Consensus.EmptyBlockTimeout = cfg.Consensus.ProposeTimeout
 			}
 
-			if cmd.Flags().Changed(genesisSnapshotFlag) {
-				genesisState := genFlags.genesisState
+			// if the user has specified genesis state, copy it to the new directory
+			if cmd.Flags().Changed("genesis-state") {
+				genesisState := cfg.GenesisState
 				genesisState, err = node.ExpandPath(genesisState)
 				if err != nil {
 					return display.PrintErr(cmd, err)
 				}
 
 				stateFile := config.GenesisStateFileName(outDir)
+
+				fmt.Println("statefile", stateFile)
 
 				if err := utils.CopyFile(genesisState, stateFile); err != nil {
 					return display.PrintErr(cmd, err)
@@ -153,7 +156,8 @@ func InitCmd() *cobra.Command {
 			}
 
 			genFile := config.GenesisFilePath(outDir)
-			if genesisPath != "" { // Init for the node to join an existing network
+			if genesisPath != "" {
+				// Init for the node to join an existing network
 				if genesisPath, err = node.ExpandPath(genesisPath); err != nil {
 					return display.PrintErr(cmd, err)
 				}
@@ -203,6 +207,13 @@ func InitCmd() *cobra.Command {
 							KeyType: v.Identifier.String(),
 							Amount:  genesisValidatorGas,
 						})
+					}
+				}
+
+				if cfg.GenesisState != "" {
+					genCfg.StateHash, err = appHashFromSnapshotFile(cfg.GenesisState)
+					if err != nil {
+						return display.PrintErr(cmd, err)
 					}
 				}
 

--- a/app/snapshot/create.go
+++ b/app/snapshot/create.go
@@ -166,7 +166,6 @@ func PGDump(ctx context.Context, dbName, dbUser, dbPass, dbHost, dbPort string, 
 		// Account Schema
 		"--schema", "kwild_accts",
 		"--schema", "kwild_engine",
-		"--schema", "info",
 		// Internal Schema
 		"--schema", "kwild_internal",
 		"-T", "kwild_internal.sentry", // Exclude sentry table (no versioning)

--- a/node/engine/interpreter/planner.go
+++ b/node/engine/interpreter/planner.go
@@ -1990,7 +1990,14 @@ func (i *interpreterPlanner) VisitCreateNamespaceStatement(p0 *parse.CreateNames
 			return fmt.Errorf(`%w: "%s"`, engine.ErrNamespaceExists, p0.Namespace)
 		}
 
-		if _, err := createNamespace(exec.engineCtx.TxContext.Ctx, exec.db, p0.Namespace, namespaceTypeUser); err != nil {
+		nsType := namespaceTypeUser
+		// if override authz is set, then it is application code setting this,
+		// so it must be system
+		if exec.engineCtx.OverrideAuthz {
+			nsType = namespaceTypeSystem
+		}
+
+		if _, err := createNamespace(exec.engineCtx.TxContext.Ctx, exec.db, p0.Namespace, nsType); err != nil {
 			return err
 		}
 

--- a/node/exts/erc20reward/meta_schema.sql
+++ b/node/exts/erc20reward/meta_schema.sql
@@ -61,3 +61,7 @@ CREATE TABLE epoch_rewards (
 );
 
 CREATE INDEX idx_epoch_rewards_epoch_id ON epoch_rewards(epoch_id);
+
+CREATE TABLE meta (
+    version INT8 PRIMARY KEY
+);

--- a/node/exts/ordered-sync/schema.sql
+++ b/node/exts/ordered-sync/schema.sql
@@ -18,3 +18,7 @@ CREATE TABLE pending_data (
     -- can be null if events are processed out of order (which is
     -- what this package is designed to handle)
 );
+
+CREATE TABLE meta(
+    version int8 PRIMARY KEY
+)


### PR DESCRIPTION
Fixes an issue where the new erc20 extensions are unable to start during migration. Also fixes an issue where paths for genesis state are not expanded in `kwild setup init`
