### PR TITLE
evm-sync: fix blocks syncing out of order

### DIFF
--- a/node/exts/erc20reward/meta_extension.go
+++ b/node/exts/erc20reward/meta_extension.go
@@ -1506,7 +1506,7 @@ func (r *rewardExtensionInfo) startTransferListener(ctx context.Context, app *co
 			var logs []*evmsync.EthLog
 			for iter.Next() {
 				logs = append(logs, &evmsync.EthLog{
-					Metadata: logTypeConfirmedEpoch,
+					Metadata: logTypeTransfer,
 					Log:      &iter.Event.Raw,
 				})
 			}

--- a/node/exts/evm-sync/listener.go
+++ b/node/exts/evm-sync/listener.go
@@ -350,18 +350,6 @@ func (i *individualListener) processEvents(ctx context.Context, from, to int64, 
 	return setLastSeenHeight(ctx, eventStore, i.orderedSyncTopic, to)
 }
 
-/*
-uyyyy ===== 7606100 <nil>
-uyyyy ===== 7606108 7606100
-uyyyy ===== 7606494 7688721
-uyyyy ===== 7612561 7606494
-uyyyy ===== 7612734 7612561
-uyyyy ===== 7613118 7612734
-uyyyy ===== 7688721 7606108
-uyyyy ===== 7731215 7613118
-uyyyy ===== 7731390 7731215
-*/
-
 // serializeLog serializes an ethCommonLogCopy into a deterministic byte slice.
 func serializeLog(log *ethtypes.Log) ([]byte, error) {
 	buf := new(bytes.Buffer)

--- a/node/exts/evm-sync/listener.go
+++ b/node/exts/evm-sync/listener.go
@@ -309,17 +309,11 @@ func (i *individualListener) processEvents(ctx context.Context, from, to int64, 
 			return fmt.Errorf("failed to serialize logs: %w", err)
 		}
 
-		var lhCopy *int64
-		if lastUsedHeight != nil {
-			lhc2 := *lastUsedHeight
-			lhCopy = &lhc2
-		}
-
 		data := orderedsync.ResolutionMessage{
 			Topic:               i.orderedSyncTopic,
 			PointInTime:         int64(blockNum),
 			Data:                serLogs,
-			PreviousPointInTime: lhCopy,
+			PreviousPointInTime: lastUsedHeight,
 		}
 
 		bts, err := data.MarshalBinary()


### PR DESCRIPTION
Fixes an issue where the Ethereum RPC gives us logs out of order, which our resolution was not expecting.
