### PR TITLE
planner: fix update and upsert bugs

### DIFF
--- a/node/engine/planner/logical/planner.go
+++ b/node/engine/planner/logical/planner.go
@@ -2454,6 +2454,14 @@ func (s *scopeContext) buildUpsert(node *parse.OnConflict, table *engine.Table, 
 			return true
 		}
 
+		// check that the table has all the columns
+		for _, col := range node.ConflictColumns {
+			_, ok := table.Column(col)
+			if !ok {
+				return nil, fmt.Errorf(`%w: conflict column "%s" not found in table`, ErrColumnNotFound, col)
+			}
+		}
+
 		found := false
 
 		// check all indexes for a unique or pk index that matches the columns
@@ -2662,10 +2670,10 @@ func (s *scopeContext) cartesian(targetTable, alias string, from parse.Table, jo
 			return &Filter{
 				Child:     targetPlan,
 				Condition: expr,
-			}, targetRel, rel, nil
+			}, rel, rel, nil
 		}
 
-		return targetPlan, rel, nil, nil
+		return targetPlan, rel, rel, nil
 	}
 
 	// update and delete statements with a FROM require a WHERE clause,


### PR DESCRIPTION
This PR fixes two bugs in the query planner that @Yaiba found.

The first bug occurred when we have an UPDATE that does not have a FROM nor WHERE, and references the updated table as part of the expression. It was unable to reference the updated table in this case.

The second bug was not technically a bug, but it was a really confusing error message. If a user had an ON CONFLICT clause targeting a composite index, and it referenced an unknown column, it would say that a unique index did not exist on those columns, rather than complaining that the column itself did not exist.