### PR TITLE
order transactions announcements in the order they are received

### DIFF
--- a/node/consensus/block.go
+++ b/node/consensus/block.go
@@ -212,7 +212,7 @@ func (ce *ConsensusEngine) BroadcastTx(ctx context.Context, tx *types.Tx, sync u
 	if ce.txAnnouncer != nil {
 		// We can't use parent context 'cause it's canceled in the caller, which
 		// could be the RPC request. handler.  This shouldn't be CE's problem...
-		go ce.txAnnouncer(context.Background(), tx.Transaction)
+		ce.txAnnouncer(context.Background(), tx.Transaction, txHash)
 	}
 
 	// If sync is set to 1, wait for the transaction to be committed in a block.

--- a/node/consensus/engine.go
+++ b/node/consensus/engine.go
@@ -224,7 +224,7 @@ type ProposalBroadcaster func(ctx context.Context, blk *ktypes.Block)
 type BlkAnnouncer func(ctx context.Context, blk *ktypes.Block, ci *types.CommitInfo)
 
 // TxAnnouncer broadcasts the new transaction to the network
-type TxAnnouncer func(ctx context.Context, tx *ktypes.Transaction)
+type TxAnnouncer func(ctx context.Context, tx *ktypes.Transaction, txID types.Hash)
 
 // AckBroadcaster gossips the ack/nack messages to the network
 // type AckBroadcaster func(ack bool, height int64, blkID types.Hash, appHash *types.Hash, Signature []byte) error

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -938,7 +938,7 @@ func mockVoteBroadcaster(msg *types.AckRes) error {
 
 func mockBlkAnnouncer(_ context.Context, blk *ktypes.Block, ci *types.CommitInfo) {}
 
-func mockTxAnnouncer(ctx context.Context, tx *ktypes.Transaction) {}
+func mockTxAnnouncer(ctx context.Context, tx *ktypes.Transaction, txID types.Hash) {}
 
 func mockResetStateBroadcaster(_ int64, _ []ktypes.Hash) error {
 	return nil


### PR DESCRIPTION
This PR ensures the FIFO consistency to the outgoing transaction announcements to maintain the nonce ordering.  So all the transaction announcements are routed through a TxQueue to enforce this order.
