### PR TITLE
[WIP] common,bp,txapp: call notices and row results in log, and use log from tx routes

### DIFF
--- a/common/common_test.go
+++ b/common/common_test.go
@@ -1,0 +1,37 @@
+package common_test
+
+import (
+	"fmt"
+
+	"github.com/kwilteam/kwil-db/common"
+	"github.com/kwilteam/kwil-db/core/types"
+)
+
+func ExampleRow_String() {
+	row := common.Row{
+		ColumnNames: []string{"id", "name", "scores"},
+		ColumnTypes: []*types.DataType{
+			{Name: "INT"},
+			{Name: "TEXT"},
+			{Name: "INT", IsArray: true},
+		},
+		Values: []any{
+			42,
+			"Alice",
+			[]int{95, 87, 91},
+		},
+	}
+	for _, ty := range row.ColumnTypes {
+		if err := ty.Clean(); err != nil {
+			panic(err)
+		}
+	}
+
+	fmt.Println(row.String())
+	fmt.Println(row.TypeStrings())
+	fmt.Println(row.ValueStrings())
+	// Output:
+	// id[int8]: 42, name[text]: Alice, scores[int8[]]: [95 87 91]
+	// [int8 text int8[]]
+	// [42 Alice [95 87 91]]
+}

--- a/core/types/data_types.go
+++ b/core/types/data_types.go
@@ -89,7 +89,7 @@ func (c *DataType) UnmarshalBinary(data []byte) error {
 // String returns the string representation of the type.
 func (c *DataType) String() string {
 	str := strings.Builder{}
-	aliased, ok := typeAlias[c.Name]
+	aliased, ok := typeAlias[strings.ToLower(c.Name)]
 	if !ok {
 		aliased = "[!invalid!]" + c.Name
 	}

--- a/extensions/consensus/payloads.go
+++ b/extensions/consensus/payloads.go
@@ -40,5 +40,5 @@ type Route interface {
 	// InTx executes the transaction, which may include state changes via the DB
 	// or Engine. The TxCode is returned by the Router, and it should be CodeOk
 	// for a nil error.
-	InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error)
+	InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error)
 }

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -395,6 +395,7 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 			txResult := ktypes.TxResult{
 				Code: uint32(res.ResponseCode),
 				Gas:  res.Spend,
+				Log:  res.Log,
 			}
 
 			// bookkeeping for the block execution status
@@ -405,10 +406,10 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 					return nil, fmt.Errorf("fatal db error during block execution: %w", res.Error)
 				}
 
-				txResult.Log = res.Error.Error()
+				if txResult.Log == "" {
+					txResult.Log = res.Error.Error() // maybe don't?
+				}
 				bp.log.Info("Failed to execute transaction", "tx", txHash, "err", res.Error)
-			} else {
-				txResult.Log = "success"
 			}
 
 			txResults[i] = txResult

--- a/node/engine/interpreter/interpreter.go
+++ b/node/engine/interpreter/interpreter.go
@@ -399,7 +399,7 @@ func funcDefToExecutable(funcName string, funcDef *engine.ScalarFunctionDefiniti
 			}
 
 			// if the function name is notice, then we need to get write the notice to our logs locally,
