### PR TITLE
trigger next round without waiting for the constant blockProposal dur…

### DIFF
--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -28,6 +28,7 @@ type Mempool interface {
 	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
 	Store(types.Hash, *ktypes.Transaction) (have, rejected bool)
 	TxsAvailable() bool
+	Size() (totalBytes, numTxns int)
 }
 
 // BlockStore includes both txns and blocks


### PR DESCRIPTION
This PR does 2 things:
- Don't download / request the block upon receiving `blkAnn` messages, if we already downloaded it during `blkProp` message
- bypass the idle wait timeout of `blockProposal` timeout, if leader has enough transactions to fill the mempool.