### PR TITLE
erc20: extension info syncing pt 2

### DIFF
--- a/core/types/decimal.go
+++ b/core/types/decimal.go
@@ -204,6 +204,60 @@ func (d *Decimal) String() string {
 	return d.dec.String()
 }
 
+// FullString returns the full string representation of the decimal.
+// It will never return scientific notation.
+func (d *Decimal) FullString() string {
+	bigint := d.dec.Coeff.MathBigInt()
+	str := formatBigInt(bigint, int(d.scale))
+	if d.dec.Negative {
+		str = "-" + str
+	}
+	return str
+}
+
+// FormatBigInt formats a big integer according to precision and scale
+func formatBigInt(n *big.Int, scale int) string {
+	str := n.String() // Convert big.Int to string
+
+	// Handle negative numbers
+	isNegative := false
+	if str[0] == '-' {
+		isNegative = true
+		str = str[1:] // Remove the negative sign for now
+	}
+
+	// Ensure the number is at least scale+1 digits long
+	for len(str) <= scale {
+		str = "0" + str
+	}
+
+	// Insert decimal point at the correct place
+	intPart := str[:len(str)-scale]
+	fracPart := str[len(str)-scale:]
+
+	// Ensure correct scale by padding with trailing zeros if necessary
+	for len(fracPart) < scale {
+		fracPart += "0"
+	}
+
+	// Trim unnecessary leading zeros from the integer part
+	if intPart == "" {
+		intPart = "0"
+	}
+
+	// Construct the final formatted number
+	result := intPart
+	if scale > 0 {
+		result += "." + fracPart
+	}
+
+	if isNegative {
+		result = "-" + result
+	}
+
+	return result
+}
+
 // setPrecision sets the precision of the decimal.
 // The precision must be between 1 and 1000.
 func (d *Decimal) setPrecision(precision uint16) error {

--- a/core/types/decimal_test.go
+++ b/core/types/decimal_test.go
@@ -712,3 +712,53 @@ func TestDecimalJSONRoundTrip(t *testing.T) {
 	assert.Equal(t, original.Precision(), unmarshaled.Precision())
 	assert.Equal(t, original.Scale(), unmarshaled.Scale())
 }
+
+func TestFullString(t *testing.T) {
+	t.Run("very big number", func(t *testing.T) {
+		dec := types.MustParseDecimal("1234567890123456789012345678901234567890.0987654321")
+		str := dec.FullString()
+		assert.Equal(t, "1234567890123456789012345678901234567890.0987654321", str)
+	})
+
+	t.Run("very small number", func(t *testing.T) {
+		dec := types.MustParseDecimal("0.0000000000000000000000000000000000000000001")
+		str := dec.FullString()
+		assert.Equal(t, "0.0000000000000000000000000000000000000000001", str)
+	})
+
+	t.Run("large integer", func(t *testing.T) {
+		dec := types.MustParseDecimal("1234567890123456789012345678901234567890")
+		str := dec.FullString()
+		assert.Equal(t, "1234567890123456789012345678901234567890", str)
+	})
+
+	t.Run("negative number", func(t *testing.T) {
+		dec := types.MustParseDecimal("-1234567890123456789012345678901234567890.0987654321")
+		str := dec.FullString()
+		assert.Equal(t, "-1234567890123456789012345678901234567890.0987654321", str)
+	})
+
+	t.Run("negative large integer", func(t *testing.T) {
+		dec := types.MustParseDecimal("-1234567890123456789012345678901234567890")
+		str := dec.FullString()
+		assert.Equal(t, "-1234567890123456789012345678901234567890", str)
+	})
+
+	t.Run("negative very small number", func(t *testing.T) {
+		dec := types.MustParseDecimal("-0.0000000000000000000000000000000000000000001")
+		str := dec.FullString()
+		assert.Equal(t, "-0.0000000000000000000000000000000000000000001", str)
+	})
+
+	t.Run("zero", func(t *testing.T) {
+		dec := types.MustParseDecimal("0")
+		str := dec.FullString()
+		assert.Equal(t, "0", str)
+	})
+
+	t.Run("explicit precision and scale", func(t *testing.T) {
+		dec := types.MustParseDecimalExplicit("123.456", 100, 4)
+		str := dec.FullString()
+		assert.Equal(t, "123.4560", str)
+	})
+}

--- a/node/exts/erc20reward/meta_extension.go
+++ b/node/exts/erc20reward/meta_extension.go
@@ -670,6 +670,10 @@ func init() {
 							to := inputs[1].(string)
 							amount := inputs[2].(*types.Decimal)
 
+							if amount.IsNegative() {
+								return fmt.Errorf("amount cannot be negative")
+							}
+
 							from, err := ethAddressFromHex(ctx.TxContext.Caller)
 							if err != nil {
 								return err
@@ -697,6 +701,10 @@ func init() {
 							id := inputs[0].(*types.UUID)
 							amount := inputs[1].(*types.Decimal)
 
+							if amount.IsNegative() {
+								return fmt.Errorf("amount cannot be negative")
+							}
+
 							return SINGLETON.lockTokens(ctx.TxContext.Ctx, app, id, ctx.TxContext.Caller, amount)
 						},
 					},
@@ -714,6 +722,10 @@ func init() {
 							id := inputs[0].(*types.UUID)
 							user := inputs[1].(string)
 							amount := inputs[2].(*types.Decimal)
+
+							if amount.IsNegative() {
+								return fmt.Errorf("amount cannot be negative")
+							}
 
 							return SINGLETON.lockTokens(ctx.TxContext.Ctx, app, id, user, amount)
 						},

--- a/node/exts/erc20reward/meta_extension.go
+++ b/node/exts/erc20reward/meta_extension.go
@@ -13,6 +13,7 @@
 package erc20reward
 
 import (
+	"bytes"
 	"context"
 	"encoding/binary"
 	"errors"
@@ -53,6 +54,20 @@ var (
 	rewardExtUUIDNamespace = *types.MustParseUUID("b1f140d1-91cf-4bbe-8f78-8f17f6282fc2")
 	minEpochPeriod         = time.Minute * 10
 	maxEpochPeriod         = time.Hour * 24 * 7 // 1 week
+	// uint256Numeric is a numeric that is big enough to hold a uint256
+	uint256Numeric = func() *types.DataType {
+		dt, err := types.NewNumericType(78, 0)
+		if err != nil {
+			panic(err)
+		}
+
+		return dt
+	}()
+
+	// the below are used to identify different types of logs from ethereum
+	// so that we know how to decode them
+	logTypeTransfer       = []byte("e20trsnfr")
+	logTypeConfirmedEpoch = []byte("cnfepch")
 )
 
 // generates a deterministic UUID for the chain and escrow
@@ -174,16 +189,25 @@ func init() {
 		instances: newInstanceMap(),
 	}
 
-	evmsync.RegisterEventResolution(transferEventResolutionName, func(ctx context.Context, app *common.App, block *common.BlockContext, uniqueName string, logs []ethtypes.Log) error {
+	evmsync.RegisterEventResolution(transferEventResolutionName, func(ctx context.Context, app *common.App, block *common.BlockContext, uniqueName string, logs []*evmsync.EthLog) error {
 		id, err := idFromTransferListenerUniqueName(uniqueName)
 		if err != nil {
 			return err
 		}
 
 		for _, log := range logs {
-			err := applyTransferLog(ctx, app, id, log)
-			if err != nil {
-				return err
+			if bytes.Equal(log.Metadata, logTypeTransfer) {
+				err := applyTransferLog(ctx, app, id, *log.Log)
+				if err != nil {
+					return err
+				}
+			} else if bytes.Equal(log.Metadata, logTypeConfirmedEpoch) {
+				err := applyConfirmedEpochLog(ctx, app, *log.Log)
+				if err != nil {
+					return err
+				}
+			} else {
+				return fmt.Errorf("unknown log type %x", log.Metadata)
 			}
 		}
 
@@ -578,13 +602,17 @@ func init() {
 						Parameters: []precompiles.PrecompileValue{
 							{Name: "id", Type: types.UUIDType},
 							{Name: "user", Type: types.TextType},
-							{Name: "amount", Type: types.TextType},
+							{Name: "amount", Type: uint256Numeric},
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.SYSTEM},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
 							id := inputs[0].(*types.UUID)
 							user := inputs[1].(string)
-							amount := inputs[2].(string)
+							amount := inputs[2].(*types.Decimal)
+
+							if amount.IsNegative() {
+								return fmt.Errorf("amount cannot be negative")
+							}
 
 							info, err := SINGLETON.getUsableInstance(id)
 							if err != nil {
@@ -595,20 +623,7 @@ func init() {
 							// the read lock before we can acquire the write lock, which
 							// we do at the end of this
 
-							// users will pass rewards with the proper number of decimals.
-							// E.g. if the erc20 has 18 decimals, they will pass 18 decimals
-							rawAmount, err := parseAmountFromUser(amount, uint16(info.syncedRewardData.Erc20Decimals))
-							if err != nil {
-								info.mu.RUnlock()
-								return err
-							}
-
-							if rawAmount.IsNegative() {
-								info.mu.RUnlock()
-								return fmt.Errorf("amount cannot be negative")
-							}
-
-							newBal, err := types.DecimalSub(info.ownedBalance, rawAmount)
+							newBal, err := types.DecimalSub(info.ownedBalance, amount)
 							if err != nil {
 								info.mu.RUnlock()
 								return err
@@ -625,7 +640,7 @@ func init() {
 								return err
 							}
 
-							err = issueReward(ctx.TxContext.Ctx, app, info.currentEpoch.ID, addr, rawAmount)
+							err = issueReward(ctx.TxContext.Ctx, app, info.currentEpoch.ID, addr, amount)
 							if err != nil {
 								info.mu.RUnlock()
 								return err
@@ -645,7 +660,7 @@ func init() {
 						Parameters: []precompiles.PrecompileValue{
 							{Name: "id", Type: types.UUIDType},
 							{Name: "to", Type: types.TextType},
-							{Name: "amount", Type: types.TextType},
+							{Name: "amount", Type: uint256Numeric},
 						},
 						// anybody can call this as long as they have the tokens.
 						// There is no security risk if somebody calls this directly
@@ -653,26 +668,7 @@ func init() {
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
 							id := inputs[0].(*types.UUID)
 							to := inputs[1].(string)
-							amount := inputs[2].(string)
-
-							info, err := SINGLETON.getUsableInstance(id)
-							if err != nil {
-								return err
-							}
-
-							info.mu.RLock()
-							defer info.mu.RUnlock()
-
-							// users will pass rewards with the proper number of decimals.
-							// E.g. if the erc20 has 18 decimals, they will pass 18 decimals
-							rawAmount, err := parseAmountFromUser(amount, uint16(info.syncedRewardData.Erc20Decimals))
-							if err != nil {
-								return err
-							}
-
-							if rawAmount.IsNegative() {
-								return fmt.Errorf("amount cannot be negative")
-							}
+							amount := inputs[2].(*types.Decimal)
 
 							from, err := ethAddressFromHex(ctx.TxContext.Caller)
 							if err != nil {
@@ -684,7 +680,7 @@ func init() {
 								return err
 							}
 
-							return transferTokens(ctx.TxContext.Ctx, app, id, from, toAddr, rawAmount)
+							return transferTokens(ctx.TxContext.Ctx, app, id, from, toAddr, amount)
 						},
 					},
 					{
@@ -694,12 +690,12 @@ func init() {
 						Name: "lock",
 						Parameters: []precompiles.PrecompileValue{
 							{Name: "id", Type: types.UUIDType},
-							{Name: "amount", Type: types.TextType},
+							{Name: "amount", Type: uint256Numeric},
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
 							id := inputs[0].(*types.UUID)
-							amount := inputs[1].(string)
+							amount := inputs[1].(*types.Decimal)
 
 							return SINGLETON.lockTokens(ctx.TxContext.Ctx, app, id, ctx.TxContext.Caller, amount)
 						},
@@ -711,13 +707,13 @@ func init() {
 						Parameters: []precompiles.PrecompileValue{
 							{Name: "id", Type: types.UUIDType},
 							{Name: "user", Type: types.TextType},
-							{Name: "amount", Type: types.TextType},
+							{Name: "amount", Type: uint256Numeric},
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.SYSTEM},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
 							id := inputs[0].(*types.UUID)
 							user := inputs[1].(string)
-							amount := inputs[2].(string)
+							amount := inputs[2].(*types.Decimal)
 
 							return SINGLETON.lockTokens(ctx.TxContext.Ctx, app, id, user, amount)
 						},
@@ -730,13 +726,22 @@ func init() {
 						Parameters: []precompiles.PrecompileValue{
 							{Name: "id", Type: types.UUIDType},
 							{Name: "user", Type: types.TextType},
-							{Name: "amount", Type: types.TextType},
+							{Name: "amount", Type: uint256Numeric},
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.SYSTEM},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
 							id := inputs[0].(*types.UUID)
 							user := inputs[1].(string)
-							amount := inputs[2].(string)
+							amount := inputs[2].(*types.Decimal)
+
+							if amount.IsNegative() {
+								return fmt.Errorf("amount cannot be negative")
+							}
+
+							addr, err := ethAddressFromHex(user)
+							if err != nil {
+								return err
+							}
 
 							info, err := SINGLETON.getUsableInstance(id)
 							if err != nil {
@@ -748,26 +753,7 @@ func init() {
 							// the read lock before we can acquire the write lock, which
 							// we do at the end of this
 
-							// users will pass rewards with the proper number of decimals.
-							// E.g. if the erc20 has 18 decimals, they will pass 18 decimals
-							rawAmount, err := parseAmountFromUser(amount, uint16(info.syncedRewardData.Erc20Decimals))
-							if err != nil {
-								info.mu.RUnlock()
-								return err
-							}
-
-							if rawAmount.IsNegative() {
-								info.mu.RUnlock()
-								return fmt.Errorf("amount cannot be negative")
-							}
-
-							addr, err := ethAddressFromHex(user)
-							if err != nil {
-								info.mu.RUnlock()
-								return err
-							}
-
-							left, err := types.DecimalSub(info.ownedBalance, rawAmount)
+							left, err := types.DecimalSub(info.ownedBalance, amount)
 							if err != nil {
 								info.mu.RUnlock()
 								return err
@@ -778,7 +764,7 @@ func init() {
 								return fmt.Errorf("network does not have enough balance to unlock %s for %s", amount, user)
 							}
 
-							err = transferTokensFromNetworkToUser(ctx.TxContext.Ctx, app, id, addr, rawAmount)
+							err = transferTokensFromNetworkToUser(ctx.TxContext.Ctx, app, id, addr, amount)
 							if err != nil {
 								info.mu.RUnlock()
 								return err
@@ -800,7 +786,7 @@ func init() {
 						},
 						Returns: &precompiles.MethodReturn{
 							Fields: []precompiles.PrecompileValue{
-								{Name: "balance", Type: types.TextType},
+								{Name: "balance", Type: uint256Numeric},
 							},
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
@@ -818,23 +804,7 @@ func init() {
 								return err
 							}
 
-							info, ok := SINGLETON.instances.Get(*id)
-							if !ok {
-								return fmt.Errorf("reward extension with id %s not found", id)
-							}
-
-							// adjust the balance to the user's decimals
-							info.mu.RLock()
-							scaled, err := scaleDownUint256(bal, uint16(info.Erc20Decimals))
-							info.mu.RUnlock()
-							if err != nil {
-								return err
-							}
-
-							// TODO: we can just do []any{scaled.String()} here
-							str := scaled.FullString()
-
-							return resultFn([]any{str})
+							return resultFn([]any{bal})
 						},
 					},
 					{
@@ -862,6 +832,102 @@ func init() {
 							return getUnconfirmedEpochs(ctx.TxContext.Ctx, app, id, func(e *Epoch) error {
 								return resultFn([]any{e.ID, e.StartHeight, e.StartTime.Unix(), *e.EndHeight, e.Root, e.BlockHash})
 							})
+						},
+					},
+					{
+						Name: "decimals",
+						Parameters: []precompiles.PrecompileValue{
+							{Name: "id", Type: types.UUIDType},
+						},
+						Returns: &precompiles.MethodReturn{
+							Fields: []precompiles.PrecompileValue{
+								{Name: "decimals", Type: types.IntType},
+							},
+						},
+						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
+						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
+							id := inputs[0].(*types.UUID)
+
+							info, err := SINGLETON.getUsableInstance(id)
+							if err != nil {
+								return err
+							}
+
+							info.mu.RLock()
+							defer info.mu.RUnlock()
+
+							return resultFn([]any{info.syncedRewardData.Erc20Decimals})
+						},
+					},
+					{
+						// scale down scales an int down to the number of decimals of the erc20 token.
+						Name: "scale_down",
+						Parameters: []precompiles.PrecompileValue{
+							{Name: "id", Type: types.UUIDType},
+							{Name: "amount", Type: uint256Numeric},
+						},
+						Returns: &precompiles.MethodReturn{
+							Fields: []precompiles.PrecompileValue{
+								{Name: "scaled", Type: types.TextType},
+							},
+						},
+						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
+						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
+							id := inputs[0].(*types.UUID)
+							amount := inputs[1].(*types.Decimal)
+
+							info, err := SINGLETON.getUsableInstance(id)
+							if err != nil {
+								return err
+							}
+
+							info.mu.RLock()
+							defer info.mu.RUnlock()
+
+							scaled, err := scaleDownUint256(amount, uint16(info.syncedRewardData.Erc20Decimals))
+							if err != nil {
+								return err
+							}
+
+							return resultFn([]any{scaled.String()})
+						},
+					},
+					{
+						// scale up scales an int up to the number of decimals of the erc20 token.
+						Name: "scale_up",
+						Parameters: []precompiles.PrecompileValue{
+							{Name: "id", Type: types.UUIDType},
+							{Name: "amount", Type: types.TextType},
+						},
+						Returns: &precompiles.MethodReturn{
+							Fields: []precompiles.PrecompileValue{
+								{Name: "scaled", Type: uint256Numeric},
+							},
+						},
+						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
+						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
+							id := inputs[0].(*types.UUID)
+							amount := inputs[1].(string)
+
+							info, err := SINGLETON.getUsableInstance(id)
+							if err != nil {
+								return err
+							}
+
+							info.mu.RLock()
+							defer info.mu.RUnlock()
+
+							parsed, err := types.ParseDecimalExplicit(amount, 78, uint16(info.syncedRewardData.Erc20Decimals))
+							if err != nil {
+								return err
+							}
+
+							scaled, err := scaleUpUint256(parsed, uint16(info.syncedRewardData.Erc20Decimals))
+							if err != nil {
+								return err
+							}
+
+							return resultFn([]any{scaled})
 						},
 					},
 					// {
@@ -1108,44 +1174,34 @@ func callDisable(ctx *common.EngineContext, app *common.App, id *types.UUID) err
 }
 
 // lockTokens locks tokens from a user's balance and gives them to the network.
-func (e *extensionInfo) lockTokens(ctx context.Context, app *common.App, id *types.UUID, from string, amount string) error {
+func (e *extensionInfo) lockTokens(ctx context.Context, app *common.App, id *types.UUID, from string, amount *types.Decimal) error {
 	fromAddr, err := ethAddressFromHex(from)
 	if err != nil {
 		return err
 	}
 
+	if amount.IsNegative() {
+		return fmt.Errorf("amount cannot be negative")
+	}
+
+	// we call getUsableInstance before transfer to ensure that the extension is active and synced.
+	// We don't actually use the mutex lock here because it will cause a deadlock with the transfer function
+	// (which recursively calls the interpreter), we just simply want to make sure that the extension
+	// is active and synced.
 	info, err := e.getUsableInstance(id)
 	if err != nil {
 		return err
 	}
 
-	info.mu.RLock()
-	// we cannot defer an RUnlock here because we need to unlock
-	// the read lock before we can acquire the write lock, which
-	// we do at the end of this
-
-	rawAmount, err := parseAmountFromUser(amount, uint16(info.syncedRewardData.Erc20Decimals))
+	err = transferTokensFromUserToNetwork(ctx, app, id, fromAddr, amount)
 	if err != nil {
-		info.mu.RUnlock()
 		return err
 	}
 
-	if rawAmount.IsNegative() {
-		info.mu.RUnlock()
-		return fmt.Errorf("amount cannot be negative")
-	}
-
-	err = transferTokensFromUserToNetwork(ctx, app, id, fromAddr, rawAmount)
-	if err != nil {
-		info.mu.RUnlock()
-		return err
-	}
-
-	info.mu.RUnlock()
 	info.mu.Lock()
 	defer info.mu.Unlock()
 
-	info.ownedBalance, err = info.ownedBalance.Add(info.ownedBalance, rawAmount)
+	info.ownedBalance, err = info.ownedBalance.Add(info.ownedBalance, amount)
 	if err != nil {
 		return err
 	}
@@ -1159,6 +1215,9 @@ func (e *extensionInfo) getUsableInstance(id *types.UUID) (*rewardExtensionInfo,
 	if !ok {
 		return nil, fmt.Errorf("reward extension with id %s not found", id)
 	}
+
+	info.mu.RLock()
+	defer info.mu.RUnlock()
 
 	if !info.active {
 		return nil, fmt.Errorf("reward extension with id %s is not active", id)
@@ -1416,7 +1475,7 @@ func (r *rewardExtensionInfo) startTransferListener(ctx context.Context, app *co
 	return evmsync.EventSyncer.RegisterNewListener(ctx, app.DB, app.Engine, evmsync.EVMEventListenerConfig{
 		UniqueName: transferListenerUniqueName(*r.ID),
 		Chain:      r.ChainInfo.Name,
-		GetLogs: func(ctx context.Context, client *ethclient.Client, startBlock, endBlock uint64, logger log.Logger) ([]ethtypes.Log, error) {
+		GetLogs: func(ctx context.Context, client *ethclient.Client, startBlock, endBlock uint64, logger log.Logger) ([]*evmsync.EthLog, error) {
 			filt, err := abigen.NewErc20Filterer(erc20Copy, client)
 			if err != nil {
 				return nil, fmt.Errorf("failed to bind to ERC20 filterer: %w", err)
@@ -1432,12 +1491,39 @@ func (r *rewardExtensionInfo) startTransferListener(ctx context.Context, app *co
 			}
 			defer iter.Close()
 
-			var logs []ethtypes.Log
+			var logs []*evmsync.EthLog
 			for iter.Next() {
-				logs = append(logs, iter.Event.Raw)
+				logs = append(logs, &evmsync.EthLog{
+					Metadata: logTypeConfirmedEpoch,
+					Log:      &iter.Event.Raw,
+				})
 			}
 			if err := iter.Error(); err != nil {
 				return nil, fmt.Errorf("failed to get transfer logs: %w", err)
+			}
+
+			escrowFilt, err := abigen.NewRewardDistributorFilterer(escrowCopy, client)
+			if err != nil {
+				return nil, fmt.Errorf("failed to bind to RewardDistributor filterer: %w", err)
+			}
+
+			postIter, err := escrowFilt.FilterRewardPosted(&bind.FilterOpts{
+				Start:   startBlock,
+				End:     &endBlock,
+				Context: ctx,
+			})
+			if err != nil {
+				return nil, fmt.Errorf("failed to get reward posted logs: %w", err)
+			}
+
+			for postIter.Next() {
+				logs = append(logs, &evmsync.EthLog{
+					Metadata: logTypeConfirmedEpoch,
+					Log:      &postIter.Event.Raw,
+				})
+			}
+			if err := postIter.Error(); err != nil {
+				return nil, fmt.Errorf("failed to get reward posted logs: %w", err)
 			}
 
 			return logs, nil
@@ -1484,6 +1570,16 @@ func applyTransferLog(ctx context.Context, app *common.App, id *types.UUID, log 
 	return creditBalance(ctx, app, id, data.From, val)
 }
 
+// applyConfirmedEpochLog applies a ConfirmedEpoch log to the reward extension.
+func applyConfirmedEpochLog(ctx context.Context, app *common.App, log ethtypes.Log) error {
+	data, err := rewardLogParser.ParseRewardPosted(log)
+	if err != nil {
+		return fmt.Errorf("failed to parse RewardPosted event: %w", err)
+	}
+
+	return confirmEpoch(ctx, app, data.Root[:])
+}
+
 // erc20ValueFromBigInt converts a big.Int to a decimal.Decimal(78,0)
 func erc20ValueFromBigInt(b *big.Int) (*types.Decimal, error) {
 	dec, err := types.NewDecimalFromBigInt(b, 0)
@@ -1506,14 +1602,28 @@ var (
 
 		return filt
 	}()
+
+	// rewardLogParser is a pre-bound RewardDistributor filterer for parsing RewardPosted events.
+	rewardLogParser = func() irewardLogParser {
+		filt, err := abigen.NewRewardDistributorFilterer(ethcommon.Address{}, nilEthFilterer{})
+		if err != nil {
+			panic(fmt.Sprintf("failed to bind to RewardDistributor filterer: %v", err))
+		}
+
+		return filt
+	}()
 )
 
 // ierc20LogParser is an interface for parsing ERC20 logs.
 // It is only defined to make it clear that the implementation
 // should not use other methods of the abigen erc20 type.
 type ierc20LogParser interface {
-	ParseApproval(log ethtypes.Log) (*abigen.Erc20Approval, error)
 	ParseTransfer(log ethtypes.Log) (*abigen.Erc20Transfer, error)
+}
+
+// irewardLogParser is an interface for parsing RewardDistributor logs.
+type irewardLogParser interface {
+	ParseRewardPosted(log ethtypes.Log) (*abigen.RewardDistributorRewardPosted, error)
 }
 
 // getSyncedRewardData reads on-chain data from both the RewardDistributor and the Gnosis Safe
@@ -1602,15 +1712,4 @@ func scaleDownUint256(amount *types.Decimal, decimals uint16) (*types.Decimal, e
 	}
 
 	return n, nil
-}
-
-// parseAmountFromUser parses an amount from a user input string.
-// It will scale the amount to the correct number of decimals.
-func parseAmountFromUser(amount string, decimals uint16) (*types.Decimal, error) {
-	dec, err := types.ParseDecimalExplicit(amount, 78, decimals)
-	if err != nil {
-		return nil, fmt.Errorf("failed to parse amount: %w", err)
-	}
-
-	return scaleUpUint256(dec, decimals)
 }

--- a/node/exts/erc20reward/meta_schema.sql
+++ b/node/exts/erc20reward/meta_schema.sql
@@ -27,7 +27,8 @@ CREATE TABLE balances (
     id UUID PRIMARY KEY,
     reward_id UUID NOT NULL REFERENCES reward_instances(id) ON UPDATE CASCADE ON DELETE CASCADE,
     address BYTEA NOT NULL, -- wallet address of the user
-    balance NUMERIC(78, 0) NOT NULL DEFAULT 0 CHECK(balance >= 0) -- the balance owned by the user on this network
+    balance NUMERIC(78, 0) NOT NULL DEFAULT 0, -- the balance owned by the user on this network
+    CONSTRAINT balance_must_be_positive CHECK (balance >= 0)
 );
 
 -- epochs holds the epoch information.

--- a/node/exts/erc20reward/meta_sql.go
+++ b/node/exts/erc20reward/meta_sql.go
@@ -77,15 +77,13 @@ func finalizeEpoch(ctx context.Context, app *common.App, epochID *types.UUID, en
 }
 
 // confirmEpoch confirms an epoch was received on-chain
-//
-//lint:ignore U1000 This function is not used yet, but will be used in the future
-func confirmEpoch(ctx context.Context, app *common.App, epochID *types.UUID) error {
+func confirmEpoch(ctx context.Context, app *common.App, root []byte) error {
 	return app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
 	{kwil_erc20_meta}UPDATE epochs
 	SET confirmed = true
-	WHERE id = $id
+	WHERE reward_root = $root
 	`, map[string]any{
-		"id": epochID,
+		"root": root,
 	}, nil)
 }
 

--- a/node/exts/erc20reward/meta_sql.go
+++ b/node/exts/erc20reward/meta_sql.go
@@ -199,9 +199,9 @@ func bytesToEthAddress(bts []byte) (ethcommon.Address, error) {
 func creditBalance(ctx context.Context, app *common.App, rewardId *types.UUID, user ethcommon.Address, amount *types.Decimal) error {
 	balanceId := userBalanceID(rewardId, user)
 	return app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
-	{kwil_erc20_meta}INSERT INTO user_balances(id, reward_id, address, balance)
+	{kwil_erc20_meta}INSERT INTO balances(id, reward_id, address, balance)
 	VALUES ($id, $reward_id, $user, $balance)
-	ON CONFLICT (id) DO UPDATE SET balance = user_balances.balance + $balance
+	ON CONFLICT (id) DO UPDATE SET balance = balances.balance + $balance
 	`, map[string]any{
 		"id":        balanceId,
 		"reward_id": rewardId,
@@ -253,13 +253,13 @@ func issueReward(ctx context.Context, app *common.App, epochID *types.UUID, user
 // transferTokens transfers tokens from one user to another.
 func transferTokens(ctx context.Context, app *common.App, rewardID *types.UUID, from, to ethcommon.Address, amount *types.Decimal) error {
 	return app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
-	{kwil_erc20_meta}UPDATE user_balances
+	{kwil_erc20_meta}UPDATE balances
 	SET balance = balance - $amount
 	WHERE reward_id = $reward_id AND address = $from;
 
-	{kwil_erc20_meta}INSERT INTO user_balances(id, reward_id, address, balance)
+	{kwil_erc20_meta}INSERT INTO balances(id, reward_id, address, balance)
 	VALUES ($to_id, $reward_id, $to, $amount)
-	ON CONFLICT (id) DO UPDATE SET balance = user_balances.balance + $amount;
+	ON CONFLICT (id) DO UPDATE SET balance = balances.balance + $amount;
 	`, map[string]any{
 		"reward_id": rewardID,
 		"from":      from.Bytes(),
@@ -273,7 +273,7 @@ func transferTokens(ctx context.Context, app *common.App, rewardID *types.UUID, 
 func transferTokensFromUserToNetwork(ctx context.Context, app *common.App, rewardID *types.UUID, user ethcommon.Address, amount *types.Decimal) error {
 	// we subtract first in case the user does not have enough funds
 	return app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
-	{kwil_erc20_meta}UPDATE user_balances
+	{kwil_erc20_meta}UPDATE balances
 	SET balance = balance - $amount
 	WHERE reward_id = $reward_id AND address = $user;
 
@@ -295,9 +295,9 @@ func transferTokensFromNetworkToUser(ctx context.Context, app *common.App, rewar
 	SET balance = balance - $amount
 	WHERE id = $reward_id;
 
-	{kwil_erc20_meta}INSERT INTO user_balances(id, reward_id, address, balance)
+	{kwil_erc20_meta}INSERT INTO balances(id, reward_id, address, balance)
 	VALUES ($user_id, $reward_id, $user, $amount)
-	ON CONFLICT (id) DO UPDATE SET balance = user_balances.balance + $amount;
+	ON CONFLICT (id) DO UPDATE SET balance = balances.balance + $amount;
 	`, map[string]any{
 		"reward_id": rewardID,
 		"user":      user.Bytes(),
@@ -311,7 +311,7 @@ func balanceOf(ctx context.Context, app *common.App, rewardID *types.UUID, user 
 	var balance *types.Decimal
 	err := app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
 	{kwil_erc20_meta}SELECT balance
-	FROM user_balances
+	FROM balances
 	WHERE reward_id = $reward_id AND address = $user
 	`, map[string]any{
 		"reward_id": rewardID,

--- a/node/exts/erc20reward/meta_sql_test.go
+++ b/node/exts/erc20reward/meta_sql_test.go
@@ -135,12 +135,13 @@ func TestCreateNewRewardInstance(t *testing.T) {
 	require.Equal(t, zeroHex, rewards[0].syncedRewardData.Erc20Address)
 	require.Equal(t, int64(18), rewards[0].syncedRewardData.Erc20Decimals)
 
+	root := []byte{0x03, 0x04}
 	// finalize the epoch
-	err = finalizeEpoch(ctx, app, pending.ID, 20, []byte{0x01, 0x02}, []byte{0x03, 0x04})
+	err = finalizeEpoch(ctx, app, pending.ID, 20, []byte{0x01, 0x02}, root)
 	require.NoError(t, err)
 
 	// confirm the epoch
-	err = confirmEpoch(ctx, app, pending.ID)
+	err = confirmEpoch(ctx, app, root)
 	require.NoError(t, err)
 
 	// TODO: we currently do not have queries for reading full epochs.

--- a/node/exts/erc20reward/named_extension.go
+++ b/node/exts/erc20reward/named_extension.go
@@ -186,6 +186,42 @@ func init() {
 					AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
 					Handler:         makeMetaHandler("list_unconfirmed_epochs"),
 				},
+				{
+					Name: "decimals",
+					Returns: &precompiles.MethodReturn{
+						Fields: []precompiles.PrecompileValue{
+							{Name: "decimals", Type: types.IntType},
+						},
+					},
+					AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
+					Handler:         makeMetaHandler("decimals"),
+				},
+				{
+					Name: "scale_down",
+					Parameters: []precompiles.PrecompileValue{
+						{Name: "amount", Type: uint256Numeric},
+					},
+					Returns: &precompiles.MethodReturn{
+						Fields: []precompiles.PrecompileValue{
+							{Name: "scaled", Type: types.TextType},
+						},
+					},
+					AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
+					Handler:         makeMetaHandler("scale_down"),
+				},
+				{
+					Name: "scale_up",
+					Parameters: []precompiles.PrecompileValue{
+						{Name: "amount", Type: types.TextType},
+					},
+					Returns: &precompiles.MethodReturn{
+						Fields: []precompiles.PrecompileValue{
+							{Name: "scaled", Type: uint256Numeric},
+						},
+					},
+					AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC, precompiles.VIEW},
+					Handler:         makeMetaHandler("scale_up"),
+				},
 			},
 		}, nil
 	})

--- a/node/exts/evm-sync/evm_state_test.go
+++ b/node/exts/evm-sync/evm_state_test.go
@@ -7,8 +7,9 @@ import (
 
 func Test_PolledEventRoundTrip(t *testing.T) {
 	original := polledEvent{
-		UniqueName: "TestPoll",
-		Data:       []byte("Hello, Blockchain"),
+		UniqueName:     "TestPoll",
+		Data:           []byte("Hello, Blockchain"),
+		ResolutionName: "TestResolution",
 	}
 
 	// Marshal

--- a/node/exts/evm-sync/instance_test.go
+++ b/node/exts/evm-sync/instance_test.go
@@ -1,0 +1,218 @@
+package evmsync
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/core/types"
+	"github.com/stretchr/testify/require"
+)
+
+// TestSerializeDeserializeEthLogs tests that we can round-trip logs
+// via serializeEthLogs -> deserializeEthLogs.
+func TestSerializeDeserializeEthLogs(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   []*EthLog
+		wantErr bool
+	}{
+		{
+			name:    "EmptyLogs",
+			input:   []*EthLog{},
+			wantErr: false,
+		},
+		{
+			name: "SingleLog",
+			input: []*EthLog{
+				{
+					Metadata: []byte("metadata"),
+					Log: &types.Log{
+						Address:     common.HexToAddress("0x1111111111111111111111111111111111111111"),
+						Topics:      []common.Hash{common.HexToHash("0xaaaabbbbccccddddeeee11112222333344445555666677778888999900001111")},
+						Data:        []byte("test data"),
+						BlockNumber: 12345,
+						TxHash:      common.HexToHash("0xbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeefbeef"),
+						BlockHash:   common.HexToHash("0xabcdef1234567890000000000000000000000000000000000000000000000000"),
+						Index:       7,
+						Removed:     false,
+					},
+				},
+			},
+			wantErr: false,
+		},
+		{
+			name: "MultipleLogs",
+			input: []*EthLog{
+				{
+					Metadata: []byte("metadata1"),
+					Log: &types.Log{
+						Address:     common.HexToAddress("0x2222222222222222222222222222222222222222"),
+						Topics:      []common.Hash{common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111")},
+						Data:        []byte("data1"),
+						BlockNumber: 8888,
+						TxHash:      common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+						BlockHash:   common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333"),
+						Index:       1,
+						Removed:     false,
+					},
+				},
+				{
+					Metadata: []byte("metadata2"),
+					Log: &types.Log{
+						Address:     common.HexToAddress("0x3333333333333333333333333333333333333333"),
+						Topics:      []common.Hash{common.HexToHash("0x4444444444444444444444444444444444444444444444444444444444444444")},
+						Data:        []byte("data2"),
+						BlockNumber: 9999,
+						TxHash:      common.HexToHash("0x5555555555555555555555555555555555555555555555555555555555555555"),
+						BlockHash:   common.HexToHash("0x6666666666666666666666666666666666666666666666666666666666666666"),
+						Index:       2,
+						Removed:     true,
+					},
+				},
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			serialized, err := serializeEthLogs(tc.input)
+			require.NoError(t, err, "serializeEthLogs should not fail")
+
+			deserialized, err := deserializeEthLogs(serialized)
+			if tc.wantErr {
+				require.Error(t, err, "deserializeEthLogs should fail")
+				return
+			}
+			require.NoError(t, err, "deserializeEthLogs should not fail")
+
+			// Compare the original slice with the deserialized slice
+			require.Equal(t, len(tc.input), len(deserialized))
+			for i := range tc.input {
+				require.Equal(t, tc.input[i].Metadata, deserialized[i].Metadata)
+				require.Equal(t, tc.input[i].Log.Address, deserialized[i].Log.Address)
+				require.Equal(t, tc.input[i].Log.Data, deserialized[i].Log.Data)
+				require.Equal(t, tc.input[i].Log.Topics, deserialized[i].Log.Topics)
+				require.Equal(t, tc.input[i].Log.BlockNumber, deserialized[i].Log.BlockNumber)
+				require.Equal(t, tc.input[i].Log.TxHash, deserialized[i].Log.TxHash)
+				require.Equal(t, tc.input[i].Log.BlockHash, deserialized[i].Log.BlockHash)
+				require.Equal(t, tc.input[i].Log.Index, deserialized[i].Log.Index)
+				require.Equal(t, tc.input[i].Log.Removed, deserialized[i].Log.Removed)
+			}
+		})
+	}
+}
+
+// TestSerializeDeserializeLog verifies that types.Log structures
+// can be round-tripped through SerializeLog and DeserializeLog without
+// losing any data.
+func TestSerializeDeserializeLog(t *testing.T) {
+	tests := []struct {
+		name string
+		log  types.Log
+	}{
+		{
+			name: "empty",
+			log: types.Log{
+				Topics: []common.Hash{},
+				Data:   []byte{},
+			},
+		},
+		{
+			name: "simple",
+			log: types.Log{
+				Address:     common.HexToAddress("0x0000000000000000000000000000000000000001"),
+				Topics:      []common.Hash{},
+				Data:        []byte{},
+				BlockNumber: 1,
+				TxHash:      common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000001"),
+				TxIndex:     0,
+				BlockHash:   common.HexToHash("0x0000000000000000000000000000000000000000000000000000000000000002"),
+				Index:       0,
+				Removed:     false,
+			},
+		},
+		{
+			name: "withdata",
+			log: types.Log{
+				Address: common.HexToAddress("0x1234567890abcdef1234567890abcdef12345678"),
+				Topics: []common.Hash{
+					common.HexToHash("0xa0a1a2a3a4a5a6a7a8a9aaabacadaeaf00000000000000000000000000000001"),
+					common.HexToHash("0xa0a1a2a3a4a5a6a7a8a9aaabacadaeaf00000000000000000000000000000002"),
+				},
+				Data:        []byte("Some arbitrary data for testing"),
+				BlockNumber: 9999999999,
+				TxHash:      common.HexToHash("0xbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"),
+				TxIndex:     42,
+				BlockHash:   common.HexToHash("0xcccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc"),
+				Index:       1234,
+				Removed:     true,
+			},
+		},
+		{
+			name: "multitopics",
+			log: types.Log{
+				Address: common.HexToAddress("0xbad0bad0bad0bad0bad0bad0bad0bad0bad0bad0"),
+				Topics: []common.Hash{
+					common.HexToHash("0x1111111111111111111111111111111111111111111111111111111111111111"),
+					common.HexToHash("0x2222222222222222222222222222222222222222222222222222222222222222"),
+					common.HexToHash("0x3333333333333333333333333333333333333333333333333333333333333333"),
+				},
+				Data:        []byte("Testing data with multiple topics"),
+				BlockNumber: 12345,
+				TxHash:      common.HexToHash("0xf0f1f2f3f4f5f6f7f8f9fafbfcfdfeff11111111111111111111111111111111"),
+				TxIndex:     99,
+				BlockHash:   common.HexToHash("0xabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabcdefabc"),
+				Index:       99999,
+				Removed:     false,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt // Capture range variable.
+		t.Run(tt.name, func(t *testing.T) {
+			// Serialize
+			serialized, err := serializeLog(&tt.log)
+			if err != nil {
+				t.Fatalf("SerializeLog() error = %v", err)
+			}
+
+			// Deserialize
+			deserialized, err := deserializeLog(serialized)
+			if err != nil {
+				t.Fatalf("DeserializeLog() error = %v", err)
+			}
+
+			// Compare
+			require.EqualValues(t, tt.log, *deserialized)
+		})
+	}
+}
+
+// TestDeserializeEthLogsMalformedData tests that deserialization fails with malformed data.
+func TestDeserializeEthLogsMalformedData(t *testing.T) {
+	// We build a buffer that's intentionally incomplete
+	// (for example, we only write a single log length,
+	// but then don't write the full log data).
+	buf := bytes.Buffer{}
+
+	// Suppose we declare there's a log length of 100 bytes
+	// but then write only 10 bytes
+	var length uint64 = 100
+
+	err := binary.Write(&buf, binary.BigEndian, length)
+	require.NoError(t, err)
+
+	// Write only 10 bytes of data
+	partialData := make([]byte, 10)
+	_, err = buf.Write(partialData)
+	require.NoError(t, err)
+
+	// Try to deserialize
+	_, err = deserializeEthLogs(buf.Bytes())
+	require.Error(t, err, "deserialization should fail on malformed data")
+}

--- a/node/exts/evm-sync/instance_test.go
+++ b/node/exts/evm-sync/instance_test.go
@@ -77,7 +77,6 @@ func TestSerializeDeserializeEthLogs(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		tc := tc
 		t.Run(tc.name, func(t *testing.T) {
 			serialized, err := serializeEthLogs(tc.input)
 			require.NoError(t, err, "serializeEthLogs should not fail")
@@ -173,7 +172,6 @@ func TestSerializeDeserializeLog(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt // Capture range variable.
 		t.Run(tt.name, func(t *testing.T) {
 			// Serialize
 			serialized, err := serializeLog(&tt.log)

--- a/node/exts/evm-sync/listener.go
+++ b/node/exts/evm-sync/listener.go
@@ -263,6 +263,10 @@ func (i *individualListener) processEvents(ctx context.Context, from, to int64, 
 		return err
 	}
 
+	if len(logs) == 0 {
+		return nil
+	}
+
 	blocks := make(map[uint64][]ethtypes.Log)
 	blockOrder := make([]uint64, 0, len(blocks))
 

--- a/node/exts/evm-sync/listener.go
+++ b/node/exts/evm-sync/listener.go
@@ -419,7 +419,7 @@ func deserializeLog(data []byte) (*ethtypes.Log, error) {
 		return nil, err
 	}
 	log.Topics = make([]ethcommon.Hash, topicCount)
-	for i := 0; i < int(topicCount); i++ {
+	for i := range int(topicCount) {
 		if _, err := io.ReadFull(buf, log.Topics[i][:]); err != nil {
 			return nil, err
 		}

--- a/node/exts/ordered-sync/sync.go
+++ b/node/exts/ordered-sync/sync.go
@@ -63,9 +63,7 @@ var registered = make(map[string]ResolveFunc)
 // It can be called many times, but each time must have a different suffix.
 // It should be called in init.
 func init() {
-	extName := ExtensionName
-
-	err := resolutions.RegisterResolution(extName+"_resolution", resolutions.ModAdd, resolutions.ResolutionConfig{
+	err := resolutions.RegisterResolution(ExtensionName, resolutions.ModAdd, resolutions.ResolutionConfig{
 		RefundThreshold:       big.NewRat(1, 3),
 		ConfirmationThreshold: big.NewRat(1, 2),
 		ExpirationPeriod:      1 * time.Hour,
@@ -83,12 +81,12 @@ func init() {
 		panic(err)
 	}
 
-	err = hooks.RegisterEngineReadyHook(extName+"_engine_ready_hook", Synchronizer.readTopicInfoOnStartup)
+	err = hooks.RegisterEngineReadyHook(ExtensionName+"_engine_ready_hook", Synchronizer.readTopicInfoOnStartup)
 	if err != nil {
 		panic(err)
 	}
 
-	err = hooks.RegisterGenesisHook(extName+"_genesis_hook", func(ctx context.Context, app *common.App, chain *common.ChainContext) error {
+	err = hooks.RegisterGenesisHook(ExtensionName+"_genesis_hook", func(ctx context.Context, app *common.App, chain *common.ChainContext) error {
 		version, notYetSet, err := getVersion(ctx, app)
 		if err != nil {
 			return err
@@ -117,7 +115,7 @@ func init() {
 		panic(err)
 	}
 
-	err = hooks.RegisterEndBlockHook(extName+"_end_block_hook", Synchronizer.resolve)
+	err = hooks.RegisterEndBlockHook(ExtensionName+"_end_block_hook", Synchronizer.resolve)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This PR standardizes rewards to always use uint256 values (rather than the scaled down values). It also optionally gives the ability to scale down / up based on a synced reward instances decimals.

This PR also reworks some of the evmsync logic to allow for us to sync many different logs from the same connection. It then uses this to add synchronization for epochs, so that we know when they are confirmed.

Finally, it fixes many bugs regarding syncing ethereum data. I've now tested syncing all necessary data and it all works as expected.
