### PR TITLE
engine: better error messages for actions used in SQL

### DIFF
--- a/node/engine/interpreter/context.go
+++ b/node/engine/interpreter/context.go
@@ -191,6 +191,19 @@ func (e *executionContext) query(sql string, fn func(*row) error) error {
 
 			return nil, engine.ErrUnknownVariable
 		},
+		func(fnName string) bool {
+			ns, err := e.getNamespace("")
+			if err != nil {
+				// should never happen, as it is getting the current namespace
+				panic(err)
+			}
+
+			executable, ok := ns.availableFunctions[fnName]
+			if !ok {
+				return false
+			}
+			return executable.Type == executableTypeAction || executable.Type == executableTypePrecompile
+		},
 		e.canMutateState,
 		e.scope.namespace,
 	)

--- a/node/engine/planner/logical/errors.go
+++ b/node/engine/planner/logical/errors.go
@@ -18,4 +18,5 @@ var (
 	ErrInvalidWindowFunction      = errors.New("invalid window function")
 	ErrWindowNotDefined           = errors.New("window not defined")
 	ErrFunctionDoesNotExist       = errors.New("function does not exist")
+	ErrActionInSQLStmt            = errors.New("actions cannot be used in SQL statements")
 )

--- a/node/engine/planner/optimizer/pushdown_test.go
+++ b/node/engine/planner/optimizer/pushdown_test.go
@@ -118,6 +118,7 @@ func Test_Pushdown(t *testing.T) {
 				func(objName string) (obj map[string]*types.DataType, err error) {
 					return nil, engine.ErrUnknownVariable
 				},
+				func(s string) bool { return false },
 				false, "")
 			require.NoError(t, err)
 


### PR DESCRIPTION
Actions are not allowed to be used within SQL. If a user tries to, two things may happen:

1. If the action has the same name of the built-in function, it will just use the built-in function. This is actually sort've misleading from the perspective of the user, because referencing that same function in an action will call the action (and all built-in functions can be called this way as well).
2. If there is not a built-in function, it simply says "function does not exist", rather than informing the user that it is illegal to use actions in a query.

This PR changes this, so that the query planner will inform the user that it cannot reference these functions.

Resolves: https://github.com/kwilteam/kwil-db/issues/1355