### PR TITLE
[FOR TESTING] node,peers: modify block get request with chunk/idle timeout and informative not found

### DIFF
--- a/node/block.go
+++ b/node/block.go
@@ -405,7 +405,7 @@ func getBlkHeight(ctx context.Context, height int64, host host.Host, log log.Log
 		t0 := time.Now()
 		resp, err := requestBlockHeight(ctx, host, peer, height, blkReadLimit)
 		if errors.Is(err, ErrNotFound) || errors.Is(err, ErrBlkNotFound) {
-			be := new(ErrNotFoundWithBestHeight)
+			var be *ErrNotFoundWithBestHeight
 			if errors.As(err, &be) {
 				theirBest := be.BestHeight
 				if theirBest > bestHeight {
@@ -486,7 +486,7 @@ func getBlkHeight(ctx context.Context, height int64, host host.Host, log log.Log
 }
 
 // ErrNotFoundWithBestHeight is an error that contains a BestHeight field, which
-// is used when a block is not found, but the the negative responses from peers
+// is used when a block is not found, but the negative responses from peers
 // contained their best height.
 //
 // Use with errors.As.  For example:
@@ -502,7 +502,7 @@ type ErrNotFoundWithBestHeight struct {
 	BestHeight int64
 }
 
-func (e *ErrNotFoundWithBestHeight) Error() string {
+func (e *ErrNotFoundWithBestHeight) Error() string { // keep it a pointer receiver to avoid pitfalls with errors.As
 	return fmt.Sprintf("block not found, best height: %d", e.BestHeight)
 }
 

--- a/node/consensus/blocksync.go
+++ b/node/consensus/blocksync.go
@@ -140,7 +140,7 @@ func (ce *ConsensusEngine) syncBlockWithRetry(ctx context.Context, height int64)
 
 // syncBlock fetches the specified block from the network
 func (ce *ConsensusEngine) syncBlock(ctx context.Context, height int64) error {
-	_, rawblk, ci, err := ce.blkRequester(ctx, height)
+	_, rawblk, ci, _, err := ce.blkRequester(ctx, height)
 	if err != nil {
 		return fmt.Errorf("failed to get block from the network: %w", err)
 	}
@@ -166,7 +166,7 @@ func (ce *ConsensusEngine) applyBlock(ctx context.Context, rawBlk []byte, ci *ty
 
 func (ce *ConsensusEngine) getBlock(ctx context.Context, height int64) (blkID types.Hash, rawBlk []byte, ci *types.CommitInfo, err error) {
 	err = blkRetrier(ctx, 15, func() error {
-		blkID, rawBlk, ci, err = ce.blkRequester(ctx, height)
+		blkID, rawBlk, ci, _, err = ce.blkRequester(ctx, height)
 		return err
 	})
 

--- a/node/consensus/engine.go
+++ b/node/consensus/engine.go
@@ -211,7 +211,7 @@ type TxAnnouncer func(ctx context.Context, txHash types.Hash, rawTx []byte)
 type AckBroadcaster func(msg *types.AckRes) error
 
 // BlkRequester requests the block from the network based on the height
-type BlkRequester func(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, error)
+type BlkRequester func(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, int64, error)
 
 type ResetStateBroadcaster func(height int64, txIDs []ktypes.Hash) error
 

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -623,13 +623,14 @@ func TestValidatorStateMachine(t *testing.T) {
 
 						rawBlk := ktypes.EncodeBlock(blkProp2.blk)
 						cnt := 0
-						val.blkRequester = func(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, error) {
+						bestHeight := blkProp2.height + 10 // TODO: update test when this is used
+						val.blkRequester = func(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, int64, error) {
 							defer func() { cnt += 1 }()
 
 							if cnt < 1 {
-								return zeroHash, nil, nil, types.ErrBlkNotFound
+								return zeroHash, nil, nil, 0, types.ErrBlkNotFound
 							}
-							return blkProp2.blkHash, rawBlk, ci, nil
+							return blkProp2.blkHash, rawBlk, ci, bestHeight, nil
 						}
 						val.doCatchup(context.Background())
 					},
@@ -660,8 +661,9 @@ func TestValidatorStateMachine(t *testing.T) {
 						ci := addVotes(t, blkProp2.blkHash, blockAppHash, leader, val)
 
 						rawBlk := ktypes.EncodeBlock(blkProp2.blk)
-						val.blkRequester = func(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, error) {
-							return blkProp2.blkHash, rawBlk, ci, nil
+						bestHeight := blkProp2.height + 10 // TODO: update test when this is used
+						val.blkRequester = func(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, int64, error) {
+							return blkProp2.blkHash, rawBlk, ci, bestHeight, nil
 						}
 						val.doCatchup(context.Background())
 					},
@@ -920,8 +922,8 @@ func TestCELeaderTwoNodesMajorityNacks(t *testing.T) {
 }
 
 // MockBroadcasters
-func mockBlkRequester(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, error) {
-	return types.Hash{}, nil, nil, types.ErrBlkNotFound
+func mockBlkRequester(ctx context.Context, height int64) (types.Hash, []byte, *types.CommitInfo, int64, error) {
+	return types.Hash{}, nil, nil, 0, types.ErrBlkNotFound
 }
 
 func mockBlockPropBroadcaster(_ context.Context, blk *ktypes.Block) {}

--- a/node/peers/peers.go
+++ b/node/peers/peers.go
@@ -179,6 +179,7 @@ func NewPeerMan(cfg *Config) (*PeerMan, error) {
 
 	host.SetStreamHandler(ProtocolIDPrefixChainID+protocol.ID(cfg.ChainID), func(s network.Stream) {
 		s.Close() // protocol handshake is all we need
+		// TODO (maybe): get and serve our height is a peer actually tries to use this protocol
 	})
 
 	if cfg.SeedMode {

--- a/node/protocol.go
+++ b/node/protocol.go
@@ -27,7 +27,7 @@ const (
 
 	ProtocolIDTx          protocol.ID = "/kwil/tx/1.0.0"
 	ProtocolIDTxAnn       protocol.ID = "/kwil/txann/1.0.0"
-	ProtocolIDBlockHeight protocol.ID = "/kwil/blkheight/1.0.0"
+	ProtocolIDBlockHeight protocol.ID = "/kwil/blkheight/1.1.0"
 	ProtocolIDBlock       protocol.ID = "/kwil/blk/1.0.0"
 	ProtocolIDBlkAnn      protocol.ID = "/kwil/blkann/1.0.0"
 	// ProtocolIDBlockHeader protocol.ID = "/kwil/blkhdr/1.0.0"
@@ -68,7 +68,10 @@ func request(rw io.ReadWriter, reqMsg []byte, readLimit int64) ([]byte, error) {
 	return rawTx, nil
 }
 
-var noData = []byte{0}
+var (
+	noData   = []byte{0}
+	withData = []byte{1}
+)
 
 // readResp reads a response of unknown length until an EOF is reached when
 // reading. As such, this is the end of a protocol.

--- a/node/protocol.go
+++ b/node/protocol.go
@@ -17,6 +17,7 @@ import (
 	"github.com/kwilteam/kwil-db/node/types"
 
 	"github.com/libp2p/go-libp2p/core/host"
+	"github.com/libp2p/go-libp2p/core/network"
 	"github.com/libp2p/go-libp2p/core/peer"
 	"github.com/libp2p/go-libp2p/core/protocol"
 )
@@ -139,7 +140,7 @@ func (n *Node) advertiseToPeer(ctx context.Context, peerID peer.ID, proto protoc
 
 		req := make([]byte, len(getMsg))
 		nr, err := s.Read(req)
-		if err != nil && !errors.Is(err, io.EOF) {
+		if err != nil && !(errors.Is(err, io.EOF) || errors.Is(err, network.ErrReset)) {
 			n.log.Warn("bad advertise response", "error", err)
 			return
 		}

--- a/node/statesync.go
+++ b/node/statesync.go
@@ -163,7 +163,7 @@ func (ss *StateSyncService) DoStatesync(ctx context.Context) (bool, error) {
 	}
 
 	// request and commit the block to the blockstore
-	_, rawBlk, ci, err := getBlkHeight(ctx, height, ss.host, ss.log)
+	_, rawBlk, ci, _, err := getBlkHeight(ctx, height, ss.host, ss.log)
 	if err != nil {
 		return false, fmt.Errorf("failed to get statesync block %d: %w", height, err)
 	}


### PR DESCRIPTION
This modifies the get-by-height block request to use a `readAll` implementation that allows setting timeouts for the 512 bytes chunks used in the read loop.  This should prevent having to hit the full (20 sec or longer) timeout for the entire response if the connection has completely stalled.

This also changes `ProtocolIDBlockHeight` protocol to include the peer's best height in both the "not found" branch of the protocol, and at the end of the positive path right after the block contents.  The former may be used to help block sync (e.g. break the catch up loop if all the not found responses say we are requesting the best known +1 or greater already); the latter could also help the CE be more intelligent about when it breaks out of initial block sync so it can get into the consensus event loop.