-			// instead of executing a query. This is the functional eqauivalent of Kwil's console.log().
+			// instead of executing a query. This is the functional equivalent of Kwil's console.log().
 			if funcName == "notice" {
 				var log string
 				if !args[0].Null() {

--- a/node/txapp/routes.go
+++ b/node/txapp/routes.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"math/big"
+	"strings"
 	"sync"
 	"time"
 
@@ -136,7 +137,7 @@ func (d *baseRoute) Price(ctx context.Context, router *TxApp, db sql.DB, tx *typ
 func (d *baseRoute) Execute(ctx *common.TxContext, router *TxApp, db sql.DB, tx *types.Transaction) *TxResponse {
 	dbTx, err := db.BeginTx(ctx.Ctx)
 	if err != nil {
-		return txRes(nil, types.CodeUnknownError, err)
+		return txRes(nil, types.CodeUnknownError, "", err)
 	}
 
 	spend, code, err := router.checkAndSpend(ctx, tx, d, dbTx)
@@ -147,7 +148,7 @@ func (d *baseRoute) Execute(ctx *common.TxContext, router *TxApp, db sql.DB, tx 
 		default:
 			logErr(router.service.Logger, dbTx.Rollback(ctx.Ctx))
 		}
-		return txRes(spend, code, err)
+		return txRes(spend, code, "", err)
 	}
 	defer func() {
 		// Always Commit the outer transaction to ensure account updates.
@@ -163,12 +164,12 @@ func (d *baseRoute) Execute(ctx *common.TxContext, router *TxApp, db sql.DB, tx 
 
 	code, err = d.PreTx(ctx, svc, tx)
 	if err != nil {
-		return txRes(spend, code, err)
+		return txRes(spend, code, "", err)
 	}
 
 	tx2, err := dbTx.BeginTx(ctx.Ctx)
 	if err != nil {
-		return txRes(spend, types.CodeUnknownError, err)
+		return txRes(spend, types.CodeUnknownError, "", err)
 	}
 	defer tx2.Rollback(ctx.Ctx) // no-op if Commit succeeded
 
@@ -180,17 +181,18 @@ func (d *baseRoute) Execute(ctx *common.TxContext, router *TxApp, db sql.DB, tx 
 		Validators: router.Validators,
 	}
 
-	code, err = d.InTx(ctx, app, tx)
+	var log string
+	code, log, err = d.InTx(ctx, app, tx)
 	if err != nil {
-		return txRes(spend, code, err)
+		return txRes(spend, code, log, err)
 	}
 
 	err = tx2.Commit(ctx.Ctx)
 	if err != nil {
-		return txRes(spend, types.CodeUnknownError, err)
+		return txRes(spend, types.CodeUnknownError, log, err)
 	}
 
-	return txRes(spend, types.CodeOk, nil)
+	return txRes(spend, types.CodeOk, log, nil)
 }
 
 // ========================== route implementations ==========================
@@ -249,15 +251,16 @@ func (d *rawStatementRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx
 	return 0, nil
 }
 
-func (d *rawStatementRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *rawStatementRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	err := app.Engine.Execute(makeEngineCtx(ctx), app.DB, d.statement, d.params, func(r *common.Row) error {
 		// we throw away all results for raw statements in a block
 		return nil
 	})
 	if err != nil {
-		return codeForEngineError(err), err
+		return codeForEngineError(err), "", err
 	}
-	return 0, nil
+	// log TODO
+	return 0, "", nil
 }
 
 func makeEngineCtx(ctx *common.TxContext) *common.EngineContext {
@@ -314,19 +317,69 @@ func (d *executeActionRoute) PreTx(ctx *common.TxContext, svc *common.Service, t
 	return 0, nil
 }
 
-func (d *executeActionRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+const unknownColName = "?column?" // TODO: get from interpreter pkg
+
+func (d *executeActionRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
+	var logBuilder strings.Builder
 	for i := range d.args {
-		// TODO: once we are able to store execution logs in the block store, we should propagate the discarded
-		// return value here.
-		_, err := app.Engine.Call(makeEngineCtx(ctx), app.DB, d.namespace, d.action, d.args[i], func(r *common.Row) error {
-			// we throw away all results for execute actions
-			return nil
-		})
+		// We should capture the results and put them in the execution result
+		// Log, which is stored in the block store. The CallResult from Call
+		// contains emitted notices, which should also be in the tx logs.
+		// var colNames, colTypes []string
+		var colHeaders []string
+		var values [][]string
+		callRes, err := app.Engine.Call(makeEngineCtx(ctx), app.DB, d.namespace, d.action, d.args[i],
+			func(r *common.Row) error {
+				if colHeaders == nil {
+					// colNames = r.ColumnNames
+					// for _, n := range r.ColumnTypes {
+					// 	colTypes = append(colTypes, n.String())
+					// }
+					colHeaders = r.ColHeaders()
+				}
+				values = append(values, r.ValueStrings())
+				return nil
+			},
+		)
 		if err != nil {
-			return codeForEngineError(err), err
+			return codeForEngineError(err), "", err
+		}
+
+		// Now put all the captured stuff into the log, starting with the
+		// notices in callRes.Logs, and then the column headers and values.
+		if len(d.args) > 1 {
+			if i > 0 {
+				logBuilder.WriteString("\n")
+			}
+			logBuilder.WriteString(fmt.Sprintf("CALL %d:\n", i))
+		}
+		if len(callRes.Logs) > 0 {
+			logBuilder.WriteString("Notices:\n")
+			logBuilder.WriteString(strings.Join(callRes.Logs, "\n"))
+			logBuilder.WriteString("\n")
+		}
+		if len(colHeaders) > 0 {
+			if len(values) > 1 { // multiple rows
+				logBuilder.WriteString("Columns:\n")
+				logBuilder.WriteString(strings.Join(colHeaders, ","))
+				logBuilder.WriteString("\n")
+				logBuilder.WriteString("Values:\n")
+				for _, row := range values {
+					logBuilder.WriteString(strings.Join(row, ","))
+					logBuilder.WriteString("\n")
+				}
+			} else { // one record or value
+				// name(type) = value
+				for i, col := range colHeaders {
+					if i > 0 {
+						logBuilder.WriteString(", ")
+					}
+					logBuilder.WriteString(fmt.Sprintf("%s = %v", col, values[0][i]))
+				}
+			}
 		}
 	}
-	return 0, nil
+	return 0, logBuilder.String(), nil
 }
 
 type transferRoute struct {
@@ -369,23 +422,23 @@ func (d *transferRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *ty
 	return 0, nil
 }
 
-func (d *transferRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *transferRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	sender, err := TxSenderAcctID(tx)
 	if err != nil {
-		return types.CodeInvalidSender, err
+		return types.CodeInvalidSender, "", err
 	}
 
 	err = app.Accounts.Transfer(ctx.Ctx, app.DB, sender, d.to, d.amt)
 	if err != nil {
 		if errors.Is(err, accounts.ErrInsufficientFunds) {
-			return types.CodeInsufficientBalance, err
+			return types.CodeInsufficientBalance, "", err
 		}
 		if errors.Is(err, accounts.ErrNegativeBalance) {
-			return types.CodeInvalidAmount, err
+			return types.CodeInvalidAmount, "", err
 		}
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
-	return 0, nil
+	return 0, "", nil
 }
 
 type validatorJoinRoute struct {
@@ -418,29 +471,29 @@ func (d *validatorJoinRoute) PreTx(ctx *common.TxContext, svc *common.Service, t
 	return 0, nil
 }
 
-func (d *validatorJoinRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *validatorJoinRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	// ensure this candidate is not already a validator
 	keyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 	if err != nil {
-		return types.CodeInvalidSender, fmt.Errorf("failed to parse key type: %w", err)
+		return types.CodeInvalidSender, "", fmt.Errorf("failed to parse key type: %w", err)
 	}
 
 	power, err := app.Validators.GetValidatorPower(ctx.Ctx, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power > 0 {
-		return types.CodeInvalidSender, ErrCallerIsValidator
+		return types.CodeInvalidSender, "", ErrCallerIsValidator
 	}
 
 	// we first need to ensure that this validator does not have a pending join request
 	// if it does, we should not allow it to join again
 	pending, err := getResolutionsByTypeAndProposer(ctx.Ctx, app.DB, voting.ValidatorJoinEventType, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if len(pending) > 0 {
-		return types.CodeInvalidSender, errors.New("validator already has a pending join request")
+		return types.CodeInvalidSender, "", errors.New("validator already has a pending join request")
 	}
 
 	// there are no pending join requests, so we can create a new one
@@ -451,7 +504,7 @@ func (d *validatorJoinRoute) InTx(ctx *common.TxContext, app *common.App, tx *ty
 	}
 	bts, err := joinReq.MarshalBinary()
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
 	event := &types.VotableEvent{
@@ -463,10 +516,10 @@ func (d *validatorJoinRoute) InTx(ctx *common.TxContext, app *common.App, tx *ty
 	expiry := ctx.BlockContext.Timestamp + int64(joinExpiry)
 	err = createResolution(ctx.Ctx, app.DB, event, expiry, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	// we do not approve, because a joiner is presumably not a voter
-	return 0, nil
+	return 0, "", nil
 }
 
 type validatorApproveRoute struct {
@@ -506,41 +559,41 @@ func (d *validatorApproveRoute) PreTx(ctx *common.TxContext, svc *common.Service
 	return 0, nil
 }
 
-func (d *validatorApproveRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *validatorApproveRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	// each pending validator can only have one active join request at a time
 	// we need to retrieve the join request and ensure that it is still pending
 	pending, err := getResolutionsByTypeAndProposer(ctx.Ctx, app.DB, voting.ValidatorJoinEventType, d.candidate, d.keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if len(pending) == 0 {
-		return types.CodeInvalidSender, errors.New("validator does not have a pending join request")
+		return types.CodeInvalidSender, "", errors.New("validator does not have a pending join request")
 	}
 	if len(pending) > 1 {
 		// this should never happen, but if it does, we should not allow it
-		return types.CodeUnknownError, errors.New("validator has more than one pending join request. this is an internal bug")
+		return types.CodeUnknownError, "", errors.New("validator has more than one pending join request. this is an internal bug")
 	}
 
 	keyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 	if err != nil {
-		return types.CodeUnknownError, fmt.Errorf("failed to parse key type: %w", err)
+		return types.CodeUnknownError, "", fmt.Errorf("failed to parse key type: %w", err)
 	}
 
 	// ensure that sender is a validator
 	power, err := app.Validators.GetValidatorPower(ctx.Ctx, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power <= 0 {
-		return types.CodeInvalidSender, ErrCallerNotValidator
+		return types.CodeInvalidSender, "", ErrCallerNotValidator
 	}
 
 	err = approveResolution(ctx.Ctx, app.DB, pending[0], tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
-	return 0, nil
+	return 0, "", nil
 }
 
 type validatorRemoveRoute struct {
@@ -576,7 +629,7 @@ func (d *validatorRemoveRoute) PreTx(ctx *common.TxContext, svc *common.Service,
 	return 0, nil
 }
 
-func (d *validatorRemoveRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *validatorRemoveRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	removeReq := &voting.UpdatePowerRequest{
 		PubKey:     d.target,
 		PubKeyType: d.keyType,
@@ -584,12 +637,12 @@ func (d *validatorRemoveRoute) InTx(ctx *common.TxContext, app *common.App, tx *
 	}
 
 	if bytes.Equal(removeReq.PubKey, ctx.BlockContext.Proposer.Bytes()) {
-		return types.CodeInvalidSender, errors.New("leader cannot be removed from validator set")
+		return types.CodeInvalidSender, "", errors.New("leader cannot be removed from validator set")
 	}
 
 	bts, err := removeReq.MarshalBinary()
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
 	event := &types.VotableEvent{
@@ -599,25 +652,25 @@ func (d *validatorRemoveRoute) InTx(ctx *common.TxContext, app *common.App, tx *
 
 	senderKeyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 	if err != nil {
-		return types.CodeUnknownError, fmt.Errorf("failed to parse key type: %w", err)
+		return types.CodeUnknownError, "", fmt.Errorf("failed to parse key type: %w", err)
 	}
 
 	// ensure the sender is a validator
 	power, err := app.Validators.GetValidatorPower(ctx.Ctx, tx.Sender, senderKeyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power <= 0 {
-		return types.CodeInvalidSender, ErrCallerNotValidator
+		return types.CodeInvalidSender, "", ErrCallerNotValidator
 	}
 
 	// ensure that the target is a validator
 	power, err = app.Validators.GetValidatorPower(ctx.Ctx, d.target, d.keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power <= 0 {
-		return types.CodeInvalidSender, ErrTargetNotValidator
+		return types.CodeInvalidSender, "", ErrTargetNotValidator
 	}
 
 	// we should try to create the resolution, since validator removals are never
@@ -626,7 +679,7 @@ func (d *validatorRemoveRoute) InTx(ctx *common.TxContext, app *common.App, tx *
 	// and if it does, approve it, otherwise create and approve it.
 	exists, err := resolutionExists(ctx.Ctx, app.DB, event.ID())
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
 	// if the resolution does not exist, create it
@@ -635,17 +688,17 @@ func (d *validatorRemoveRoute) InTx(ctx *common.TxContext, app *common.App, tx *
 		expiry := ctx.BlockContext.Timestamp + int64(joinExpiry)
 		err = createResolution(ctx.Ctx, app.DB, event, expiry, tx.Sender, senderKeyType)
 		if err != nil {
-			return types.CodeUnknownError, err
+			return types.CodeUnknownError, "", err
 		}
 	}
 
 	// we need to approve the resolution as well
 	err = approveResolution(ctx.Ctx, app.DB, event.ID(), tx.Sender, senderKeyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
-	return 0, nil
+	return 0, "", nil
 }
 
 type validatorLeaveRoute struct{}
@@ -668,32 +721,32 @@ func (d *validatorLeaveRoute) PreTx(ctx *common.TxContext, svc *common.Service, 
 	return 0, nil // no payload to decode or validate for this route
 }
 
-func (d *validatorLeaveRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *validatorLeaveRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	if bytes.Equal(tx.Sender, ctx.BlockContext.Proposer.Bytes()) {
-		return types.CodeInvalidSender, errors.New("leader cannot leave validator set")
+		return types.CodeInvalidSender, "", errors.New("leader cannot leave validator set")
 	}
 
 	keyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 	if err != nil {
-		return types.CodeInvalidSender, fmt.Errorf("failed to parse key type: %w", err)
+		return types.CodeInvalidSender, "", fmt.Errorf("failed to parse key type: %w", err)
 	}
 
 	power, err := app.Validators.GetValidatorPower(ctx.Ctx, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power <= 0 {
-		return types.CodeInvalidSender, ErrCallerNotValidator
+		return types.CodeInvalidSender, "", ErrCallerNotValidator
 	}
 
 	const noPower = 0
 
 	err = app.Validators.SetValidatorPower(ctx.Ctx, app.DB, tx.Sender, keyType, noPower)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
-	return 0, nil
+	return 0, "", nil
 }
 
 // validatorVoteIDsRoute is a route for approving a set of votes based on their IDs.
@@ -723,31 +776,31 @@ func (d *validatorVoteIDsRoute) PreTx(ctx *common.TxContext, svc *common.Service
 	return 0, nil
 }
 
-func (d *validatorVoteIDsRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *validatorVoteIDsRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	// if the caller has 0 power, they are not a validator, and should not be able to vote
 	keyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 	if err != nil {
-		return types.CodeInvalidSender, fmt.Errorf("failed to parse key type: %w", err)
+		return types.CodeInvalidSender, "", fmt.Errorf("failed to parse key type: %w", err)
 	}
 
 	power, err := app.Validators.GetValidatorPower(ctx.Ctx, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power == 0 {
-		return types.CodeInvalidSender, ErrCallerNotValidator
+		return types.CodeInvalidSender, "", ErrCallerNotValidator
 	}
 
 	approve := &types.ValidatorVoteIDs{}
 	err = approve.UnmarshalBinary(tx.Body.Payload)
 	if err != nil {
-		return types.CodeEncodingError, err
+		return types.CodeEncodingError, "", err
 	}
 
 	// filter out the vote IDs that have already been processed
 	ids, err := voting.FilterNotProcessed(ctx.Ctx, app.DB, approve.ResolutionIDs)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
 	fromLocalValidator := bytes.Equal(tx.Sender, app.Service.Identity)
@@ -755,14 +808,14 @@ func (d *validatorVoteIDsRoute) InTx(ctx *common.TxContext, app *common.App, tx 
 	for _, voteID := range ids {
 		err = approveResolution(ctx.Ctx, app.DB, voteID, tx.Sender, keyType)
 		if err != nil {
-			return types.CodeUnknownError, err
+			return types.CodeUnknownError, "", err
 		}
 
 		// if from local validator, delete the event now that we have voted on it and network already has the event body
 		if fromLocalValidator {
 			err = deleteEvent(ctx.Ctx, app.DB, voteID)
 			if err != nil {
-				return types.CodeUnknownError, err
+				return types.CodeUnknownError, "", err
 			}
 		}
 	}
@@ -771,7 +824,7 @@ func (d *validatorVoteIDsRoute) InTx(ctx *common.TxContext, app *common.App, tx 
 		app.Service.Logger.Warn("vote contains resolution IDs that are already done. too late, no refund!", "numTooLate", tooLate)
 	}
 
-	return 0, nil
+	return 0, "", nil
 }
 
 // validatorVoteIDsRoute is a route for approving a set of votes based on their IDs.
@@ -823,7 +876,7 @@ func (d *validatorVoteBodiesRoute) PreTx(ctx *common.TxContext, _ *common.Servic
 	return 0, nil
 }
 
-func (d *validatorVoteBodiesRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *validatorVoteBodiesRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	fromLocalValidator := bytes.Equal(tx.Sender, app.Service.Identity)
 
 	// Expectation:
@@ -832,7 +885,7 @@ func (d *validatorVoteBodiesRoute) InTx(ctx *common.TxContext, app *common.App, 
 	for _, event := range d.events {
 		resCfg, err := resolutions.GetResolution(event.Type)
 		if err != nil {
-			return types.CodeUnknownError, err
+			return types.CodeUnknownError, "", err
 		}
 
 		ev := &types.VotableEvent{
@@ -842,32 +895,32 @@ func (d *validatorVoteBodiesRoute) InTx(ctx *common.TxContext, app *common.App, 
 
 		keyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 		if err != nil {
-			return types.CodeInvalidSender, fmt.Errorf("failed to parse key type: %w", err)
+			return types.CodeInvalidSender, "", fmt.Errorf("failed to parse key type: %w", err)
 		}
 
 		expiryHeight := ctx.BlockContext.Timestamp + int64(resCfg.ExpirationPeriod.Seconds())
 		err = createResolution(ctx.Ctx, app.DB, ev, expiryHeight, tx.Sender, keyType)
 		if err != nil {
-			return types.CodeUnknownError, err
+			return types.CodeUnknownError, "", err
 		}
 
 		// since the vote body proposer is implicitly voting for the event,
 		// we need to approve the newly created vote body here
 		err = approveResolution(ctx.Ctx, app.DB, ev.ID(), tx.Sender, keyType)
 		if err != nil {
-			return types.CodeUnknownError, err
+			return types.CodeUnknownError, "", err
 		}
 
 		// If the local validator is the proposer, then we should delete the event from the event store.
 		if fromLocalValidator {
 			err = deleteEvent(ctx.Ctx, app.DB, ev.ID())
 			if err != nil {
-				return types.CodeUnknownError, err
+				return types.CodeUnknownError, "", err
 			}
 		}
 	}
 
-	return 0, nil
+	return 0, "", nil
 }
 
 type createResolutionRoute struct {
@@ -926,37 +979,37 @@ func (d *createResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Service
 	return 0, nil
 }
 
-func (d *createResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *createResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	// ensure the sender is a validator
 	// only validators can create resolutions
 
 	keyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 	if err != nil {
-		return types.CodeInvalidSender, err
+		return types.CodeInvalidSender, "", err
 	}
 
 	power, err := app.Validators.GetValidatorPower(ctx.Ctx, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power <= 0 {
-		return types.CodeInvalidSender, ErrCallerNotValidator
+		return types.CodeInvalidSender, "", ErrCallerNotValidator
 	}
 
 	// create the resolution
 	// if resolution already exists, it will return an error
 	err = createResolution(ctx.Ctx, app.DB, d.resolution, d.expiry, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
 	// approve the resolution
 	err = approveResolution(ctx.Ctx, app.DB, d.resolution.ID(), tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
-	return 0, nil
+	return 0, "", nil
 }
 
 type approveResolutionRoute struct {
@@ -989,44 +1042,44 @@ func (d *approveResolutionRoute) PreTx(ctx *common.TxContext, svc *common.Servic
 	return 0, nil
 }
 
-func (d *approveResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, error) {
+func (d *approveResolutionRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
 	// ensure the sender is a validator
 
 	keyType, err := authExt.GetAuthenticatorKeyType(tx.Signature.Type)
 	if err != nil {
-		return types.CodeInvalidSender, err
+		return types.CodeInvalidSender, "", err
 	}
 
 	power, err := app.Validators.GetValidatorPower(ctx.Ctx, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if power <= 0 {
-		return types.CodeInvalidSender, ErrCallerNotValidator
+		return types.CodeInvalidSender, "", ErrCallerNotValidator
 	}
 
 	// Check if the resolution exists and is still pending
 	// You can only vote on a resolution that already exists
 	resolution, err := resolutionByID(ctx.Ctx, app.DB, d.resolutionID)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 	if resolution == nil {
-		return types.CodeInvalidResolutionType, fmt.Errorf("resolution with ID %s does not exist", d.resolutionID)
+		return types.CodeInvalidResolutionType, "", fmt.Errorf("resolution with ID %s does not exist", d.resolutionID)
 	}
 
 	if ctx.BlockContext.ChainContext.NetworkParameters.MigrationStatus.Active() &&
 		resolution.Type == voting.StartMigrationEventType {
-		return types.CodeNetworkInMigration, errors.New("migration is about to start, cannot accept new migration proposals")
+		return types.CodeNetworkInMigration, "", errors.New("migration is about to start, cannot accept new migration proposals")
 	}
 
 	// vote on the resolution
 	err = approveResolution(ctx.Ctx, app.DB, d.resolutionID, tx.Sender, keyType)
 	if err != nil {
-		return types.CodeUnknownError, err
+		return types.CodeUnknownError, "", err
 	}
 
-	return 0, nil
+	return 0, "", nil
 }
 
 /* enable and test this in the future

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -155,7 +155,7 @@ func (r *TxApp) Execute(ctx *common.TxContext, db sql.DB, tx *types.Transaction)
 	// RegisterRoute call is not concurrent
 	route, ok := routes[tx.Body.PayloadType.String()]
 	if !ok {
-		return txRes(nil, types.CodeInvalidTxType, fmt.Errorf("unknown payload type: %s", tx.Body.PayloadType.String()))
+		return txRes(nil, types.CodeInvalidTxType, "", fmt.Errorf("unknown payload type: %s", tx.Body.PayloadType.String()))
 	}
 
 	r.service.Logger.Debug("executing transaction", "tx", tx)
@@ -465,6 +465,8 @@ type TxResponse struct {
 	// ResponseCode is the response code from the transaction
 	ResponseCode types.TxCode
 
+	Log string
+
 	// Spend is the amount of tokens spent by the transaction
 	Spend int64
 
@@ -475,13 +477,14 @@ type TxResponse struct {
 // txRes wraps a spend, tx code, and error into a tx response.
 // the spend amount is included because an error can occur after the tokens
 // are spent.
-func txRes(spend *big.Int, code types.TxCode, err error) *TxResponse {
+func txRes(spend *big.Int, code types.TxCode, log string, err error) *TxResponse {
 	if spend == nil {
 		spend = big.NewInt(0)
 	}
 
 	return &TxResponse{
 		ResponseCode: code,
+		Log:          log,
 		Spend:        spend.Int64(),
 		Error:        err,
 	}


### PR DESCRIPTION
JUST TESTING.

I'm experimenting with putting results from action execution in the transaction log:
- notices
- scanned rows from an action return, either a single value, single record/row, or a table

I think there are gotchas when a table is returned, but I like the possibility to have action returns go somewhere. 