### PR TITLE
node,consensus: no duplicate proposals allowed

### DIFF
--- a/node/consensus/engine.go
+++ b/node/consensus/engine.go
@@ -577,6 +577,8 @@ func (ce *ConsensusEngine) resetEventLoop(ctx context.Context) {
 func (ce *ConsensusEngine) handleConsensusMessages(ctx context.Context, msg consensusMessage) {
 	ce.log.Info("Consensus message received", "type", msg.MsgType, "sender", hex.EncodeToString(msg.Sender))
 
+	defer msg.Handled()
+
 	switch v := msg.Msg.(type) {
 	case *blockProposal:
 		if err := ce.processBlockProposal(ctx, v); err != nil {

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -279,7 +279,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkProp",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -306,7 +306,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkProp",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -335,7 +335,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -344,7 +344,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk)
+						val.NotifyBlockProposal(blkProp2.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -371,7 +371,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk)
+						val.NotifyBlockProposal(blkProp2.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -380,7 +380,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -407,7 +407,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -426,7 +426,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew (ignored)",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Committed, 1, zeroHash)
@@ -443,7 +443,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -461,7 +461,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk)
+						val.NotifyBlockProposal(blkProp2.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -488,7 +488,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -524,7 +524,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -569,7 +569,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkProp",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk)
+						val.NotifyBlockProposal(blkProp1.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -614,7 +614,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk)
+						val.NotifyBlockProposal(blkProp2.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -653,7 +653,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk)
+						val.NotifyBlockProposal(blkProp2.blk, nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -18,7 +18,7 @@ type ConsensusEngine interface {
 	InCatchup() bool
 
 	AcceptProposal(height int64, blkID, prevBlkID types.Hash, leaderSig []byte, timestamp int64) bool
-	NotifyBlockProposal(blk *ktypes.Block)
+	NotifyBlockProposal(blk *ktypes.Block, done func())
 
 	AcceptCommit(height int64, blkID types.Hash, hdr *ktypes.BlockHeader, ci *types.CommitInfo, leaderSig []byte) bool
 	NotifyBlockCommit(blk *ktypes.Block, ci *types.CommitInfo, blkID types.Hash, doneFn func())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -340,7 +340,7 @@ func (ce *dummyCE) NotifyResetState(height int64, txIDs []types.Hash, sender []b
 	}
 }
 
-func (ce *dummyCE) NotifyBlockProposal(blk *ktypes.Block) {
+func (ce *dummyCE) NotifyBlockProposal(blk *ktypes.Block, _ func()) {
 	if ce.blockPropHandler != nil {
 		ce.blockPropHandler(blk)
 		return


### PR DESCRIPTION
This addresses a strange proposal announcement amplification that can occur given the right timing, which @charithabandi  observed once but could not easily reproduce.

In short, to support reannoucement of block proposals as well as preventing malicious spam proposals from stacking up behind the consensus event loop, we made the entire proposal stream handler atomic w.r.t. `AcceptProposal` => download = `NotifyBlockProposal`.  **However**, `NotifyBlockProposal` is mostly asynchronous, meaning the next call to `AcceptProposal` will return true and allow the same proposal, which includes a full block, to be downloaded again and queued in another consensus msg for `NotifyBlockProposal`.

To resolve this, we take a nearly identical approach to that used with `AcceptCommit` and its stream handler.  The main difference being that we completely block any subsequent proposal until the prior is processed (either fully rejected or fully accepted and block execution begun).