### PR TITLE
core/types,node/types: add cached tx hash to ktypes.Transaction, create node/types.Tx

### DIFF
--- a/core/types/block.go
+++ b/core/types/block.go
@@ -63,7 +63,7 @@ func NewBlock(height int64, prevHash, appHash, valSetHash, paramsHash Hash, stam
 	numTxns := len(txns)
 	txHashes := make([]Hash, numTxns)
 	for i, tx := range txns {
-		txHashes[i] = tx.Hash()
+		txHashes[i] = tx.HashCache()
 	}
 	merkelRoot := CalcMerkleRoot(txHashes)
 	hdr := &BlockHeader{
@@ -91,7 +91,7 @@ func (b *Block) Hash() Hash {
 func (b *Block) MerkleRoot() Hash {
 	txHashes := make([]Hash, len(b.Txns))
 	for i, tx := range b.Txns {
-		txHashes[i] = tx.Hash()
+		txHashes[i] = tx.HashCache()
 	}
 	return CalcMerkleRoot(txHashes)
 }

--- a/core/types/block.go
+++ b/core/types/block.go
@@ -88,7 +88,7 @@ func (b *Block) Hash() Hash {
 	return b.Header.Hash()
 }
 
-func (b *Block) MerkleRoot() Hash {
+func (b *Block) CalcMerkleRoot() Hash {
 	txHashes := make([]Hash, len(b.Txns))
 	for i, tx := range b.Txns {
 		txHashes[i] = tx.HashCache()

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -222,8 +222,9 @@ func (bp *BlockProcessor) loadNetworkParams(ctx context.Context, readTx sql.Tx) 
 	return networkParams, nil
 }
 
-func (bp *BlockProcessor) CheckTx(ctx context.Context, tx *ktypes.Transaction, height int64, blockTime time.Time, recheck bool) error {
-	txHash := tx.Hash()
+func (bp *BlockProcessor) CheckTx(ctx context.Context, ntx *types.Tx, height int64, blockTime time.Time, recheck bool) error {
+	tx := ntx.Transaction
+	txHash := ntx.Hash()
 
 	// If the network is halted for migration, we reject all transactions.
 	if bp.chainCtx.NetworkParameters.MigrationStatus == ktypes.MigrationCompleted {
@@ -678,7 +679,7 @@ func (bp *BlockProcessor) Commit(ctx context.Context, req *ktypes.CommitRequest)
 // that consensus limits such as the maximum block size, maxVotesPerTx are met. It also adds
 // validator vote transactions for events observed by the leader. This function is
 // used exclusively by the leader node to prepare the proposal block.
-func (bp *BlockProcessor) PrepareProposal(ctx context.Context, txs []*ktypes.Transaction) (finalTxs []*ktypes.Transaction, invalidTxs []*ktypes.Transaction, err error) {
+func (bp *BlockProcessor) PrepareProposal(ctx context.Context, txs []*types.Tx) (finalTxs []*ktypes.Transaction, invalidTxs []*ktypes.Transaction, err error) {
 	// unmarshal and index the transactions
 	return bp.prepareBlockTransactions(ctx, txs)
 }

--- a/node/block_processor/status.go
+++ b/node/block_processor/status.go
@@ -42,7 +42,7 @@ func (bp *BlockProcessor) BlockExecutionStatus() *ktypes.BlockExecutionStatus {
 func (bp *BlockProcessor) initBlockExecutionStatus(blk *ktypes.Block) []ktypes.Hash {
 	txIDs := make([]ktypes.Hash, len(blk.Txns))
 	for i, tx := range blk.Txns {
-		txID := tx.Hash()
+		txID := tx.HashCache()
 		txIDs[i] = txID
 	}
 	bp.statusMu.Lock()

--- a/node/block_processor/transactions_test.go
+++ b/node/block_processor/transactions_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/kwilteam/kwil-db/core/log"
 	"github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/txapp"
+	nodetypes "github.com/kwilteam/kwil-db/node/types"
 	"github.com/kwilteam/kwil-db/node/types/sql"
 )
 
@@ -237,7 +238,12 @@ func TestPrepareMempoolTxns(t *testing.T) {
 
 			chainCtx.NetworkParameters.DisabledGasCosts = !tt.gas
 
-			got, invalids, err := bp.prepareBlockTransactions(ctx, tt.txs)
+			ntxs := make([]*nodetypes.Tx, len(tt.txs))
+			for i, tx := range tt.txs {
+				ntxs[i] = nodetypes.NewTx(tx)
+			}
+
+			got, invalids, err := bp.prepareBlockTransactions(ctx, ntxs)
 			require.NoError(t, err)
 
 			if len(got) != len(tt.want) {

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -34,7 +34,7 @@ func (ce *ConsensusEngine) validateBlock(blk *ktypes.Block) error {
 	}
 
 	// Verify the merkle root of the block transactions
-	merkleRoot := blk.MerkleRoot()
+	merkleRoot := blk.CalcMerkleRoot() // NOTE: this expects CalcMerkleRoot to use tx.HashCache() to prepare the Transaction's internal hash cache
 	if merkleRoot != blk.Header.MerkleRoot {
 		return fmt.Errorf("merkleroot mismatch, expected %v, got %v", merkleRoot, blk.Header.MerkleRoot)
 	}

--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -117,14 +117,13 @@ func (ce *ConsensusEngine) lastBlock() (int64, types.Hash, time.Time) {
 // It is an error if the transaction is already in the mempool.
 // It is an error if the transaction fails CheckTx.
 // This method holds the mempool lock for the duration of the call.
-func (ce *ConsensusEngine) QueueTx(ctx context.Context, tx *ktypes.Transaction) error {
+func (ce *ConsensusEngine) QueueTx(ctx context.Context, tx *types.Tx) error {
 	height, _, timestamp := ce.lastBlock()
 
 	ce.mempoolMtx.Lock()
 	defer ce.mempoolMtx.Unlock()
 
-	txHash := tx.Hash()
-	have, rejected := ce.mempool.Store(txHash, tx)
+	have, rejected := ce.mempool.Store(tx)
 	if have {
 		return ktypes.ErrTxAlreadyExists
 	}
@@ -135,7 +134,7 @@ func (ce *ConsensusEngine) QueueTx(ctx context.Context, tx *ktypes.Transaction) 
 	const recheck = false
 	err := ce.blockProcessor.CheckTx(ctx, tx, height, timestamp, recheck)
 	if err != nil {
-		ce.mempool.Remove(txHash)
+		ce.mempool.Remove(tx.Hash())
 		return err
 	}
 
@@ -181,9 +180,9 @@ func (ce *ConsensusEngine) lastBlockInternal() (int64, time.Time) {
 
 // recheckTxFn creates a tx recheck function for the mempool that assumes the
 // provided height and timestamp for each call.
-func (ce *ConsensusEngine) recheckTxFn(height int64, timestamp time.Time) func(ctx context.Context, tx *ktypes.Transaction) error {
+func (ce *ConsensusEngine) recheckTxFn(height int64, timestamp time.Time) func(ctx context.Context, tx *types.Tx) error {
 	// height, _, timestamp := ce.lastBlock()
-	return func(ctx context.Context, tx *ktypes.Transaction) error {
+	return func(ctx context.Context, tx *types.Tx) error {
 		const recheck = true
 		return ce.blockProcessor.CheckTx(ctx, tx, height, timestamp, recheck)
 	}
@@ -192,8 +191,10 @@ func (ce *ConsensusEngine) recheckTxFn(height int64, timestamp time.Time) func(c
 // BroadcastTx checks the transaction with the mempool and if the verification
 // is successful, broadcasts it to the network. The TxResult will be nil unless
 // sync is set to 1, in which case the BroadcastTx returns only after it is
-// successfully executed in a committed block.
-func (ce *ConsensusEngine) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, sync uint8) (types.Hash, *ktypes.TxResult, error) {
+// successfully executed in a committed block. This method is effectively
+// [QueueTx] followed, by P2P broadcast of the transaction, followed by
+// optionally waiting for the transaction to be mined.
+func (ce *ConsensusEngine) BroadcastTx(ctx context.Context, tx *types.Tx, sync uint8) (types.Hash, *ktypes.TxResult, error) {
 	// check and store the transaction in the mempool
 	if err := ce.QueueTx(ctx, tx); err != nil {
 		return types.Hash{}, nil, err
@@ -205,7 +206,7 @@ func (ce *ConsensusEngine) BroadcastTx(ctx context.Context, tx *ktypes.Transacti
 	if ce.txAnnouncer != nil {
 		// We can't use parent context 'cause it's canceled in the caller, which
 		// could be the RPC request. handler.  This shouldn't be CE's problem...
-		go ce.txAnnouncer(context.Background(), tx)
+		go ce.txAnnouncer(context.Background(), tx.Transaction)
 	}
 
 	// If sync is set to 1, wait for the transaction to be committed in a block.
@@ -301,7 +302,7 @@ func (ce *ConsensusEngine) commit(ctx context.Context) error {
 
 	// remove transactions from the mempool
 	for idx, txn := range blkProp.blk.Txns {
-		txHash := txn.Hash()
+		txHash := txn.HashCache()
 		ce.mempool.Remove(txHash)
 
 		txRes := ce.state.blockRes.txResults[idx]

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -23,10 +23,10 @@ type DB interface {
 }
 
 type Mempool interface {
-	PeekN(maxTxns, totalSizeLimit int) []types.NamedTx
+	PeekN(maxTxns, totalSizeLimit int) []*types.Tx
 	Remove(txid types.Hash)
 	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
-	Store(types.Hash, *ktypes.Transaction) (have, rejected bool)
+	Store(*types.Tx) (have, rejected bool)
 	TxsAvailable() bool
 	Size() (totalBytes, numTxns int)
 }
@@ -44,13 +44,13 @@ type BlockProcessor interface {
 	InitChain(ctx context.Context) (int64, []byte, error)
 	SetCallbackFns(applyBlockFn blockprocessor.BroadcastTxFn, addPeer, removePeer func(string) error)
 
-	PrepareProposal(ctx context.Context, txs []*ktypes.Transaction) (finalTxs []*ktypes.Transaction, invalidTxs []*ktypes.Transaction, err error)
+	PrepareProposal(ctx context.Context, txs []*types.Tx) (finalTxs []*ktypes.Transaction, invalidTxs []*ktypes.Transaction, err error)
 	ExecuteBlock(ctx context.Context, req *ktypes.BlockExecRequest) (*ktypes.BlockExecResult, error)
 	Commit(ctx context.Context, req *ktypes.CommitRequest) error
 	Rollback(ctx context.Context, height int64, appHash ktypes.Hash) error
 	Close() error
 
-	CheckTx(ctx context.Context, tx *ktypes.Transaction, height int64, blockTime time.Time, recheck bool) error
+	CheckTx(ctx context.Context, tx *types.Tx, height int64, blockTime time.Time, recheck bool) error
 
 	GetValidators() []*ktypes.Validator
 	ConsensusParams() *ktypes.NetworkParameters

--- a/node/consensus/leader.go
+++ b/node/consensus/leader.go
@@ -217,11 +217,7 @@ func (ce *ConsensusEngine) createBlockProposal(ctx context.Context) (*blockPropo
 	defer ce.mempoolMtx.Unlock()
 
 	totalTxSizeLimit := ce.ConsensusParams().MaxBlockSize
-	nTxs := ce.mempool.PeekN(maxNumTxnsInBlock, int(totalTxSizeLimit))
-	txns := make([]*ktypes.Transaction, len(nTxs))
-	for i, ntx := range nTxs {
-		txns[i] = ntx.Tx
-	}
+	txns := ce.mempool.PeekN(maxNumTxnsInBlock, int(totalTxSizeLimit))
 
 	finalTxs, invalidTxs, err := ce.blockProcessor.PrepareProposal(ctx, txns)
 	if err != nil {

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -31,8 +31,8 @@ type ConsensusEngine interface {
 
 	Start(ctx context.Context, fns consensus.BroadcastFns, peerFns consensus.WhitelistFns) error
 
-	QueueTx(ctx context.Context, tx *ktypes.Transaction) error
-	BroadcastTx(ctx context.Context, tx *ktypes.Transaction, sync uint8) (ktypes.Hash, *ktypes.TxResult, error)
+	QueueTx(ctx context.Context, tx *types.Tx) error
+	BroadcastTx(ctx context.Context, tx *types.Tx, sync uint8) (ktypes.Hash, *ktypes.TxResult, error)
 
 	ConsensusParams() *ktypes.NetworkParameters
 	CancelBlockExecution(height int64, txIDs []types.Hash) error

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -353,11 +353,11 @@ func (ce *dummyCE) Role() types.Role {
 	return types.RoleLeader
 }
 
-func (ce *dummyCE) QueueTx(ctx context.Context, tx *ktypes.Transaction) error {
+func (ce *dummyCE) QueueTx(ctx context.Context, tx *types.Tx) error {
 	return nil
 }
 
-func (ce *dummyCE) BroadcastTx(ctx context.Context, tx *ktypes.Transaction, sync uint8) (ktypes.Hash, *ktypes.TxResult, error) {
+func (ce *dummyCE) BroadcastTx(ctx context.Context, tx *types.Tx, sync uint8) (ktypes.Hash, *ktypes.TxResult, error) {
 	return types.Hash{}, nil, nil
 }
 

--- a/node/services/jsonrpc/chainsvc/service.go
+++ b/node/services/jsonrpc/chainsvc/service.go
@@ -44,7 +44,7 @@ type Node interface {
 	BlockResultByHash(hash ktypes.Hash) ([]ktypes.TxResult, error)
 	ChainTx(hash ktypes.Hash) (*chaintypes.Tx, error)
 	BlockHeight() int64
-	ChainUnconfirmedTx(limit int) (int, []nodetypes.NamedTx)
+	ChainUnconfirmedTx(limit int) (int, []*nodetypes.Tx)
 	ConsensusParams() *ktypes.NetworkParameters
 }
 
@@ -287,15 +287,15 @@ func (svc *Service) UnconfirmedTxs(_ context.Context, req *chainjson.Unconfirmed
 	}, nil
 }
 
-// The admin Service must be usable as a Svc registered with a JSON-RPC Server.
+// The chain Service must be usable as a Svc registered with a JSON-RPC Server.
 var _ rpcserver.Svc = (*Service)(nil)
 
-func convertNamedTxs(txs []nodetypes.NamedTx) []chaintypes.NamedTx {
+func convertNamedTxs(txs []*nodetypes.Tx) []chaintypes.NamedTx {
 	res := make([]chaintypes.NamedTx, len(txs))
 	for i, tx := range txs {
 		res[i] = chaintypes.NamedTx{
-			Hash: tx.Hash,
-			Tx:   tx.Tx,
+			Hash: tx.Hash(),
+			Tx:   tx.Transaction,
 		}
 	}
 	return res

--- a/node/store/store.go
+++ b/node/store/store.go
@@ -316,7 +316,7 @@ func (bki *BlockStore) Store(blk *ktypes.Block, commitInfo *types.CommitInfo) er
 
 	txHashes := make([]ktypes.Hash, blk.Header.NumTxns)
 	for i, tx := range blk.Txns {
-		txHashes[i] = tx.Hash()
+		txHashes[i] = tx.HashCache()
 	}
 
 	txn := bki.db.NewTransaction(true)

--- a/node/tx.go
+++ b/node/tx.go
@@ -104,13 +104,11 @@ func (n *Node) txGetStreamHandler(s network.Stream) {
 	}
 
 	// first check mempool
-	tx := n.mp.Get(req.Hash)
-	if tx != nil {
-		tx.WriteTo(s)
+	ntx := n.mp.Get(req.Hash)
+	if ntx != nil {
+		ntx.Transaction.WriteTo(s)
 		return
 	}
-
-	// this is racy, and should be different in product
 
 	// then confirmed tx index
 	tx, _, _, _, err := n.bki.GetTx(req.Hash)

--- a/node/types/interfaces.go
+++ b/node/types/interfaces.go
@@ -66,11 +66,10 @@ type TxGetter interface {
 
 type MemPool interface {
 	Size() (count, bts int)
-	ReapN(int) []NamedTx
-	Get(Hash) *types.Transaction
+	Get(Hash) *Tx
 	Remove(Hash)
-	Store(Hash, *types.Transaction) (found, rejected bool)
-	PeekN(maxNumTxns, maxTotalTxBytes int) []NamedTx
+	Store(*Tx) (found, rejected bool)
+	PeekN(maxNumTxns, maxTotalTxBytes int) []*Tx
 	PreFetch(txid Hash) (ok bool, done func()) // should be app level instead
 }
 
@@ -79,9 +78,4 @@ type QualifiedBlock struct { // basically just caches the hash
 	Hash     Hash
 	Proposed bool
 	AppHash  *Hash
-}
-
-type NamedTx struct {
-	Hash Hash
-	Tx   *types.Transaction
 }

--- a/node/types/transaction.go
+++ b/node/types/transaction.go
@@ -1,0 +1,44 @@
+package types
+
+import "github.com/kwilteam/kwil-db/core/types"
+
+// Tx represents an immutable transaction. The constructor will compute the
+// hash, which it will return directly from the Hash method. This means that the
+// hash is only computed once. However, it is important note that the
+// transaction fields should not be changed, because the hash will not be
+// correct.
+//
+// This is intended for use in node internals, primarily mempool and consensus
+// engine where the hash is repeatedly accessed on deep call stacks.
+//
+// In most cases, you should use the Tx type from the core/types package. Be
+// aware of the cost of computing the hash, and avoid recomputing it.
+//
+// If you use this type, be aware of the mutability caveat, and consider the
+// cost of the memory allocation, and the persistence of the hash potentially
+// after it is no longer needed.
+type Tx struct {
+	*types.Transaction
+	hash types.Hash // computed on construction
+}
+
+// NewTx creates a new Tx from a *core/types.Transaction. This computes and
+// stores the hash, which is returned by the [Hash] method without any
+// recomputation. As such, the transaction fields should not be changed since
+// the hash is never recomputed.
+func NewTx(tx *types.Transaction) *Tx {
+	return &Tx{
+		Transaction: tx,
+		hash:        tx.Hash(),
+	}
+}
+
+// Hash returns the hash computed on construction. This shadows the Hash method
+// of the *core/types.Transaction.
+func (tx Tx) Hash() types.Hash {
+	return tx.hash
+}
+
+func (tx Tx) Bytes() []byte {
+	return tx.Transaction.Bytes()
+}


### PR DESCRIPTION
This updates `core/types.Transaction` a.k.a. `ktypes.Transation` with an unexported `cachedHash` field, which is only populated or referenced via the new `HashCache` method, rather than modifying the `Hash` method to do this automatically.  A few reasons are outlined in the docs, but they include concurrency concerns, needless allocs in many cases, the tx mutability gotchas particularly in client side applications.

This also removes the `node/types.NamedTx` which was used in a handful of places to pair the hash with the `core/types.Transaction`, replacing `NamedTx` with `node/types.Tx` for brevity.  This new types adds a constructor `NewTx` that computes the has on construction.  The `Hash()` method of this type shadows the embedded `types.Transaction`'s method to return this stored hash.  This should be less likely to become an issue since it is "internal" to the `node/...` packages, and the hash being computed in the constructor avoids any concurrency concerns.  Plus it is documented explicitly as an _immutable_ transaction type.

The `node/types.Tx` with it's construction-time hash storage is primarily used in mempool and the CE.
The `HashCache` method is used in other places that deal with a `core/types.Block`, which is necessarily defined in terms of a `core/types.Transaction`.