### PR TITLE
more log fixes

### DIFF
--- a/node/exts/erc20-bridge/signersvc/signer.go
+++ b/node/exts/erc20-bridge/signersvc/signer.go
@@ -353,7 +353,10 @@ func (m *ServiceMgr) Start(ctx context.Context) error {
 		}
 
 		m.logger.Warn("failed to initialize erc20 bridge signer, will retry", "error", err.Error())
-		time.Sleep(time.Second * 3)
+		select {
+		case <-time.After(time.Second * 30):
+		case <-ctx.Done():
+		}
 	}
 
 	wg := &sync.WaitGroup{}


### PR DESCRIPTION
The spam of peer logs complaining about "no addresses" for a peer is a result of the node having an **incoming** connection with a peer that is both not routable (behind NAT with no port forwarding, or just a firewall, etc.) and has not configured `external_address`.  This silences those logs, which as it turns out are normal.

This also silences the "Commit hash" log from the `node/pg` logical replication stream.  It will be logged in CE when needed.

Finally, this converts a `time.Sleep` in the erc20_bridge into a select with a with `ctx.Done()` so that it does not hang for a big on shutdown.