### PR TITLE
docker: fix GOWORK build

### DIFF
--- a/contrib/docker/kwild.debug.dockerfile
+++ b/contrib/docker/kwild.debug.dockerfile
@@ -15,6 +15,8 @@ RUN chmod 777 /var/run/kwil
 
 COPY . .
 
+RUN rm -f go.work && go work init . ./core ./test
+
 RUN GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time GO_GCFLAGS="all=-N -l" CGO_ENABLED=0 TARGET="/app/dist" GO_BUILDTAGS=$go_build_tags GO_RACEFLAG=$go_race ./contrib/scripts/build/binary kwild
 RUN GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" GO_RACEFLAG=$go_race ./contrib/scripts/build/binary kwil-cli
 RUN chmod +x /app/dist/kwild /app/dist/kwil-cli

--- a/contrib/docker/kwild.dockerfile
+++ b/contrib/docker/kwild.dockerfile
@@ -12,6 +12,8 @@ RUN chmod 777 /var/run/kwil
 
 COPY . .
 
+RUN rm -f go.work && go work init . ./core ./test
+
 RUN GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" GO_BUILDTAGS=$go_build_tags GO_RACEFLAG=$go_race ./contrib/scripts/build/binary kwild
 RUN GIT_VERSION=$version GIT_COMMIT=$git_commit BUILD_TIME=$build_time CGO_ENABLED=0 TARGET="/app/dist" GO_BUILDTAGS=$go_build_tags GO_RACEFLAG=$go_race ./contrib/scripts/build/binary kwil-cli
 RUN chmod +x /app/dist/kwild /app/dist/kwil-cli


### PR DESCRIPTION
The go.work file from the builder machine is not necessarily right for the builder, which specified a Go version in the Dockerfile such as 'FROM golang:1.23 AS build'.

Since we converted to the Dockerfile doing GOWORK builds, the solution is to do 'go work init . ./core ./test' inside the builder.