### PR TITLE
ce,node: CE crash must stop node

### DIFF
--- a/app/node/node.go
+++ b/app/node/node.go
@@ -241,7 +241,7 @@ func (s *server) Start(ctx context.Context) error {
 			if errors.Is(err, context.Canceled) {
 				s.log.Infof("Shutdown signaled. Cancellation details: [%v]", err)
 			} else {
-				s.log.Error("failed to start node", "error", err)
+				s.log.Error("Abnormal node termination", "error", err)
 			}
 			return err
 		}
@@ -268,8 +268,6 @@ func (s *server) Start(ctx context.Context) error {
 			s.log.Info("server context is canceled")
 			return nil
 		}
-
-		s.log.Error("server error", "error", err)
 		return err
 	}
 

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -159,10 +159,7 @@ func (ce *ConsensusEngine) executeBlock(ctx context.Context, blkProp *blockPropo
 	}
 	results, err := ce.blockProcessor.ExecuteBlock(ctx, req)
 	if err != nil {
-		if !errors.Is(err, context.Canceled) { // unexpected error
-			ce.log.Error("Error executing block", "height", blkProp.height, "hash", blkProp.blkHash, "error", err)
-		} // else caller thinks this is a regular shutdown, with error including details
-		return fmt.Errorf("Error executing block %s at height %d: %w", blkProp.blkHash, blkProp.height, err)
+		return err
 	}
 
 	ce.state.blockRes = &blockResult{

--- a/node/consensus/follower.go
+++ b/node/consensus/follower.go
@@ -371,13 +371,13 @@ func (ce *ConsensusEngine) commitBlock(ctx context.Context, blk *ktypes.Block, c
 
 	if !ce.state.blockRes.paramUpdates.Equals(ci.ParamUpdates) { // this is absorbed in apphash anyway, but helps diagnostics
 		haltR := fmt.Sprintf("Incorrect ParamUpdates, halting the node. received: %s, computed: %s", ci.ParamUpdates, ce.state.blockRes.paramUpdates)
-		ce.haltChan <- haltR
+		ce.sendHalt(haltR)
 		return nil
 	}
 
 	if ce.state.blockRes.appHash != ci.AppHash {
 		haltR := fmt.Sprintf("Incorrect AppHash, halting the node. received: %s, computed: %s", ci.AppHash, ce.state.blockRes.appHash)
-		ce.haltChan <- haltR
+		ce.sendHalt(haltR)
 		return nil
 	}
 
@@ -436,14 +436,14 @@ func (ce *ConsensusEngine) processAndCommit(ctx context.Context, blk *ktypes.Blo
 
 	if !ce.state.blockRes.paramUpdates.Equals(ci.ParamUpdates) { // this is absorbed in apphash anyway, but helps diagnostics
 		haltR := fmt.Sprintf("processAndCommit: Incorrect ParamUpdates, halting the node. received: %s, computed: %s", ci.ParamUpdates, ce.state.blockRes.paramUpdates)
-		ce.haltChan <- haltR
+		ce.sendHalt(haltR)
 		return errors.New(haltR)
 	}
 
 	// Commit the block if the appHash and commitInfo is valid
 	if ce.state.blockRes.appHash != ci.AppHash {
 		haltR := fmt.Sprintf("processAndCommit: AppHash mismatch, halting the node. expected: %s, received: %s", ce.state.blockRes.appHash, ci.AppHash)
-		ce.haltChan <- haltR
+		ce.sendHalt(haltR)
 		return errors.New(haltR)
 	}
 

--- a/node/node.go
+++ b/node/node.go
@@ -323,7 +323,7 @@ func (n *Node) Start(ctx context.Context) error {
 
 	// mine is our block anns goroutine, which must be only for leader
 	n.wg.Add(1)
-	var nodeErr error
+	var ceErr error
 
 	go func() {
 		defer n.wg.Done()
@@ -347,11 +347,7 @@ func (n *Node) Start(ctx context.Context) error {
 			RemovePeer: n.Whitelister().RemovePeer,
 		}
 
-		nodeErr = n.ce.Start(ctx, broadcastFns, whitelistFns)
-		if err != nil {
-			n.log.Errorf("Consensus engine failed: %v", nodeErr)
-			return // cancel context
-		}
+		ceErr = n.ce.Start(ctx, broadcastFns, whitelistFns)
 	}()
 
 	n.wg.Add(1)
@@ -366,7 +362,7 @@ func (n *Node) Start(ctx context.Context) error {
 	n.wg.Wait()
 
 	n.log.Info("Node stopped.")
-	return nodeErr
+	return ceErr
 }
 
 func peerIDForValidator(pubkeyBts []byte) (peer.ID, error) {


### PR DESCRIPTION
The ensures that fatal CE errors (those which kill the consensus event loop other than parent context cancellation) are returned to the the caller of Start. This fixes a halted / dead CE not stopping the node.

This also reduces a lot of duplicate error logging when the error is continually passed up the call stack.