### PR TITLE
rpc: add authenticated query

### DIFF
--- a/core/rpc/client/user/jsonrpc/methods.go
+++ b/core/rpc/client/user/jsonrpc/methods.go
@@ -154,6 +154,17 @@ func (cl *Client) Query(ctx context.Context, query string, params map[string]*ty
 	return (*types.QueryResult)(res), nil
 }
 
+func (cl *Client) AuthenticatedQuery(ctx context.Context, msg *types.AuthenticatedQuery) (*types.QueryResult, error) {
+	cmd := msg
+	res := &userjson.QueryResponse{}
+	err := cl.CallMethod(ctx, string(userjson.MethodAuthenticatedQuery), cmd, res)
+	if err != nil {
+		return nil, err
+	}
+
+	return (*types.QueryResult)(res), nil
+}
+
 func (cl *Client) TxQuery(ctx context.Context, txHash types.Hash) (*types.TxQueryResponse, error) {
 	cmd := &userjson.TxQueryRequest{
 		TxHash: txHash,

--- a/core/rpc/client/user/txsvc.go
+++ b/core/rpc/client/user/txsvc.go
@@ -20,6 +20,7 @@ type TxSvcClient interface {
 	GetAccount(ctx context.Context, identifier *types.AccountID, status types.AccountStatus) (*types.Account, error)
 	Ping(ctx context.Context) (string, error)
 	Query(ctx context.Context, query string, params map[string]*types.EncodedValue) (*types.QueryResult, error)
+	AuthenticatedQuery(ctx context.Context, msg *types.AuthenticatedQuery) (*types.QueryResult, error)
 	TxQuery(ctx context.Context, txHash types.Hash) (*types.TxQueryResponse, error)
 
 	// Migration methods

--- a/core/rpc/json/user/commands.go
+++ b/core/rpc/json/user/commands.go
@@ -65,6 +65,9 @@ const (
 // CallRequest contains the request parameters for MethodCall.
 type CallRequest = types.CallMessage
 
+// AuthenticatedQueryRequest contains the request parameters for MethodAuthenticatedQuery.
+type AuthenticatedQueryRequest = types.AuthenticatedQuery
+
 // ChainInfoRequest contains the request parameters for MethodChainInfo.
 type ChainInfoRequest struct{}
 

--- a/core/rpc/json/user/methods.go
+++ b/core/rpc/json/user/methods.go
@@ -13,6 +13,7 @@ const (
 	MethodDatabases             jsonrpc.Method = "user.databases"
 	MethodPrice                 jsonrpc.Method = "user.estimate_price"
 	MethodQuery                 jsonrpc.Method = "user.query"
+	MethodAuthenticatedQuery    jsonrpc.Method = "user.authenticated_query"
 	MethodTxQuery               jsonrpc.Method = "user.tx_query"
 	MethodSchema                jsonrpc.Method = "user.schema"
 	MethodUpdateProposalStatus  jsonrpc.Method = "user.update_proposal_status"

--- a/node/engine/interpreter/roles.go
+++ b/node/engine/interpreter/roles.go
@@ -35,64 +35,106 @@ func newAccessController(ctx context.Context, db sql.DB) (*accessController, err
 		knownNamespaces: make(map[string]struct{}),
 	}
 
-	getRolesStmt := `SELECT r.name, array_agg(rp.privilege_type::text), array_agg(n.name)
+	// register all namespaces
+	namespaceList, err := listNamespaces(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, ns := range namespaceList {
+		ac.registerNamespace(ns.Name)
+	}
+
+	// we order global privileges first so that they get applied,
+	// and then we apply more specific privileges on top of that.
+	getRolesStmt := `SELECT r.name,
+		array_agg(rp.privilege_type::text order by rp.namespace_id nulls first),
+		array_agg(n.name order by rp.namespace_id nulls first),
+		array_agg(rp.granted order by rp.namespace_id nulls first)
 	FROM kwild_engine.roles r
 	LEFT JOIN kwild_engine.role_privileges rp ON rp.role_id = r.id
 	LEFT JOIN kwild_engine.namespaces n ON rp.namespace_id = n.id
-	GROUP BY r.name
-	ORDER BY 1,2,3`
+	GROUP BY r.id
+	ORDER BY 1,2,3,4`
 
 	// list all roles, their perms, and users
 	var roleName string
 	var privileges []*string
 	var namespaces []*string
-	err := queryRowFunc(ctx, db, getRolesStmt, []any{&roleName, &privileges, &namespaces}, func() error {
-		perm := &perms{
-			namespacePrivileges: make(map[string]map[privilege]struct{}),
-			globalPrivileges:    make(map[privilege]struct{}),
-		}
+	var granted []*bool
+	err = queryRowFunc(ctx, db, getRolesStmt, []any{&roleName, &privileges, &namespaces, &granted}, func() error {
+		perm := ac.newPerm()
 
 		if len(privileges) != len(namespaces) {
 			return fmt.Errorf(`unexpected error: length of privileges and namespaces do not match. this is an internal bug`)
 		}
+		if len(privileges) != len(granted) {
+			return fmt.Errorf(`unexpected error: length of privileges and granted do not match. this is an internal bug`)
+		}
 
-		for i, priv := range privileges {
-			if priv == nil {
-				// priv can be nil if the role has no privileges
-				if len(namespaces) != 1 {
-					return fmt.Errorf(`unexpected error: nil privilege in non-nil list of privileges. this is an internal bug`)
-				}
-				if namespaces[i] != nil {
-					return fmt.Errorf(`unexpected error: nil privilege in non-nil list of namespaces. this is an internal bug`)
-				}
+		// for i, priv := range privileges {
+		// 	if priv == nil {
+		// 		// priv can be nil if the role has no privileges
+		// 		if len(namespaces) != 1 {
+		// 			return fmt.Errorf(`unexpected error: nil privilege in non-nil list of privileges. this is an internal bug`)
+		// 		}
+		// 		if namespaces[i] != nil {
+		// 			return fmt.Errorf(`unexpected error: nil privilege in non-nil list of namespaces. this is an internal bug`)
+		// 		}
+		// 		continue
+		// 	}
+
+		// 	// check that the privilege exists
+		// 	// This should never not be the case, but it is good to check
+		// 	_, ok := privilegeNames[privilege(*priv)]
+		// 	if !ok {
+		// 		return fmt.Errorf(`unknown privilege "%s" stored in DB`, *priv)
+		// 	}
+
+		// 	// if namespace is nil, then it is a global privilege
+		// 	// We still register all global privileges with each namespace
+		// 	if namespaces[i] == nil {
+		// 		perm.globalPrivileges[privilege(*priv)] = struct{}{}
+
+		// 		for nsPriv, np := range perm.namespacePrivileges {
+		// 			np[privilege(*priv)] = struct{}{}
+
+		// 			perm.namespacePrivileges[nsPriv] = np
+		// 		}
+		// 	} else {
+		// 		if _, ok := perm.namespacePrivileges[*namespaces[i]]; !ok {
+		// 			perm.namespacePrivileges[*namespaces[i]] = make(map[privilege]struct{})
+		// 		}
+
+		// 		perm.namespacePrivileges[*namespaces[i]][privilege(*priv)] = struct{}{}
+		// 	}
+		// }
+
+		for i, p := range privileges {
+			// can be nil if the role has no privileges
+			if p == nil {
 				continue
 			}
 
-			// check that the privilege exists
-			// This should never not be the case, but it is good to check
-			_, ok := privilegeNames[privilege(*priv)]
+			// should never happen, but it is good to check in case
+			// we make a mistake in the future
+			_, ok := privilegeNames[privilege(*p)]
 			if !ok {
-				return fmt.Errorf(`unknown privilege "%s" stored in DB`, *priv)
+				return fmt.Errorf(`unknown privilege "%s" stored in DB`, *p)
 			}
 
-			// if namespace is nil, then it is a global privilege
-			// We still register all global privileges with each namespace
-			if namespaces[i] == nil {
-				perm.globalPrivileges[privilege(*priv)] = struct{}{}
+			namespace := namespaces[i]
+			granted := granted[i]
+			if granted == nil {
+				// unsure if this can happen
+				panic("unexpected error: granted is nil")
+			}
 
-				for nsPriv, np := range perm.namespacePrivileges {
-					np[privilege(*priv)] = struct{}{}
-
-					perm.namespacePrivileges[nsPriv] = np
-				}
+			if *granted {
+				perm.grant(namespace, privilege(*p))
 			} else {
-				if _, ok := perm.namespacePrivileges[*namespaces[i]]; !ok {
-					perm.namespacePrivileges[*namespaces[i]] = make(map[privilege]struct{})
-				}
-
-				perm.namespacePrivileges[*namespaces[i]][privilege(*priv)] = struct{}{}
+				perm.revoke(namespace, privilege(*p))
 			}
-
 		}
 
 		ac.roles[roleName] = perm
@@ -171,17 +213,23 @@ func (a *accessController) CreateRole(ctx context.Context, db sql.DB, role strin
 		return err
 	}
 
+	a.roles[role] = a.newPerm()
+
+	return nil
+}
+
+// newPerm creates a new permission struct. It fills it with all known namespaces.
+func (a *accessController) newPerm() *perms {
 	p := &perms{
 		namespacePrivileges: make(map[string]map[privilege]struct{}),
 		globalPrivileges:    make(map[privilege]struct{}),
 	}
+
 	for ns := range a.knownNamespaces {
 		p.namespacePrivileges[ns] = make(map[privilege]struct{})
 	}
 
-	a.roles[role] = p
-
-	return nil
+	return p
 }
 
 func (a *accessController) DeleteRole(ctx context.Context, db sql.DB, role string) error {
@@ -482,15 +530,21 @@ func grantPrivilegesSQL(ctx context.Context, db sql.DB, roleName string, privile
 
 	if namespace == nil {
 		err := execute(ctx, db, `INSERT INTO kwild_engine.role_privileges (role_id, privilege_type)
-		SELECT r.id, unnest($2::text[])::kwild_engine.privilege_type FROM kwild_engine.roles r WHERE r.name = $1`, roleName, privStrs)
+		SELECT r.id, unnest($2::kwild_engine.privilege_type[]) FROM kwild_engine.roles r WHERE r.name = $1`, roleName, privStrs)
 		return err
 	}
 
-	err := execute(ctx, db, `INSERT INTO kwild_engine.role_privileges (role_id, namespace_id, privilege_type)
-	SELECT r.id, n.id, unnest($3::text[])::kwild_engine.privilege_type FROM kwild_engine.roles r
+	// there are two cases to account for here.
+	// Either the privilege was disallowed globally, or it was specifically revoked
+	// for this namespace. If it was revoked for this namespace, we need to update the row
+	// to say that it has been granted. If it is not allowed globally, we need to insert a new row.
+	// Therefore, we use ON CONFLICT to handle both cases.
+
+	return execute(ctx, db, `INSERT INTO kwild_engine.role_privileges (role_id, namespace_id, privilege_type, granted)
+	SELECT r.id, n.id, unnest($3::kwild_engine.privilege_type[]), true FROM kwild_engine.roles r
 	JOIN kwild_engine.namespaces n ON n.name = $2
-	WHERE r.name = $1`, roleName, *namespace, privStrs)
-	return err
+	WHERE r.name = $1
+	ON CONFLICT (role_id, namespace_id, privilege_type) DO UPDATE SET granted = true`, roleName, *namespace, privStrs)
 }
 
 // revokePrivilegesSQL revokes privileges from a role.
@@ -505,15 +559,19 @@ func revokePrivilegesSQL(ctx context.Context, db sql.DB, roleName string, privil
 
 	if namespace == nil {
 		err := execute(ctx, db, `DELETE FROM kwild_engine.role_privileges
-	WHERE role_id = (SELECT id FROM kwild_engine.roles WHERE name = $1) AND privilege_type::text = ANY($2::text[])`, roleName, privStrs)
+	WHERE role_id = (SELECT id FROM kwild_engine.roles WHERE name = $1) AND privilege_type = ANY($2::kwild_engine.privilege_type[])`, roleName, privStrs)
 		return err
 	}
 
-	err := execute(ctx, db, `DELETE FROM kwild_engine.role_privileges
-	WHERE role_id = (SELECT id FROM kwild_engine.roles WHERE name = $1)
-	AND namespace_id = (SELECT id FROM kwild_engine.namespaces WHERE name = $2)
-	AND privilege_type::text = ANY($3::text[])`, roleName, *namespace, privStrs)
-	return err
+	// there are two cases to account for when a namespace is provided:
+	// either it was epxlicitly granted to the namespace before, or it was granted globally.
+	// Therefore, what we do is insert into the table to say that it has been revoked (which will succeed
+	// if it was granted globally), and if there is a conflict (which means it was explicity granted
+	// to this namespace), we will update the row to say that it has been revoked.
+
+	return execute(ctx, db, `INSERT INTO kwild_engine.role_privileges (role_id, namespace_id, privilege_type, granted)
+	VALUES ((SELECT id FROM kwild_engine.roles WHERE name = $1), (SELECT id FROM kwild_engine.namespaces WHERE name = $2), unnest($3::kwild_engine.privilege_type[]), false)
+	ON CONFLICT (role_id, namespace_id, privilege_type) DO UPDATE SET granted = false`, roleName, *namespace, privStrs)
 }
 
 // assignRole assigns a role to a user.
@@ -638,7 +696,7 @@ func (p *perms) grant(namespace *string, privs ...privilege) {
 	} else {
 		np, ok := p.namespacePrivileges[*namespace]
 		if !ok {
-			panic("unexpected error: namespace does not exist")
+			panic("unexpected error: namespace does not exist: " + *namespace)
 		}
 
 		for _, priv := range privs {

--- a/node/engine/interpreter/roles.go
+++ b/node/engine/interpreter/roles.go
@@ -566,7 +566,7 @@ func revokePrivilegesSQL(ctx context.Context, db sql.DB, roleName string, privil
 	// there are two cases to account for when a namespace is provided:
 	// either it was epxlicitly granted to the namespace before, or it was granted globally.
 	// Therefore, what we do is insert into the table to say that it has been revoked (which will succeed
-	// if it was granted globally), and if there is a conflict (which means it was explicity granted
+	// if it was granted globally), and if there is a conflict (which means it was explicitly granted
 	// to this namespace), we will update the row to say that it has been revoked.
 
 	return execute(ctx, db, `INSERT INTO kwild_engine.role_privileges (role_id, namespace_id, privilege_type, granted)

--- a/node/engine/interpreter/roles.go
+++ b/node/engine/interpreter/roles.go
@@ -72,44 +72,6 @@ func newAccessController(ctx context.Context, db sql.DB) (*accessController, err
 			return fmt.Errorf(`unexpected error: length of privileges and granted do not match. this is an internal bug`)
 		}
 
-		// for i, priv := range privileges {
-		// 	if priv == nil {
-		// 		// priv can be nil if the role has no privileges
-		// 		if len(namespaces) != 1 {
-		// 			return fmt.Errorf(`unexpected error: nil privilege in non-nil list of privileges. this is an internal bug`)
-		// 		}
-		// 		if namespaces[i] != nil {
-		// 			return fmt.Errorf(`unexpected error: nil privilege in non-nil list of namespaces. this is an internal bug`)
-		// 		}
-		// 		continue
-		// 	}
-
-		// 	// check that the privilege exists
-		// 	// This should never not be the case, but it is good to check
-		// 	_, ok := privilegeNames[privilege(*priv)]
-		// 	if !ok {
-		// 		return fmt.Errorf(`unknown privilege "%s" stored in DB`, *priv)
-		// 	}
-
-		// 	// if namespace is nil, then it is a global privilege
-		// 	// We still register all global privileges with each namespace
-		// 	if namespaces[i] == nil {
-		// 		perm.globalPrivileges[privilege(*priv)] = struct{}{}
-
-		// 		for nsPriv, np := range perm.namespacePrivileges {
-		// 			np[privilege(*priv)] = struct{}{}
-
-		// 			perm.namespacePrivileges[nsPriv] = np
-		// 		}
-		// 	} else {
-		// 		if _, ok := perm.namespacePrivileges[*namespaces[i]]; !ok {
-		// 			perm.namespacePrivileges[*namespaces[i]] = make(map[privilege]struct{})
-		// 		}
-
-		// 		perm.namespacePrivileges[*namespaces[i]][privilege(*priv)] = struct{}{}
-		// 	}
-		// }
-
 		for i, p := range privileges {
 			// can be nil if the role has no privileges
 			if p == nil {

--- a/node/engine/interpreter/roles_test.go
+++ b/node/engine/interpreter/roles_test.go
@@ -1,0 +1,126 @@
+package interpreter
+
+import (
+	"context"
+	"testing"
+
+	"github.com/kwilteam/kwil-db/node/pg"
+	"github.com/kwilteam/kwil-db/node/types/sql"
+	"github.com/stretchr/testify/require"
+)
+
+func Test_Roles(t *testing.T) {
+	ctx := context.Background()
+
+	db, err := pg.NewDB(ctx, &pg.DBConfig{
+		PoolConfig: pg.PoolConfig{
+			ConnConfig: pg.ConnConfig{
+				Host:   "127.0.0.1",
+				Port:   "5432",
+				User:   "kwild",
+				Pass:   "kwild", // would be ignored if pg_hba.conf set with trust
+				DBName: "kwil_test_db",
+			},
+			MaxConns: 11,
+		},
+	})
+	require.NoError(t, err)
+	defer db.Close()
+
+	setup := func(t *testing.T) (*accessController, sql.DB, func()) {
+		tx, err := db.BeginTx(ctx)
+		require.NoError(t, err)
+
+		err = initSQLIfNotInitialized(ctx, tx)
+		require.NoError(t, err)
+
+		ac, err := newAccessController(ctx, tx)
+		if err != nil {
+			tx.Rollback(ctx)
+			t.Fatal(err)
+		}
+
+		return ac, tx, func() {
+			tx.Rollback(ctx)
+		}
+	}
+
+	handleErr := func(t *testing.T, err error, fn func()) {
+		if err != nil {
+			fn()
+			t.Fatal(err)
+		}
+	}
+
+	t.Run("Removing SELECT from default role and restarting DB", func(t *testing.T) {
+		// I test two cases: global revocation and namespace revocation.
+		// There have been cases where the global revocation worked but the namespace revocation didn't.
+		for _, namespace := range []*string{&mainNamespace, nil} {
+			ac, db, done := setup(t)
+
+			err = ac.RevokePrivileges(ctx, db, defaultRole, []privilege{_SELECT_PRIVILEGE}, namespace, false)
+			handleErr(t, err, done)
+
+			if ac.HasPrivilege(defaultRole, namespace, _SELECT_PRIVILEGE) {
+				done()
+				if namespace == nil {
+					t.Fatal("expected SELECT privilege to be removed globally")
+				} else {
+					t.Fatal("expected SELECT privilege to be removed from namespace " + *namespace)
+				}
+			}
+
+			// we make a new access controller to simulate a fresh interpreter starting
+			// with state in the DB
+			ac2, err := newAccessController(ctx, db)
+			handleErr(t, err, done)
+
+			if ac2.HasPrivilege("some_user", namespace, _SELECT_PRIVILEGE) {
+				done()
+				if namespace == nil {
+					t.Fatal("AFTER RESTART: expected SELECT privilege to be removed globally")
+				} else {
+					t.Fatal("AFTER RESTART: expected SELECT privilege to be removed from namespace " + *namespace)
+				}
+			}
+
+			done()
+		}
+	})
+
+	t.Run("Adding INSERT to default role and restarting DB", func(t *testing.T) {
+		for _, namespace := range []*string{&mainNamespace, nil} {
+			ac, db, done := setup(t)
+
+			err = ac.GrantPrivileges(ctx, db, defaultRole, []privilege{_INSERT_PRIVILEGE}, namespace, false)
+			handleErr(t, err, done)
+
+			if !ac.HasPrivilege(defaultRole, namespace, _INSERT_PRIVILEGE) {
+				done()
+				if namespace == nil {
+					t.Fatal("expected INSERT privilege to be added globally")
+				} else {
+					t.Fatal("expected INSERT privilege to be added for namespace " + *namespace)
+				}
+			}
+
+			// we make a new access controller to simulate a fresh interpreter starting
+			// with state in the DB
+			ac2, err := newAccessController(ctx, db)
+			handleErr(t, err, done)
+
+			if !ac2.HasPrivilege(defaultRole, namespace, _INSERT_PRIVILEGE) {
+				done()
+				if namespace == nil {
+					t.Fatal("AFTER RESTART: expected INSERT privilege to be added globally")
+				} else {
+					t.Fatal("AFTER RESTART: expected INSERT privilege to be added for namespace " + *namespace)
+				}
+			}
+
+			done()
+		}
+	})
+}
+
+var mainNamespace = "main"

--- a/node/engine/interpreter/schema.sql
+++ b/node/engine/interpreter/schema.sql
@@ -113,7 +113,9 @@ CREATE TABLE IF NOT EXISTS kwild_engine.role_privileges (
     id BIGSERIAL PRIMARY KEY,
     privilege_type kwild_engine.privilege_type NOT NULL,
     namespace_id INT8 REFERENCES kwild_engine.namespaces(id) ON UPDATE CASCADE ON DELETE CASCADE, -- the namespace it is targeting. Can be null if it is a global privilege
-    role_id INT8 NOT NULL REFERENCES kwild_engine.roles(id) ON UPDATE CASCADE ON DELETE CASCADE
+    role_id INT8 NOT NULL REFERENCES kwild_engine.roles(id) ON UPDATE CASCADE ON DELETE CASCADE,
+    granted BOOLEAN DEFAULT TRUE, -- if false, it is explicitly denied. otherwise, it is only granted if the user has it globally
+    UNIQUE (privilege_type, namespace_id, role_id)
 );
 
 -- user_roles is a table that stores all users who have been assigned roles
@@ -499,7 +501,8 @@ CREATE VIEW info.role_privileges AS
 SELECT 
     r.name AS role_name,
     p.privilege_type::text AS privilege,
-    n.name AS namespace
+    n.name AS namespace,
+    p.granted AS granted
 FROM
     kwild_engine.role_privileges p
 JOIN
@@ -509,7 +512,7 @@ LEFT JOIN
     kwild_engine.namespaces n
     ON p.namespace_id = n.id
 ORDER BY
-    1, 2, 3;
+    1, 2, 3, 4;
 
 CREATE VIEW info.extensions AS
 SELECT 

--- a/node/engine/interpreter/sql.go
+++ b/node/engine/interpreter/sql.go
@@ -23,11 +23,6 @@ var (
 	schemaInitSQL string
 )
 
-// initSQL initializes the SQL schema.
-func initSQL(ctx context.Context, db sql.DB) error {
-	return pg.Exec(ctx, db, schemaInitSQL)
-}
-
 // queryOneInt64 queries for a single int64 value.
 func queryOneInt64(ctx context.Context, db sql.DB, query string, args ...any) (int64, error) {
 	var res *int64

--- a/node/engine/interpreter/sql_test.go
+++ b/node/engine/interpreter/sql_test.go
@@ -678,23 +678,23 @@ func Test_Metadata(t *testing.T) {
 	// the role_privileges table has columns "role_name", "privilege", "namespace"
 	assertQuery(`SELECT * FROM role_privileges`, [][]any{
 		// default has select and call
-		{"default", "CALL", nil},
-		{"default", "SELECT", nil},
+		{"default", "CALL", nil, true},
+		{"default", "SELECT", nil, true},
 
 		// owner has all privileges on all/nil namespaces
-		{"owner", "ALTER", nil},
-		{"owner", "CALL", nil},
-		{"owner", "CREATE", nil},
-		{"owner", "DELETE", nil},
-		{"owner", "DROP", nil},
-		{"owner", "INSERT", nil},
-		{"owner", "ROLES", nil},
-		{"owner", "SELECT", nil},
-		{"owner", "UPDATE", nil},
-		{"owner", "USE", nil},
+		{"owner", "ALTER", nil, true},
+		{"owner", "CALL", nil, true},
+		{"owner", "CREATE", nil, true},
+		{"owner", "DELETE", nil, true},
+		{"owner", "DROP", nil, true},
+		{"owner", "INSERT", nil, true},
+		{"owner", "ROLES", nil, true},
+		{"owner", "SELECT", nil, true},
+		{"owner", "UPDATE", nil, true},
+		{"owner", "USE", nil, true},
 
-		{"some_perms", "INSERT", nil},
-		{"some_perms", "SELECT", "info"},
+		{"some_perms", "INSERT", nil, true},
+		{"some_perms", "SELECT", "info", true},
 	})
 
 	// 2.4 Extensions


### PR DESCRIPTION
Adds an RPC endpoint for authenticated queries. It also automatically uses the endpoint if the client has a private key.

This PR also fixes a bug I found in our roles system, where certain types of fine grained permissions could be lost if a node restarts.
