### PR TITLE
rpc,config: disable RPC response compression by default, add setting

### DIFF
--- a/app/node/prof.go
+++ b/app/node/prof.go
@@ -32,6 +32,7 @@ func startProfilers(mode profMode, pprofFile string) (func(), error) {
 		// handler with the root path on the default mux.
 		http.Handle("/", http.RedirectHandler("/debug/pprof/", http.StatusSeeOther))
 		go func() {
+			fmt.Println("starting http profiler on localhost:6060")
 			if err := http.ListenAndServe("localhost:6060", nil); err != nil {
 				fmt.Printf("http.ListenAndServe: %v\n", err)
 			}

--- a/config/config.go
+++ b/config/config.go
@@ -388,6 +388,7 @@ type RPCConfig struct {
 	Timeout            types.Duration `toml:"timeout" comment:"user request duration limit after which it is cancelled"`
 	MaxReqSize         int            `toml:"max_req_size" comment:"largest permissible user request size"`
 	Private            bool           `toml:"private" comment:"enable private mode that requires challenge authentication for each call"`
+	Compression        bool           `toml:"compression" comment:"use compression in RPC responses"`
 	ChallengeExpiry    types.Duration `toml:"challenge_expiry" comment:"lifetime of a server-generated challenge"`
 	ChallengeRateLimit float64        `toml:"challenge_rate_limit" comment:"maximum number of challenges per second that a user can request"`
 }

--- a/core/log/log.go
+++ b/core/log/log.go
@@ -188,6 +188,12 @@ func formatArgs(args ...any) string {
 var _ KVLogger = (*plainLogger)(nil)
 
 func (l *plainLogger) Debug(msg string, args ...any) {
+	// Avoid malloc and memmove with formatArgs and string concatenation. Since
+	// Debug is typically used liberally (it would be display very often) on
+	// frequently used paths, we want to avoid this unless the level is low enough.
+	if l.log.Level() > sublog.LevelDebug {
+		return
+	}
 	// args are pairs of key-values, so we will print them in pairs after the message.
 	msg += formatArgs(args...)
 	l.log.Debugf(msg)


### PR DESCRIPTION
This was a hotspot in performance tests.  This is not feature that needs to be enabled by default.  It can be a convenience to reduce response sizes if there are large compressible responses AND the operator doesn't want to deploy a proper reverse proxy to offload this task.  Hence, this disables it by default and provides the option to enable it for quick bandwidth reduction at the expense of increased CPU.