### PR TITLE
Fix/bridge: properly unuse a erc20 bridge

### DIFF
--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -272,7 +272,7 @@ func init() {
 			// we need to unlock before we call start because it
 			// will acquire the write lock
 			info.mu.Unlock()
-			return info.startTransferListener(ctx, app)
+			return info.startTransferListener(ctx, app, false)
 		}
 
 		info.mu.Unlock()
@@ -309,7 +309,7 @@ func init() {
 						// transfer listener. Otherwise, we should start the state poller
 						if instance.active {
 							if instance.synced {
-								err = instance.startTransferListener(ctx, app)
+								err = instance.startTransferListener(ctx, app, false)
 								if err != nil {
 									return err
 								}
@@ -411,7 +411,7 @@ func init() {
 									info.mu.RLock()
 									defer info.mu.RUnlock()
 
-									err = info.startTransferListener(ctx.TxContext.Ctx, app)
+									err = info.startTransferListener(ctx.TxContext.Ctx, app, true)
 									if err != nil {
 										return err
 									}
@@ -491,7 +491,7 @@ func init() {
 								return err
 							}
 
-							err = info.stopAllListeners(ctx.TxContext.Ctx, app.DB, app.Engine)
+							err = info.stopAllListeners()
 							if err != nil {
 								info.mu.RUnlock()
 								return err
@@ -1721,7 +1721,7 @@ func (r *rewardExtensionInfo) startStatePoller() error {
 }
 
 // startTransferListener starts an event listener that listens for Transfer events
-func (r *rewardExtensionInfo) startTransferListener(ctx context.Context, app *common.App) error {
+func (r *rewardExtensionInfo) startTransferListener(ctx context.Context, app *common.App, reuseTopic bool) error {
 	// I'm not sure if copies are needed because the values should never be modified,
 	// but just in case, I copy them to be used in GetLogs, which runs outside of consensus
 	escrowCopy := r.EscrowAddress
@@ -1784,16 +1784,19 @@ func (r *rewardExtensionInfo) startTransferListener(ctx context.Context, app *co
 
 			return logs, nil
 		},
-		Resolve: transferEventResolutionName,
+		Resolve:    transferEventResolutionName,
+		ReuseTopic: reuseTopic,
 	})
 }
 
 // stopAllListeners stops all event listeners for the reward extension.
 // If it is synced, this means it must have an active Transfer listener.
 // If it is not synced, it must have an active state poller.
-func (r *rewardExtensionInfo) stopAllListeners(ctx context.Context, db sql.DB, eng common.Engine) error {
+// NOTE: because the reward instance will not be deleted when `unuse`/`disable`,
+// we need to keep the topics to make sure we don't lose events.
+func (r *rewardExtensionInfo) stopAllListeners() error {
 	if r.synced {
-		return evmsync.EventSyncer.UnregisterListener(ctx, db, eng, transferListenerUniqueName(*r.ID))
+		return evmsync.EventSyncer.UnregisterListener(transferListenerUniqueName(*r.ID))
 	}
 	return evmsync.StatePoller.UnregisterPoll(statePollerUniqueName(*r.ID))
 }

--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -1784,16 +1784,17 @@ func (r *rewardExtensionInfo) startTransferListener(ctx context.Context, app *co
 
 			return logs, nil
 		},
-		Resolve:    transferEventResolutionName,
-		ReuseTopic: reuseTopic,
+		Resolve:     transferEventResolutionName,
+		TopicExists: reuseTopic,
 	})
 }
 
 // stopAllListeners stops all event listeners for the reward extension.
 // If it is synced, this means it must have an active Transfer listener.
 // If it is not synced, it must have an active state poller.
-// NOTE: because the reward instance will not be deleted when `unuse`/`disable`,
-// we need to keep the topics to make sure we don't lose events.
+// NOTE: UnregisterListener doesn't unregister the topic because the reward
+// instance will not be deleted when `unuse`/`disable`, we need to keep the
+// topics to make sure we don't lose events.
 func (r *rewardExtensionInfo) stopAllListeners() error {
 	if r.synced {
 		return evmsync.EventSyncer.UnregisterListener(transferListenerUniqueName(*r.ID))

--- a/node/exts/erc20-bridge/erc20/meta_sql.go
+++ b/node/exts/erc20-bridge/erc20/meta_sql.go
@@ -219,6 +219,20 @@ func userBalanceID(rewardID *types.UUID, user ethcommon.Address) *types.UUID {
 	return &id
 }
 
+// reuseRewardInstance reuse existing synced reward instance, set active status to true,
+// and update the distribution period.
+// This should be only called when re-use an extension.
+func reuseRewardInstance(ctx context.Context, app *common.App, id *types.UUID, distributionPeriod int64) error {
+	return app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
+    {kwil_erc20_meta}UPDATE reward_instances
+    SET distribution_period = $distribution_period, active = true
+    WHERE id = $id;
+    `, map[string]any{
+		"id":                  id,
+		"distribution_period": distributionPeriod,
+	}, nil)
+}
+
 // setActiveStatus sets the active status of a reward.
 func setActiveStatus(ctx context.Context, app *common.App, id *types.UUID, active bool) error {
 	return app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `

--- a/node/exts/erc20-bridge/signersvc/signer.go
+++ b/node/exts/erc20-bridge/signersvc/signer.go
@@ -366,7 +366,7 @@ func (m *ServiceMgr) Start(ctx context.Context) error {
 		go func() {
 			defer wg.Done()
 
-			s.logger.Info("start watching erc20 reward epoches")
+			s.logger.Info("start watching erc20 bridge epoches")
 			tick := time.NewTicker(m.syncInterval)
 
 			for {
@@ -374,7 +374,7 @@ func (m *ServiceMgr) Start(ctx context.Context) error {
 
 				select {
 				case <-ctx.Done():
-					s.logger.Info("stop watching erc20 reward epoches")
+					s.logger.Info("stop watching erc20 bridge epoches")
 					return
 				case <-tick.C:
 				}

--- a/node/exts/evm-sync/instance.go
+++ b/node/exts/evm-sync/instance.go
@@ -79,9 +79,9 @@ type EVMEventListenerConfig struct {
 	// Resolve is the function that will be called the Kwil network
 	// has confirmed events from Ethereum.
 	Resolve string
-	// ReuseTopic indicate whether to use the existing topic.
+	// TopicExists indicate whether the targeting topic exists.
 	// This is useful for erc20-bridge, we never delete the topics.
-	ReuseTopic bool
+	TopicExists bool
 }
 
 // RegisterListener registers a new listener.
@@ -106,7 +106,7 @@ func (l *globalListenerManager) RegisterNewListener(ctx context.Context, db sql.
 		return fmt.Errorf("chain %s not found", conf.Chain)
 	}
 
-	if !conf.ReuseTopic {
+	if !conf.TopicExists {
 		err := orderedsync.Synchronizer.RegisterTopic(ctx, db, eng, conf.UniqueName, conf.Resolve)
 		if err != nil {
 			return err
@@ -133,8 +133,9 @@ func (l *globalListenerManager) RegisterNewListener(ctx context.Context, db sql.
 	return nil
 }
 
-// UnregisterListener unregisters a listener in manger, BUT not the topic.
+// UnregisterListener unregisters a listener.
 // It should be called when an extension gets unused
+// NOTE: this doesn't unregister the related topic, for now.
 func (l *globalListenerManager) UnregisterListener(uniqueName string) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()

--- a/node/exts/evm-sync/instance.go
+++ b/node/exts/evm-sync/instance.go
@@ -130,7 +130,7 @@ func (l *globalListenerManager) RegisterNewListener(ctx context.Context, db sql.
 
 // UnregisterListener unregisters a listener.
 // It should be called when an extension gets unused
-func (l *globalListenerManager) UnregisterListener(uniqueName string) error {
+func (l *globalListenerManager) UnregisterListener(ctx context.Context, db sql.DB, eng common.Engine, uniqueName string) error {
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
@@ -141,6 +141,11 @@ func (l *globalListenerManager) UnregisterListener(uniqueName string) error {
 
 	close(info.done)
 	delete(l.listeners, uniqueName)
+
+	err := orderedsync.Synchronizer.UnregisterTopic(ctx, db, eng, uniqueName)
+	if err != nil {
+		return err
+	}
 
 	return nil
 }

--- a/node/exts/ordered-sync/sync.go
+++ b/node/exts/ordered-sync/sync.go
@@ -247,7 +247,6 @@ func (r *ResolutionMessage) UnmarshalBinary(data []byte) error {
 // It should be called by other extensions that want to inform
 // orderedsync of a new topic they will be publishing for.
 // It should be called every time the engine starts.
-// It is idempotent.
 func registerTopic(ctx context.Context, db sql.DB, eng common.Engine, topic, resolveFn string) error {
 	return eng.ExecuteWithoutEngineCtx(ctx, db,
 		fmt.Sprintf(`{%s}INSERT INTO topics (id, name, last_processed_point, resolve_func) VALUES (
@@ -255,7 +254,7 @@ func registerTopic(ctx context.Context, db sql.DB, eng common.Engine, topic, res
 		$name,
 		null,
 		$resolve_func
-		) ON CONFLICT DO NOTHING`, ExtensionName),
+        )`, ExtensionName),
 		map[string]any{
 			"name":         topic,
 			"resolve_func": resolveFn,


### PR DESCRIPTION
This pr fix issue that when `unuse` an erc20 bridge ext, the listener topic is still registered.

Also add the support to update `period` config when re-use the existing erc20 bridge