### PR TITLE
kwild: re-add extension config flags

### DIFF
--- a/app/node/start.go
+++ b/app/node/start.go
@@ -40,6 +40,10 @@ func StartCmd() *cobra.Command {
 
 			cfg := conf.ActiveConfig()
 
+			// we don't need to worry about order of priority with applying the extension
+			// flag configs because flags are always highest priority
+			cfg.Extensions = extConfs
+
 			bind.Debugf("effective node config (toml):\n%s", bind.LazyPrinter(func() string {
 				rawToml, err := cfg.ToTOML()
 				if err != nil {
@@ -60,8 +64,6 @@ func StartCmd() *cobra.Command {
 			if !cmd.Flags().Changed(emptyBlockTimeoutFlag) && autogen {
 				cfg.Consensus.EmptyBlockTimeout = cfg.Consensus.ProposeTimeout
 			}
-
-			cfg.Extensions = extConfs
 
 			return runNode(cmd.Context(), rootDir, cfg, autogen, dbOwner)
 		},

--- a/app/node/start.go
+++ b/app/node/start.go
@@ -33,6 +33,11 @@ func StartCmd() *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			rootDir := conf.RootDir()
 
+			extConfs, err := parseExtensionFlags(args)
+			if err != nil {
+				return err
+			}
+
 			cfg := conf.ActiveConfig()
 
 			bind.Debugf("effective node config (toml):\n%s", bind.LazyPrinter(func() string {
@@ -55,6 +60,8 @@ func StartCmd() *cobra.Command {
 			if !cmd.Flags().Changed(emptyBlockTimeoutFlag) && autogen {
 				cfg.Consensus.EmptyBlockTimeout = cfg.Consensus.ProposeTimeout
 			}
+
+			cfg.Extensions = extConfs
 
 			return runNode(cmd.Context(), rootDir, cfg, autogen, dbOwner)
 		},

--- a/app/node/start_test.go
+++ b/app/node/start_test.go
@@ -1,0 +1,72 @@
+package node
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_ExtensionFlags(t *testing.T) {
+	type testcase struct {
+		name    string
+		flagset []string
+		want    map[string]map[string]string
+		wantErr bool
+	}
+
+	tests := []testcase{
+		{
+			name:    "empty flagset",
+			flagset: []string{},
+			want:    map[string]map[string]string{},
+		},
+		{
+			name:    "single flag",
+			flagset: []string{"--extension.extname.flagname", "value"},
+			want: map[string]map[string]string{
+				"extname": {
+					"flagname": "value",
+				},
+			},
+		},
+		{
+			name:    "multiple flags",
+			flagset: []string{"--extension.extname.flagname", "value", "--extension.extname2.flagname2=value2"},
+			want: map[string]map[string]string{
+				"extname": {
+					"flagname": "value",
+				},
+				"extname2": {
+					"flagname2": "value2",
+				},
+			},
+		},
+		{
+			name: "missing value",
+			flagset: []string{
+				"--extension.extname.flagname",
+			},
+			wantErr: true,
+		},
+		{
+			name: "pass flag as a value errors",
+			flagset: []string{
+				"--extension.extname.flagname", "--extension.extname2.flagname2=value2",
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseExtensionFlags(tt.flagset)
+			if tt.wantErr {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			require.EqualValues(t, tt.want, got)
+		})
+	}
+}


### PR DESCRIPTION
It seems like we forgot to re-add the ability to [configure extensions from the command line](<https://prerelease.kwil.com/docs/daemon/config/settings#configuration-source-priority>). This re-adds that
