### PR TITLE
update postgres docker: more tx locks, v 16.8

### DIFF
--- a/.github/workflows/ci-main.yaml
+++ b/.github/workflows/ci-main.yaml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       postgres:
-        image: kwildb/postgres:16.5-1
+        image: kwildb/postgres:16.8-1
         env:
           POSTGRES_HOST_AUTH_METHOD: trust
         options: >-

--- a/.github/workflows/ci-release.yaml
+++ b/.github/workflows/ci-release.yaml
@@ -43,7 +43,7 @@ jobs:
 
     services:
       postgres:
-        image: kwildb/postgres:16.5-1
+        image: kwildb/postgres:16.8-1
         env:
           POSTGRES_PORT: 5432
           POSTGRES_HOST_AUTH_METHOD: trust

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ easiest is to run our pre-configured Docker image:
 
 ```shell
 docker run -p 5432:5432 -v kwil-pg-demo:/var/lib/postgresql/data \
-    --shm-size 256m -e "POSTGRES_HOST_AUTH_METHOD=trust" \
+    --shm-size 512m -e "POSTGRES_HOST_AUTH_METHOD=trust" \
     --name kwil-pg-demo kwildb/postgres:latest
 ```
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -147,7 +147,7 @@ tasks:
       - |
         docker run -p :5432 -v {{ .NAME }}:/var/lib/postgresql/data \
             --shm-size 512m -e "POSTGRES_HOST_AUTH_METHOD=trust" \
-            --name {{ .NAME }} kwildb/postgres:16.5-1
+            --name {{ .NAME }} kwildb/postgres:16.8-1
 
   pg:clean:
     desc: Wipe data from the pg task

--- a/contrib/docker/compose/kwil/docker-compose.yml
+++ b/contrib/docker/compose/kwil/docker-compose.yml
@@ -5,7 +5,7 @@ volumes:
 services:
   pg:
     container_name: postgres-kwild-single
-    image: kwildb/postgres:16.5-1
+    image: kwildb/postgres:16.8-1
     ports:
       - "15432:5432"
     restart: always

--- a/contrib/docker/compose/postgres/docker-compose.yml
+++ b/contrib/docker/compose/postgres/docker-compose.yml
@@ -1,9 +1,10 @@
 services:
   pg:
     container_name: postgres
-    image: kwildb/postgres:16.5-1
+    image: kwildb/postgres:16.8-1
     ports:
       - "5432:5432"
+    shm_size: "512m"
     restart: always
     environment:
       POSTGRES_HOST_AUTH_METHOD: trust

--- a/contrib/docker/postgres.dockerfile
+++ b/contrib/docker/postgres.dockerfile
@@ -1,4 +1,4 @@
-FROM postgres:16.6
+FROM postgres:16.8
 
 # Inject the init script that makes the kwild superuser and a kwild database
 # owned by that kwild user, as well as a kwil_test_db database for tests.
@@ -15,4 +15,4 @@ COPY ./pginit.sql /docker-entrypoint-initdb.d/init.sql
 # Override the default entrypoint/command to include the additional configuration
 CMD ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=10", "-c", "max_replication_slots=10", \
 	"-c", "track_commit_timestamp=true", "-c", "wal_sender_timeout=0", "-c", "max_prepared_transactions=2", \
-	"-c", "max_locks_per_transaction=256", "-c", "max_connections=128"]
+	"-c", "max_locks_per_transaction=4096", "-c", "max_connections=128"]

--- a/test/setup/node-compose.yml.template
+++ b/test/setup/node-compose.yml.template
@@ -34,7 +34,7 @@
       retries: 10
 
   {{ .PGServicePrefix }}{{ .NodeNumber }}:
-    image: kwildb/postgres:16.5-1
+    image: kwildb/postgres:16.8-1
     ports:
       - "5432"
     restart: always

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -572,7 +572,7 @@ const ContainerName = "kwil-testing-postgres"
 // dockerStartArgs returns the docker start command args
 func dockerStartArgs(port string) (args []string) {
 	return []string{"run", "-d", "-p", port + ":5432", "--name", ContainerName,
-		"-e", "POSTGRES_HOST_AUTH_METHOD=trust", "kwildb/postgres:16.5-1"}
+		"-e", "POSTGRES_HOST_AUTH_METHOD=trust", "kwildb/postgres:16.8-1"}
 }
 
 // connectWithRetry tries to connect to Postgres, and will retry n times at


### PR DESCRIPTION
This is the pg part of https://github.com/kwilteam/kwil-db/pull/1413 that went into `release-v0.9`.

This updates the base postgres image to 16.8, and increases `max_locks_per_transaction` to 4096 (from 256).