### PR TITLE
consensus,store: enforce block size limits, compact serializations, misc badger fixes

### DIFF
--- a/app/node/build.go
+++ b/app/node/build.go
@@ -367,7 +367,7 @@ func schemaExists(ctx context.Context, db sql.Executor, schema string) (bool, er
 
 func buildBlockStore(d *coreDependencies, closers *closeFuncs) *store.BlockStore {
 	blkStrDir := config.BlockstoreDir(d.rootDir)
-	bs, err := store.NewBlockStore(blkStrDir)
+	bs, err := store.NewBlockStore(blkStrDir, store.WithCompression(d.cfg.Store.Compression))
 	if err != nil {
 		failBuild(err, "failed to open blockstore")
 	}

--- a/app/shared/display/message_test.go
+++ b/app/shared/display/message_test.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"encoding/hex"
 	"errors"
-	"fmt"
 	"io"
 	"math/big"
 	"os"
@@ -172,7 +171,7 @@ func Example_respTxQuery_json() {
 	//       "log": "This is log",
 	//       "events": null
 	//     },
-	//     "warning": "HASH MISMATCH: requested 0102030400000000000000000000000000000000000000000000000000000000; received a349a2279adc9a6067733523298932e8a78b8ae51e41fbfcb9f6c4149bcdfeaf"
+	//     "warning": "HASH MISMATCH: requested 0102030400000000000000000000000000000000000000000000000000000000; received 53096abc68a1f0a09823a4d8dea302b0ea930715627fc80be7607a9fa714fe60"
 	//   },
 	//   "error": ""
 	// }
@@ -207,8 +206,8 @@ func Example_respTxQuery_WithRaw_json() {
 	//       "log": "This is log",
 	//       "events": null
 	//     },
-	//     "raw": "00005500000041000000cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e2534758000c000000736563703235366b315f6570c1000000220000005468697320697320612074657374207472616e73616374696f6e20666f7220636c69740000000000390000007866363137616631636137373465626264366432336538666531326335366434316432356132326438316538386636376336633665653064340b0000006372656174655f75736572010001001e00000000000f000000000000000004746578740000000000010003000000666f6f070000006578656375746501030000003130300a00000000000000040000006173646606000000636f6e63617400000000",
-	//     "warning": "HASH MISMATCH: requested 0102030400000000000000000000000000000000000000000000000000000000; received a349a2279adc9a6067733523298932e8a78b8ae51e41fbfcb9f6c4149bcdfeaf"
+	//     "raw": "00009e0141cb3fed7f6ff36e59054c04a831b215e514052753ee353e6fe31d4b4ef736acd6155127db555d3006ba14fcb4c79bbad56c8e63b81a9896319bb053a9e2534758000c736563703235366b315f6570e602225468697320697320612074657374207472616e73616374696f6e20666f7220636c69e8010000390000007866363137616631636137373465626264366432336538666531326335366434316432356132326438316538386636376336633665653064340b0000006372656174655f75736572010001001e00000000000f000000000000000004746578740000000000010003000000666f6f076578656375746501033130300a00000000000000046173646606636f6e63617400",
+	//     "warning": "HASH MISMATCH: requested 0102030400000000000000000000000000000000000000000000000000000000; received 53096abc68a1f0a09823a4d8dea302b0ea930715627fc80be7607a9fa714fe60"
 	//   },
 	//   "error": ""
 	// }
@@ -229,7 +228,7 @@ func Test_TxHashAndExecResponse(t *testing.T) {
 	assert.Equal(t, expectText, string(outText), "MarshalText should return expected text")
 
 	outJSON, err := resp.MarshalJSON()
-	fmt.Println(string(outJSON))
+	// fmt.Println(string(outJSON))
 	assert.NoError(t, err, "MarshalJSON should not return error")
 	assert.Equal(t, expectJSON, string(outJSON), "MarshalJSON should return expected json")
 }
@@ -286,7 +285,7 @@ func TestRespTxQuery_MarshalText(t *testing.T) {
 			name: "pending status",
 			input: &RespTxQuery{
 				Msg: &types.TxQueryResponse{
-					Hash:   mustUnmarshalHash("8d741508a6849f9d11c8f478584b5067a6bcfc1114300feff53454b0e064c0a0"),
+					Hash:   mustUnmarshalHash("1f456bec9c3819f077a7aafce25cf43ad9ab0a264cbae6efeaa8b92ec0bf4b47"),
 					Height: -1, // -1 height indicates pending
 					Tx: &types.Transaction{
 						Body: &types.TransactionBody{
@@ -304,7 +303,7 @@ func TestRespTxQuery_MarshalText(t *testing.T) {
 					},
 				},
 			},
-			expected: "Transaction ID: 8d741508a6849f9d11c8f478584b5067a6bcfc1114300feff53454b0e064c0a0\nStatus: pending\nHeight: -1\nLog: transaction pending",
+			expected: "Transaction ID: 1f456bec9c3819f077a7aafce25cf43ad9ab0a264cbae6efeaa8b92ec0bf4b47\nStatus: pending\nHeight: -1\nLog: transaction pending",
 		},
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -267,6 +267,9 @@ func DefaultConfig() *Config {
 			BlockProposalInterval: types.Duration(1 * time.Second),
 			BlockAnnInterval:      types.Duration(3 * time.Second),
 		},
+		Store: StoreConfig{
+			Compression: true,
+		},
 		DB: DBConfig{
 			Host:          "127.0.0.1",
 			Port:          "5432",
@@ -323,6 +326,7 @@ type Config struct {
 	P2P          PeerConfig                   `toml:"p2p" comment:"P2P related configuration"`
 	Consensus    ConsensusConfig              `toml:"consensus" comment:"Consensus related configuration"`
 	DB           DBConfig                     `toml:"db" comment:"DB (PostgreSQL) related configuration"`
+	Store        StoreConfig                  `toml:"store" comment:"Block store configuration"`
 	RPC          RPCConfig                    `toml:"rpc" comment:"User RPC service configuration"`
 	Admin        AdminConfig                  `toml:"admin" comment:"Admin RPC service configuration"`
 	Snapshots    SnapshotConfig               `toml:"snapshots" comment:"Snapshot creation and provider configuration"`
@@ -342,6 +346,18 @@ type PeerConfig struct {
 	Whitelist         []string `toml:"whitelist" comment:"allowed node IDs when in private mode"`
 	TargetConnections int      `toml:"target_connections" comment:"target number of connections to maintain"`
 	ExternalAddress   string   `toml:"external_address" comment:"external address in host:port format to advertise to the network"`
+}
+
+// StoreConfig contains options related to the block store. This is the embedded
+// database used to store the raw block data, unlike the DBConfig which is
+// effectively the state store.
+type StoreConfig struct {
+	Compression bool `toml:"compression" comment:"compress data when writing new data"`
+
+	// Internal block size and block cache size may be of use soon.
+	//   https://github.com/kwilteam/kwil-db/issues/1347
+	// CacheSize int `toml:"cache_size" comment:"size of the block store cache in bytes"`
+	// ChunkSize int `toml:"chunk_size" comment:"size of the block store's internal blocks"`
 }
 
 type DBConfig struct {

--- a/core/types/hash_test.go
+++ b/core/types/hash_test.go
@@ -142,3 +142,79 @@ func TestHashIsZero(t *testing.T) {
 		}
 	})
 }
+
+func TestHashTextMarshaling(t *testing.T) {
+	t.Run("marshal text valid hash", func(t *testing.T) {
+		h := Hash{0xff, 0xee, 0xdd, 0xcc}
+		data, err := h.MarshalText()
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "ffeeddcc00000000000000000000000000000000000000000000000000000000"
+		if string(data) != expected {
+			t.Errorf("got %s, want %s", string(data), expected)
+		}
+
+		// now test that it can be unmarshaled
+		var h2 Hash
+		err = h2.UnmarshalText(data)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if h != h2 {
+			t.Errorf("got %v, want %v", h2, h)
+		}
+	})
+
+	t.Run("unmarshal text valid hash", func(t *testing.T) {
+		input := "ffeeddcc00000000000000000000000000000000000000000000000000000000"
+		var h Hash
+		err := h.UnmarshalText([]byte(input))
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := Hash{0xff, 0xee, 0xdd, 0xcc}
+		if h != expected {
+			t.Errorf("got %v, want %v", h, expected)
+		}
+	})
+
+	t.Run("unmarshal text odd length", func(t *testing.T) {
+		input := "ffeeddccc"
+		var h Hash
+		err := h.UnmarshalText([]byte(input))
+		if err == nil {
+			t.Error("expected error for odd length hex string")
+		}
+	})
+
+	t.Run("unmarshal text invalid characters", func(t *testing.T) {
+		input := "gghhiijj00000000000000000000000000000000000000000000000000000000"
+		var h Hash
+		err := h.UnmarshalText([]byte(input))
+		if err == nil {
+			t.Error("expected error for invalid hex characters")
+		}
+	})
+
+	t.Run("marshal empty hash", func(t *testing.T) {
+		var h Hash
+		data, err := h.MarshalText()
+		if err != nil {
+			t.Fatal(err)
+		}
+		expected := "0000000000000000000000000000000000000000000000000000000000000000"
+		if string(data) != expected {
+			t.Errorf("got %s, want %s", string(data), expected)
+		}
+	})
+
+	t.Run("unmarshal text with whitespace", func(t *testing.T) {
+		input := "  ffeeddcc00000000000000000000000000000000000000000000000000000000  "
+		var h Hash
+		err := h.UnmarshalText([]byte(input))
+		if err == nil {
+			t.Error("expected error for input with whitespace")
+		}
+	})
+}

--- a/core/types/hex_test.go
+++ b/core/types/hex_test.go
@@ -183,6 +183,25 @@ func TestHexBytes_JSON(t *testing.T) {
 			t.Errorf("roundtrip failed: got %v, want %v", decoded, original)
 		}
 	})
+
+	t.Run("roundtrip null", func(t *testing.T) {
+		original := HexBytes(nil)
+		encoded, err := original.MarshalJSON()
+		if err != nil {
+			t.Fatalf("MarshalJSON failed: %v", err)
+		}
+		if string(encoded) != `null` { // unquoted JSON null
+			t.Errorf("expected null, got %s", encoded)
+		}
+		var decoded HexBytes
+		err = decoded.UnmarshalJSON(encoded)
+		if err != nil {
+			t.Fatalf("UnmarshalJSON failed: %v", err)
+		}
+		if decoded != nil {
+			t.Errorf("expected nil, got %v", decoded)
+		}
+	})
 }
 
 func TestHexBytes_Format(t *testing.T) {

--- a/core/types/message.go
+++ b/core/types/message.go
@@ -58,6 +58,9 @@ func CallSigText(namespace, action string, payload []byte, challenge []byte) str
 	return fmt.Sprintf(callMsgToSignTmplV0, namespace, action, digest[:20], challenge)
 }
 
+// TODO: support authentication on execute SQL (ad hoc querys)
+// kgw client must use StmtSigText
+
 const stmtMsgToSignTmplV0 = `Kwil SQL statement.
 
 Statement: %s

--- a/core/types/params.go
+++ b/core/types/params.go
@@ -613,7 +613,11 @@ func (np NetworkParameters) String() string {
 
 func (np *NetworkParameters) Hash() Hash {
 	hasher := NewHasher()
-	hasher.Write(np.Leader.Bytes())
+	if np.Leader.PublicKey == nil { // this is not valid in use, but don't panic
+		hasher.Write([]byte{0})
+	} else {
+		hasher.Write(np.Leader.Bytes())
+	}
 	binary.Write(hasher, SerializationByteOrder, np.MaxBlockSize)
 	binary.Write(hasher, SerializationByteOrder, np.JoinExpiry)
 	binary.Write(hasher, SerializationByteOrder, np.DisabledGasCosts)

--- a/core/types/params.go
+++ b/core/types/params.go
@@ -94,7 +94,9 @@ type NetworkParameters struct {
 	// Validators set is logically also network parameters that evolve, but they
 	// are tracked separately.
 
-	// MaxBlockSize is the maximum size of a block in bytes.
+	// MaxBlockSize is the maximum total size of the serialized transactions in
+	// a block, in bytes. The size of the serialized block will be slightly
+	// larger for the header and other encoding overhead
 	MaxBlockSize int64 `json:"max_block_size"`
 
 	// JoinExpiry is the time duration (in seconds) after which a resolution is

--- a/core/types/time_test.go
+++ b/core/types/time_test.go
@@ -1,0 +1,95 @@
+package types
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDuration_MarshalText(t *testing.T) {
+	t.Run("marshal zero duration", func(t *testing.T) {
+		d := Duration(0)
+		data, err := d.MarshalText()
+		require.NoError(t, err)
+		require.Equal(t, "0s", string(data))
+	})
+
+	t.Run("marshal positive duration", func(t *testing.T) {
+		d := Duration(2*time.Hour + 30*time.Minute)
+		data, err := d.MarshalText()
+		require.NoError(t, err)
+		require.Equal(t, "2h30m0s", string(data))
+	})
+
+	t.Run("marshal negative duration", func(t *testing.T) {
+		d := Duration(-1 * time.Minute)
+		data, err := d.MarshalText()
+		require.NoError(t, err)
+		require.Equal(t, "-1m0s", string(data))
+	})
+}
+
+func TestDuration_UnmarshalText(t *testing.T) {
+	t.Run("unmarshal valid duration", func(t *testing.T) {
+		var d Duration
+		err := d.UnmarshalText([]byte("1h30m"))
+		require.NoError(t, err)
+		require.Equal(t, Duration(90*time.Minute), d)
+	})
+
+	t.Run("unmarshal zero duration", func(t *testing.T) {
+		var d Duration
+		err := d.UnmarshalText([]byte("0s"))
+		require.NoError(t, err)
+		require.Equal(t, Duration(0), d)
+	})
+
+	t.Run("unmarshal invalid duration", func(t *testing.T) {
+		var d Duration
+		err := d.UnmarshalText([]byte("invalid"))
+		require.Error(t, err)
+	})
+
+	t.Run("unmarshal empty duration", func(t *testing.T) {
+		var d Duration
+		err := d.UnmarshalText([]byte(""))
+		require.Error(t, err)
+	})
+
+	t.Run("unmarshal complex duration", func(t *testing.T) {
+		var d Duration
+		err := d.UnmarshalText([]byte("2h45m30.5s"))
+		require.NoError(t, err)
+		expected := Duration(2*time.Hour + 45*time.Minute + 30*time.Second + 500*time.Millisecond)
+		require.Equal(t, expected, d)
+	})
+}
+
+func TestDurationRoundTrip(t *testing.T) {
+	tests := []struct {
+		name     string
+		duration Duration
+	}{
+		{"1 hour", Duration(time.Hour)},
+		{"2 minutes", Duration(2 * time.Minute)},
+		{"500 ms", Duration(500 * time.Millisecond)},
+		{"90 minutes", Duration(90 * time.Minute)},
+		{"zero", Duration(0)},
+		{"mixed", Duration(time.Hour + 2*time.Minute + 6*time.Second)},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			text, err := tt.duration.MarshalText()
+			require.NoError(t, err)
+
+			var decoded Duration
+			err = decoded.UnmarshalText(text)
+			require.NoError(t, err)
+
+			assert.Equal(t, tt.duration, decoded)
+		})
+	}
+}

--- a/core/types/varint_test.go
+++ b/core/types/varint_test.go
@@ -1,0 +1,247 @@
+package types
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_uvarintLen(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    uint64
+		expected int
+	}{
+		{
+			name:     "zero value",
+			input:    0,
+			expected: len(binary.AppendUvarint(nil, 0)), // 1,
+		},
+		{
+			name:     "single byte value",
+			input:    127,
+			expected: len(binary.AppendUvarint(nil, 127)), // 1,
+		},
+		{
+			name:     "two byte value lower bound",
+			input:    128,
+			expected: len(binary.AppendUvarint(nil, 128)), // 2,
+		},
+		{
+			name:     "two byte value upper bound",
+			input:    16383,
+			expected: len(binary.AppendUvarint(nil, 16383)), // 2,
+		},
+		{
+			name:     "three byte value",
+			input:    16384,
+			expected: len(binary.AppendUvarint(nil, 16384)), // 3,
+		},
+		{
+			name:     "max uint32",
+			input:    4294967295,
+			expected: len(binary.AppendUvarint(nil, 4294967295)), // 5,
+		},
+		{
+			name:     "max uint64",
+			input:    18446744073709551615,
+			expected: len(binary.AppendUvarint(nil, 18446744073709551615)), // 10,
+		},
+		{
+			name:     "power of 2 - 64",
+			input:    1 << 63,
+			expected: len(binary.AppendUvarint(nil, 1<<63)), // 10,
+		},
+		{
+			name:     "large number requiring multiple bytes",
+			input:    1234567890123456789,
+			expected: len(binary.AppendUvarint(nil, 1234567890123456789)), // 9,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := uvarintLen(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_varintLen(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name     string
+		input    int64
+		expected int
+	}{
+		{
+			name:     "zero value",
+			input:    0,
+			expected: len(binary.AppendVarint(nil, 0)),
+		},
+		{
+			name:     "max positive int64",
+			input:    9223372036854775807,
+			expected: len(binary.AppendVarint(nil, 9223372036854775807)),
+		},
+		{
+			name:     "min negative int64",
+			input:    -9223372036854775808,
+			expected: len(binary.AppendVarint(nil, -9223372036854775808)),
+		},
+		{
+			name:     "small negative number",
+			input:    -42,
+			expected: len(binary.AppendVarint(nil, -42)),
+		},
+		{
+			name:     "small positive number",
+			input:    42,
+			expected: len(binary.AppendVarint(nil, 42)),
+		},
+		{
+			name:     "power of 2 - 32",
+			input:    1 << 31,
+			expected: len(binary.AppendVarint(nil, 1<<31)),
+		},
+		{
+			name:     "negative power of 2 - 32",
+			input:    -(1 << 31),
+			expected: len(binary.AppendVarint(nil, -(1 << 31))),
+		},
+		{
+			name:     "large positive requiring multiple bytes",
+			input:    1234567890123456789,
+			expected: len(binary.AppendVarint(nil, 1234567890123456789)),
+		},
+		{
+			name:     "large negative requiring multiple bytes",
+			input:    -1234567890123456789,
+			expected: len(binary.AppendVarint(nil, -1234567890123456789)),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := varintLen(tc.input)
+			require.Equal(t, tc.expected, result)
+		})
+	}
+}
+
+func Test_uvarintLen_range(t *testing.T) {
+	for i := range uint64(10_000_000) {
+		expected := len(binary.AppendUvarint(nil, i))
+		got := uvarintLen(i)
+		if got != expected {
+			t.Errorf("uvarintLen(%d) = %d, want %d", i, got, expected)
+		}
+	}
+
+	// Test some larger values
+	largeVals := []uint64{
+		1<<32 - 1,
+		1 << 32,
+		1<<32 + 1,
+		1<<63 - 1,
+		1 << 63,
+		1<<64 - 1,
+	}
+	for _, v := range largeVals {
+		expected := len(binary.AppendUvarint(nil, v))
+		got := uvarintLen(v)
+		if got != expected {
+			t.Errorf("uvarintLen(%d) = %d, want %d", v, got, expected)
+		}
+	}
+}
+
+func Test_varintLen_range(t *testing.T) {
+	for i := int64(-6_000_000); i < 6_000_000; i++ {
+		expected := len(binary.AppendVarint(nil, i))
+		got := varintLen(i)
+		if got != expected {
+			t.Errorf("varintLen(%d) = %d, want %d", i, got, expected)
+		}
+	}
+
+	// Test some edge cases
+	edgeCases := []int64{
+		-(1 << 63),
+		-(1 << 32),
+		-(1 << 16),
+		1<<16 - 1,
+		1 << 32,
+		1<<32 - 1,
+		1<<32 + 1,
+		1<<63 - 1,
+	}
+	for _, v := range edgeCases {
+		expected := len(binary.AppendVarint(nil, v))
+		got := varintLen(v)
+		if got != expected {
+			t.Errorf("varintLen(%d) = %d, want %d", v, got, expected)
+		}
+	}
+}
+
+func TestCompactBytesRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name        string
+		input       []byte
+		expectError bool
+		ensureNil   bool
+	}{
+		{
+			name:        "nil bytes",
+			input:       nil,
+			expectError: false,
+			ensureNil:   true,
+		},
+		{
+			name:        "empty bytes",
+			input:       []byte{},
+			expectError: false,
+		},
+		{
+			name:        "small data",
+			input:       []byte("hello"),
+			expectError: false,
+		},
+		{
+			name:        "large data",
+			input:       bytes.Repeat([]byte("x"), 1000),
+			expectError: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Write to buffer
+			buf := &bytes.Buffer{}
+			err := WriteCompactBytes(buf, tc.input)
+			if tc.expectError {
+				require.Error(t, err)
+				return
+			}
+			require.NoError(t, err)
+
+			// Read back and verify
+			result, err := ReadCompactBytes(buf)
+			require.NoError(t, err)
+			require.Equal(t, tc.input, result)
+
+			require.Equal(t, tc.ensureNil, result == nil)
+
+			// Verify buffer is empty
+			require.Equal(t, 0, buf.Len(), "buffer should be empty after reading")
+		})
+	}
+}

--- a/core/utils/rw.go
+++ b/core/utils/rw.go
@@ -36,10 +36,20 @@ func NewCountingReader(r io.Reader) *CountingReader {
 	return &CountingReader{r: r}
 }
 
+var _ io.Reader = (*CountingReader)(nil)
+
 func (cr *CountingReader) Read(p []byte) (int, error) {
 	n, err := cr.r.Read(p)
 	cr.c += int64(n)
 	return n, err
+}
+
+var _ io.ByteReader = (*CountingReader)(nil)
+
+func (cr *CountingReader) ReadByte() (byte, error) {
+	var b [1]byte
+	_, err := cr.Read(b[:]) // must call our Read to count this byte
+	return b[0], err
 }
 
 func (cr *CountingReader) ReadCount() int64 {

--- a/node/block.go
+++ b/node/block.go
@@ -43,8 +43,8 @@ func (n *Node) blkGetStreamHandler(s network.Stream) {
 		ciBytes, _ := ci.MarshalBinary()
 		s.SetWriteDeadline(time.Now().Add(blkSendTimeout))
 		binary.Write(s, binary.LittleEndian, blk.Header.Height)
-		ktypes.WriteBytes(s, ciBytes)
-		ktypes.WriteBytes(s, rawBlk)
+		ktypes.WriteCompactBytes(s, ciBytes)
+		ktypes.WriteCompactBytes(s, rawBlk)
 	}
 }
 
@@ -71,8 +71,8 @@ func (n *Node) blkGetHeightStreamHandler(s network.Stream) {
 		// hang up earlier depending...
 		s.SetWriteDeadline(time.Now().Add(blkSendTimeout))
 		s.Write(hash[:])
-		ktypes.WriteBytes(s, ciBytes)
-		ktypes.WriteBytes(s, rawBlk)
+		ktypes.WriteCompactBytes(s, ciBytes)
+		ktypes.WriteCompactBytes(s, rawBlk)
 	}
 }
 
@@ -268,7 +268,7 @@ func (n *Node) getBlk(ctx context.Context, blkHash types.Hash) (int64, []byte, *
 			continue
 		}
 
-		ciBts, err := ktypes.ReadBytes(rd)
+		ciBts, err := ktypes.ReadCompactBytes(rd)
 		if err != nil {
 			n.log.Info("failed to read commit info in the block response", "error", err)
 			continue
@@ -280,7 +280,7 @@ func (n *Node) getBlk(ctx context.Context, blkHash types.Hash) (int64, []byte, *
 			continue
 		}
 
-		rawBlk, err := ktypes.ReadBytes(rd)
+		rawBlk, err := ktypes.ReadCompactBytes(rd)
 		if err != nil {
 			n.log.Info("failed to read block in the block response", "error", err)
 			continue
@@ -334,7 +334,7 @@ func getBlkHeight(ctx context.Context, height int64, host host.Host, log log.Log
 			continue
 		}
 
-		ciBts, err := ktypes.ReadBytes(rd)
+		ciBts, err := ktypes.ReadCompactBytes(rd)
 		if err != nil {
 			log.Info("failed to read commit info in the block response", "error", err)
 			continue
@@ -346,7 +346,7 @@ func getBlkHeight(ctx context.Context, height int64, host host.Host, log log.Log
 			continue
 		}
 
-		rawBlk, err := ktypes.ReadBytes(rd)
+		rawBlk, err := ktypes.ReadCompactBytes(rd)
 		if err != nil {
 			log.Warn("failed to read block in the block response", "error", err)
 		}

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -58,6 +58,11 @@ func (ce *ConsensusEngine) validateBlock(blk *ktypes.Block) error {
 		}
 	}
 
+	maxBlockSize := ce.ConsensusParams().MaxBlockSize
+	if blockTxnsSize := blk.TxnsSize(); blockTxnsSize > maxBlockSize {
+		return fmt.Errorf("block size %d exceeds max block size %d", blockTxnsSize, maxBlockSize)
+	}
+
 	return nil
 }
 

--- a/node/protocol.go
+++ b/node/protocol.go
@@ -207,7 +207,7 @@ func (m *blockAnnMsg) WriteTo(w io.Writer) (int64, error) {
 
 	// write block header length and bytes
 	hBts := ktypes.EncodeBlockHeader(m.Header)
-	if err := ktypes.WriteBytes(cw, hBts); err != nil {
+	if err := ktypes.WriteCompactBytes(cw, hBts); err != nil {
 		return cw.Written(), err
 	}
 
@@ -217,12 +217,12 @@ func (m *blockAnnMsg) WriteTo(w io.Writer) (int64, error) {
 	}
 
 	// write commit info length and bytes
-	if err := ktypes.WriteBytes(cw, ciBts); err != nil {
+	if err := ktypes.WriteCompactBytes(cw, ciBts); err != nil {
 		return cw.Written(), err
 	}
 
 	// write leader sig length and bytes
-	if err := ktypes.WriteBytes(cw, m.LeaderSig); err != nil {
+	if err := ktypes.WriteCompactBytes(cw, m.LeaderSig); err != nil {
 		return cw.Written(), err
 	}
 
@@ -242,7 +242,7 @@ func (m *blockAnnMsg) ReadFrom(r io.Reader) (int64, error) {
 		return cr.ReadCount(), err
 	}
 
-	headerBts, err := ktypes.ReadBytes(cr)
+	headerBts, err := ktypes.ReadCompactBytes(cr)
 	if err != nil {
 		return cr.ReadCount(), err
 	}
@@ -252,7 +252,7 @@ func (m *blockAnnMsg) ReadFrom(r io.Reader) (int64, error) {
 	}
 	m.Header = hdr
 
-	ciBts, err := ktypes.ReadBytes(cr)
+	ciBts, err := ktypes.ReadCompactBytes(cr)
 	if err != nil {
 		return cr.ReadCount(), err
 	}
@@ -263,7 +263,7 @@ func (m *blockAnnMsg) ReadFrom(r io.Reader) (int64, error) {
 	}
 	m.CommitInfo = &ci
 
-	leaderSig, err := ktypes.ReadBytes(cr)
+	leaderSig, err := ktypes.ReadCompactBytes(cr)
 	if err != nil {
 		return cr.ReadCount(), err
 	}

--- a/node/statesync.go
+++ b/node/statesync.go
@@ -202,8 +202,8 @@ func (ss *StateSyncService) blkGetHeightRequestHandler(stream network.Stream) {
 		// hang up earlier depending...
 		stream.SetWriteDeadline(time.Now().Add(blkSendTimeout))
 		stream.Write(hash[:])
-		ktypes.WriteBytes(stream, ciBytes)
-		ktypes.WriteBytes(stream, rawBlk)
+		ktypes.WriteCompactBytes(stream, ciBytes)
+		ktypes.WriteCompactBytes(stream, rawBlk)
 	}
 }
 

--- a/node/store/opts.go
+++ b/node/store/opts.go
@@ -1,14 +1,14 @@
 package store
 
 import (
-	"fmt"
-
 	"github.com/kwilteam/kwil-db/core/log"
 )
 
 type options struct {
 	logger   log.Logger
 	compress bool
+	// blockSize      int
+	// blockCacheSize int
 }
 
 type Option func(*options)
@@ -25,23 +25,35 @@ func WithCompression(compress bool) Option {
 	}
 }
 
+/*func WithBlockSize(size int) Option {
+	return func(o *options) {
+		o.blockSize = size
+	}
+}
+
+func WithBlockCacheSize(size int) Option {
+	return func(o *options) {
+		o.blockCacheSize = size
+	}
+}*/
+
 // badgerLogger implements the badger.Logger interface.
 type badgerLogger struct {
 	log log.Logger
 }
 
-func (b *badgerLogger) Debugf(p0 string, p1 ...any) {
-	b.log.Debug(fmt.Sprintf(p0, p1...))
+func (b *badgerLogger) Debugf(msg string, args ...any) {
+	b.log.Debugf(msg, args...)
 }
 
-func (b *badgerLogger) Errorf(p0 string, p1 ...any) {
-	b.log.Error(fmt.Sprintf(p0, p1...))
+func (b *badgerLogger) Errorf(msg string, args ...any) {
+	b.log.Errorf(msg, args...)
 }
 
-func (b *badgerLogger) Infof(p0 string, p1 ...any) {
-	b.log.Info(fmt.Sprintf(p0, p1...))
+func (b *badgerLogger) Infof(msg string, args ...any) {
+	b.log.Infof(msg, args...)
 }
 
-func (b *badgerLogger) Warningf(p0 string, p1 ...any) {
-	b.log.Warn(fmt.Sprintf(p0, p1...))
+func (b *badgerLogger) Warningf(msg string, args ...any) {
+	b.log.Warnf(msg, args...)
 }

--- a/node/store/store_test.go
+++ b/node/store/store_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/kwilteam/kwil-db/core/crypto/auth"
+	"github.com/kwilteam/kwil-db/core/log"
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/types"
 	"github.com/stretchr/testify/require"
@@ -409,12 +410,22 @@ func newTx(nonce uint64, sender string, optPayload ...string) *ktypes.Transactio
 }
 
 func TestLargeBlockStore(t *testing.T) {
-	// This test demonstrates that zstd level 1 compression is faster than no
+	// This test demonstrates that zstd level 1 compression is no slower than no
 	// compression for reasonably compressible data.
+	t.Run("no compression", func(t *testing.T) {
+		testLargeBlockStore(t, false)
+	})
 
+	t.Run("compression", func(t *testing.T) {
+		testLargeBlockStore(t, true)
+	})
+}
+
+func testLargeBlockStore(t *testing.T, compress bool) {
 	// Create block store
 	dir := t.TempDir()
-	bs, err := NewBlockStore(dir, WithCompression(true))
+	logger := log.NewStdoutLogger()
+	bs, err := NewBlockStore(dir, WithCompression(compress), WithLogger(logger))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/node/txapp/mempool.go
+++ b/node/txapp/mempool.go
@@ -52,7 +52,7 @@ func (m *mempool) accountInfo(ctx context.Context, tx sql.Executor, acctID *type
 	}
 
 	m.accounts[string(id)] = acct
-	m.log.Info("added new account to mempool records", "account", acctID, "nonce", acct.Nonce, "balance", acct.Balance)
+	m.log.Debug("added new account to mempool records", "account", acctID, "nonce", acct.Nonce, "balance", acct.Balance)
 
 	return acct, nil
 }

--- a/node/types/consensus.go
+++ b/node/types/consensus.go
@@ -190,25 +190,25 @@ func (ar AckRes) MarshalBinary() ([]byte, error) {
 		}
 	} else {
 		// nack status
-		if err := types.WriteString(&buf, (*ar.NackStatus).String()); err != nil {
+		if err := types.WriteCompactString(&buf, (*ar.NackStatus).String()); err != nil {
 			return nil, fmt.Errorf("failed to write nack status in AckRes: %v", err)
 		}
 		// if nack status is NackStatusOutOfSync, write out of sync proof
 		if *ar.NackStatus == NackStatusOutOfSync {
 			// write header
 			headerBts := types.EncodeBlockHeader(ar.OutOfSyncProof.Header)
-			if err := types.WriteBytes(&buf, headerBts); err != nil {
+			if err := types.WriteCompactBytes(&buf, headerBts); err != nil {
 				return nil, fmt.Errorf("failed to write header in AckRes: %v", err)
 			}
 			// write signature
-			if err := types.WriteBytes(&buf, ar.OutOfSyncProof.Signature); err != nil {
+			if err := types.WriteCompactBytes(&buf, ar.OutOfSyncProof.Signature); err != nil {
 				return nil, fmt.Errorf("failed to write signature in AckRes: %v", err)
 			}
 		}
 	}
 
 	sigBts := ar.Signature.Bytes()
-	if err := types.WriteBytes(&buf, sigBts); err != nil {
+	if err := types.WriteCompactBytes(&buf, sigBts); err != nil {
 		return nil, fmt.Errorf("failed to write signature in AckRes: %v", err)
 	}
 	return buf.Bytes(), nil
@@ -240,7 +240,7 @@ func (ar *AckRes) UnmarshalBinary(data []byte) error {
 		ar.AppHash = &appHash
 	} else {
 		// Read nack status
-		ns, err := types.ReadString(buf)
+		ns, err := types.ReadCompactString(buf)
 		if err != nil {
 			return fmt.Errorf("failed to read nack status in AckRes: %v", err)
 		}
@@ -249,7 +249,7 @@ func (ar *AckRes) UnmarshalBinary(data []byte) error {
 
 		// if nack status is NackStatusOutOfSync, read out of sync proof
 		if *ar.NackStatus == NackStatusOutOfSync {
-			headerBts, err := types.ReadBytes(buf)
+			headerBts, err := types.ReadCompactBytes(buf)
 			if err != nil {
 				return fmt.Errorf("failed to read header in AckRes: %v", err)
 			}
@@ -258,7 +258,7 @@ func (ar *AckRes) UnmarshalBinary(data []byte) error {
 				return fmt.Errorf("failed to decode header in AckRes: %v", err)
 			}
 
-			sigBts, err := types.ReadBytes(buf)
+			sigBts, err := types.ReadCompactBytes(buf)
 			if err != nil {
 				return fmt.Errorf("failed to read signature in AckRes: %v", err)
 			}
@@ -270,7 +270,7 @@ func (ar *AckRes) UnmarshalBinary(data []byte) error {
 		}
 	}
 
-	sigBts, err := types.ReadBytes(buf)
+	sigBts, err := types.ReadCompactBytes(buf)
 	if err != nil {
 		return fmt.Errorf("failed to read signature in AckRes: %v", err)
 	}

--- a/node/voting/validators.go
+++ b/node/voting/validators.go
@@ -79,10 +79,10 @@ func (j *UpdatePowerRequest) MarshalBinary() ([]byte, error) {
 	if err := binary.Write(buf, types.SerializationByteOrder, uint16(updatePowerRequestVersion)); err != nil {
 		return nil, err
 	}
-	if err := types.WriteBytes(buf, j.PubKey); err != nil {
+	if err := types.WriteCompactBytes(buf, j.PubKey); err != nil {
 		return nil, err
 	}
-	if err := types.WriteString(buf, j.PubKeyType.String()); err != nil {
+	if err := types.WriteCompactString(buf, j.PubKeyType.String()); err != nil {
 		return nil, err
 	}
 	if err := binary.Write(buf, types.SerializationByteOrder, j.Power); err != nil {
@@ -102,10 +102,10 @@ func (j *UpdatePowerRequest) UnmarshalBinary(data []byte) error {
 	if version != updatePowerRequestVersion {
 		return fmt.Errorf("invalid version %d", version)
 	}
-	if j.PubKey, err = types.ReadBytes(buf); err != nil {
+	if j.PubKey, err = types.ReadCompactBytes(buf); err != nil {
 		return err
 	}
-	pubKeyType, err := types.ReadString(buf)
+	pubKeyType, err := types.ReadCompactString(buf)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
The PR starts with enforcing the consensus parameter (in genesis.json) for max block size.

This also led to several changes in block and transaction serialization, primarily the use of variable length integers in length-prefixed data, which includes many fields in the transaction and transaction body.  None of the payloads that JS would have to serialize are changed.  The size of a block with many fairly small transactions is drastically reduced.

The `SerializeSize` methods are added or improved, as these are required for efficient size checks without actually allocating huge amounts of memory.

Finally, this addresses some minor issues related to the block store:
- much of the config was not working as intended, namely the logger was being overriden
- our default of no-compression (an override from badger defaults) did not set badger's internal "block" cache to 0 (disabled) which the badger docs recommend if no compression or encryption are used
- expose a `store.compression` option

Related: https://github.com/kwilteam/kwil-db/issues/1347