### PR TITLE
rpc: json stringify numbers

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -154,7 +155,12 @@ type Row struct {
 	// ColumnTypes are the types of the columns in the row.
 	ColumnTypes []*types.DataType
 	// Values are the values of the columns in the row.
+	// It is one of the following types:
+	// nil, string, int64, []byte, bool, *types.UUID, *types.Decimal,
+	// []*string, []*int64, [][]byte, []*bool, []*types.UUID, []*types.Decimal
 	Values []any
+	// JsonValues are the values of the columns in the row, formatted as JSON.
+	JsonValues []json.Marshaler
 }
 
 // Accounts is an interface for managing accounts on the Kwil network. It

--- a/common/common.go
+++ b/common/common.go
@@ -2,7 +2,6 @@ package common
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"math/big"
 
@@ -159,8 +158,6 @@ type Row struct {
 	// nil, string, int64, []byte, bool, *types.UUID, *types.Decimal,
 	// []*string, []*int64, [][]byte, []*bool, []*types.UUID, []*types.Decimal
 	Values []any
-	// JsonValues are the values of the columns in the row, formatted as JSON.
-	JsonValues []json.Marshaler
 }
 
 // Accounts is an interface for managing accounts on the Kwil network. It

--- a/test/acceptance/act_test.go
+++ b/test/acceptance/act_test.go
@@ -5,6 +5,7 @@ import (
 	_ "embed"
 	"flag"
 	"fmt"
+	"math"
 	"math/big"
 	"os"
 	"os/signal"
@@ -288,7 +289,7 @@ func Test_Roundtrip(t *testing.T) {
 
 			textVal := "hello world"
 			textArrVal := []*string{p("hello"), p("world"), nil}
-			intVal := int64(123)
+			intVal := int64(math.MaxInt64)
 			intArrVal := []*int64{p(intVal), p(intVal + 1), nil}
 			boolVal := true
 			boolArrVal := []*bool{p(boolVal), p(!boolVal), nil}


### PR DESCRIPTION
JSON stringifies int64 so that we can handle high precision int values in JavaScript.
