### PR TITLE
node,peers: proposal annoucement and PEX fixes

### DIFF
--- a/node/dht.go
+++ b/node/dht.go
@@ -23,9 +23,16 @@ import (
 // Higher level logic will be needed for the aggregation, and fallback to
 // next-best shapshots in the event that restore of the current best fails.
 
-func makeDHT(ctx context.Context, h host.Host, peers []peer.AddrInfo, mode dht.ModeOpt) (*dht.IpfsDHT, error) {
+func makeDHT(ctx context.Context, h host.Host, peers []peer.AddrInfo, mode dht.ModeOpt, pex bool) (*dht.IpfsDHT, error) {
 	// Create a DHT
-	kadDHT, err := dht.New(ctx, h, dht.BootstrapPeers(peers...), dht.Mode(mode))
+	opts := []dht.Option{
+		dht.BootstrapPeers(peers...),
+		dht.Mode(mode),
+	}
+	if !pex {
+		opts = append(opts, dht.DisableAutoRefresh()) // just use connected peers
+	}
+	kadDHT, err := dht.New(ctx, h, opts...)
 	if err != nil {
 		return nil, err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -240,7 +240,7 @@ func (n *Node) Start(ctx context.Context) error {
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	ps, err := pubsub.NewGossipSub(ctx, n.host)
+	ps, err := pubsub.NewGossipSub(ctx, n.host, pubsub.WithPeerExchange(n.P2PService.PEX()))
 	if err != nil {
 		return err
 	}

--- a/node/node.go
+++ b/node/node.go
@@ -136,6 +136,8 @@ type Node struct {
 	// from gossip, to consensus engine for calculating best height of the validators during blocksync.
 	// discResp chan types.DiscoveryResponse
 
+	blkPropHandlerMtx sync.Mutex // atomicity of proposal check and retrieval
+
 	wg  sync.WaitGroup
 	log log.Logger
 }

--- a/node/nogossip.go
+++ b/node/nogossip.go
@@ -69,7 +69,7 @@ func (n *Node) txAnnStreamHandler(s network.Stream) {
 	ctx := context.Background()
 	if err := n.ce.QueueTx(ctx, &tx); err != nil {
 		n.log.Warnf("tx %v failed check: %v", txHash, err)
-		return // must mempool.Remove (fetched must still be false here)
+		return
 	}
 
 	// re-announce

--- a/node/peers/peers.go
+++ b/node/peers/peers.go
@@ -316,7 +316,6 @@ func (pm *PeerMan) maintainMinPeers(ctx context.Context) {
 				} else {
 					pm.log.Infof("Connected to peer %s", peerIDStringer(pid))
 					added++
-
 				}
 			}
 
@@ -344,7 +343,9 @@ func (pm *PeerMan) startPex(ctx context.Context) {
 			go func() {
 				var count int
 				for peer := range peerChan {
+
 					if pm.addPeerAddrs(peer) {
+						pm.log.Info("Found new peer %v, connecting", peerIDStringer(peer.ID))
 						// TODO: connection manager, with limits
 						if err = pm.c.Connect(ctx, peer); err != nil {
 							pm.log.Warnf("Failed to connect to %s: %v", peerIDStringer(peer.ID), CompressDialError(err))

--- a/node/statesync_test.go
+++ b/node/statesync_test.go
@@ -57,7 +57,7 @@ func newTestStatesyncer(ctx context.Context, t *testing.T, mn mock.Mocknet, root
 		return nil, nil, nil, nil, nil, err
 	}
 
-	dht, err := makeDHT(ctx, h, nil, dht.ModeServer)
+	dht, err := makeDHT(ctx, h, nil, dht.ModeServer, true)
 	if err != nil {
 		return nil, nil, nil, nil, nil, err
 	}


### PR DESCRIPTION
This fixes several things:
- the block proposal announcement stream handler `blkPropStreamHandler` could be abused to download block proposals multiple times because the sequence of `AcceptProposal` => download => `NotifyBlockProposal` was not made atomic.  This is fixed with a mutex.
- `AcceptProposal` does leader signature verification *first* before any other action such as retrieving the block from the block store.  This allows the proposal handler to return quite quickly if the annoucement was illegitimate (spam)
- followers, such as normal validators, now immediately reannounce a block proposal to their peers on first receipt of a new valid proposal.  This allows sparse network connectivity, including validators that are not directly connected to the leader.
- It was discovered that both gossipsub and dht external modules were initiating new peer connections using the `host.Host` directly.  This is undesirable if PEX is disabled in the application, so both are now created with appropriate options to disable their own peer discovery mechanisms if kwild is started with `p2p.pex = false`.
- Finally, we were ignoring the `cfg.P2P.TargetConnections` field.  It is now passed to the peer manager, where it is considered in `maintainMinPeers`.  Previously a hard coded value was used.