### PR TITLE
engine: cache prepared statements

### DIFF
--- a/node/engine/interpreter/context.go
+++ b/node/engine/interpreter/context.go
@@ -220,7 +220,7 @@ func (e *executionContext) prepareQuery(sql string) (pgSql string, plan *logical
 
 			return cached.deterministicSQL, cached.deterministicPlan, values, nil
 		}
-		values, err := e.getValues(cached.deterministicParams)
+		values, err := e.getValues(cached.nonDeterministicParams)
 		if err != nil {
 			return "", nil, nil, err
 		}
@@ -342,7 +342,7 @@ func (e *executionContext) prepareQuery(sql string) (pgSql string, plan *logical
 
 		return deterministicSQL, deterministicPlan, values, nil
 	}
-	values, err := e.getValues(deterministicParams)
+	values, err := e.getValues(nonDeterministicParams)
 	if err != nil {
 		return "", nil, nil, err
 	}

--- a/node/engine/interpreter/context.go
+++ b/node/engine/interpreter/context.go
@@ -401,12 +401,12 @@ func (p *preparedStatements) set(namespace, query string, stmt *preparedStatemen
 	p.statements[namespace][query] = stmt
 }
 
-// clearNamespace clears the cache for a namespace.
-func (p *preparedStatements) clearNamespace(namespace string) {
+// clear clears the cache namespace.
+func (p *preparedStatements) clear() {
 	p.mu.Lock()
 	defer p.mu.Unlock()
 
-	delete(p.statements, namespace)
+	p.statements = make(map[string]map[string]*preparedStatement)
 }
 
 var statementCache = &preparedStatements{
@@ -572,7 +572,7 @@ func (e *executionContext) reloadNamespaceCache() error {
 		ns.tables[table.Name] = table
 	}
 
-	statementCache.clearNamespace(e.scope.namespace)
+	statementCache.clear()
 
 	return nil
 }

--- a/node/engine/interpreter/context.go
+++ b/node/engine/interpreter/context.go
@@ -355,8 +355,11 @@ func (e *executionContext) prepareQuery(sql string) (pgSql string, plan *logical
 // This is necessary because we use the AST to generate Postgres SQL
 // queries, so we actually modify the AST to make it deterministic.
 type preparedStatement struct {
-	deterministicPlan      *logical.AnalyzedPlan
-	deterministicSQL       string
+	deterministicPlan *logical.AnalyzedPlan
+	deterministicSQL  string
+	// the params for deterministic and non-deterministic
+	// queries _should_ be the same, but I am keeping them separate
+	// because it might change based on the implementation of the planner
 	deterministicParams    []string
 	nonDeterministicPlan   *logical.AnalyzedPlan
 	nonDeterministicSQL    string

--- a/node/engine/interpreter/planner.go
+++ b/node/engine/interpreter/planner.go
@@ -680,13 +680,6 @@ func (i *interpreterPlanner) VisitLoopTermExpression(p0 *parse.LoopTermExpressio
 }
 
 func (i *interpreterPlanner) VisitLoopTermSQL(p0 *parse.LoopTermSQL) any {
-	// raw, err := p0.Statement.Raw()
-	// if err != nil {
-	// 	return err
-	// }
-
-	// ast1, err := parse.Parse(raw)
-
 	return loopTermFunc(func(exec *executionContext, fn func(value) error) error {
 		raw, err := p0.Statement.Raw()
 		if err != nil {

--- a/node/engine/interpreter/planner.go
+++ b/node/engine/interpreter/planner.go
@@ -680,6 +680,13 @@ func (i *interpreterPlanner) VisitLoopTermExpression(p0 *parse.LoopTermExpressio
 }
 
 func (i *interpreterPlanner) VisitLoopTermSQL(p0 *parse.LoopTermSQL) any {
+	// raw, err := p0.Statement.Raw()
+	// if err != nil {
+	// 	return err
+	// }
+
+	// ast1, err := parse.Parse(raw)
+
 	return loopTermFunc(func(exec *executionContext, fn func(value) error) error {
 		raw, err := p0.Statement.Raw()
 		if err != nil {
@@ -1624,7 +1631,7 @@ func (i *interpreterPlanner) VisitCreateTableStatement(p0 *parse.CreateTableStat
 			return err
 		}
 
-		return exec.reloadTables()
+		return exec.reloadNamespaceCache()
 	})
 }
 
@@ -1665,7 +1672,7 @@ func (i *interpreterPlanner) VisitDropTableStatement(p0 *parse.DropTableStatemen
 			return err
 		}
 
-		return exec.reloadTables()
+		return exec.reloadNamespaceCache()
 	})
 }
 
@@ -1709,7 +1716,7 @@ func (i *interpreterPlanner) VisitCreateIndexStatement(p0 *parse.CreateIndexStat
 		}
 
 		// we reload tables here because we track indexes in the table object
-		return exec.reloadTables()
+		return exec.reloadNamespaceCache()
 	})
 }
 
@@ -1735,7 +1742,7 @@ func (i *interpreterPlanner) VisitDropIndexStatement(p0 *parse.DropIndexStatemen
 		}
 
 		// we reload tables here because we track indexes in the table object
-		return exec.reloadTables()
+		return exec.reloadNamespaceCache()
 	})
 }
 
@@ -2111,7 +2118,7 @@ func (i *interpreterPlanner) VisitAlterTableStatement(p0 *parse.AlterTableStatem
 			return err
 		}
 
-		return exec.reloadTables()
+		return exec.reloadNamespaceCache()
 	})
 }
 


### PR DESCRIPTION
This PR adds caching for statements in the interpreter, removing the need to redundantly parse, analyze, and generate SQL for statements that don't change. The cache is invalidated any time any table is changed; this is because a change in the DB schema may change what is necessary to make a query deterministic.

This PR also fixes a bug that I coincidentally found while clicking through the query planner looking for something else. It was not properly applying default ordering to window functions.
