### PR TITLE
node,consensus: robust to transient network failure

### DIFF
--- a/contrib/docker/postgres.dockerfile
+++ b/contrib/docker/postgres.dockerfile
@@ -12,7 +12,8 @@ COPY ./pginit.sql /docker-entrypoint-initdb.d/init.sql
 # ENV POSTGRES_PASSWORD kwild
 # ENV POSTGRES_DB kwild
 
-# Override the default entrypoint/command to include the additional configuration
+# Override the default entrypoint/command to include the additional configuration.
+# 'track_commit_timestamp' is not required, but may be useful for debugging.
 CMD ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=10", "-c", "max_replication_slots=10", \
 	"-c", "track_commit_timestamp=true", "-c", "wal_sender_timeout=0", "-c", "max_prepared_transactions=2", \
 	"-c", "max_locks_per_transaction=4096", "-c", "max_connections=128"]

--- a/node/consensus.go
+++ b/node/consensus.go
@@ -239,8 +239,8 @@ func (n *Node) blkPropStreamHandler(s network.Stream) {
 	}()
 
 	from := s.Conn().RemotePeer()
-	n.log.Info("Accept proposal?", "height", height, "blockID", prop.Hash, "prevHash", prop.PrevHash,
-		"from_peer", peers.PeerIDStringer(from)) // maybe debug level?
+	n.log.Debug("Accept proposal?", "height", height, "blockID", prop.Hash, "prevHash", prop.PrevHash,
+		"from_peer", peers.PeerIDStringer(from))
 
 	if !n.ce.AcceptProposal(height, prop.Hash, prop.PrevHash, prop.LeaderSig, prop.Stamp) {
 		// NOTE: if this is ahead of our last commit height, we have to try to catch up

--- a/node/nogossip.go
+++ b/node/nogossip.go
@@ -231,11 +231,6 @@ func (n *Node) startOrderedTxQueueAnns(ctx context.Context) {
 			case <-ctx.Done():
 				return
 			case txn := <-n.txQueue:
-				// skip if node is still catching up
-				if n.InCatchup() {
-					continue
-				}
-
 				rawTx := txn.rawtx
 				if txn.rawtx == nil {
 					// fetch the raw tx from the mempool


### PR DESCRIPTION
Even a brief transient network failure will make a syncing node shutdown.  A node should never shutdown in this case.

This also updates some of the progress logs so that they are always on to/from boundaries modulus 100 rather than whatever it was at at startup.

I need to chat with @charithabandi about retries