### PR TITLE
engine: fix conn busy error

### DIFF
--- a/node/engine/interpreter/interpreter.go
+++ b/node/engine/interpreter/interpreter.go
@@ -478,6 +478,10 @@ func funcDefToExecutable(funcName string, funcDef *engine.ScalarFunctionDefiniti
 				return newUserDefinedErr(errors.New(msg))
 			}
 
+			if e.queryActive {
+				return fmt.Errorf(`%w: cannot execute function "%s" while a query is active`, engine.ErrQueryActive, funcName)
+			}
+
 			zeroVal, err := newZeroValue(retTyp)
 			if err != nil {
 				return err

--- a/node/engine/interpreter/interpreter_test.go
+++ b/node/engine/interpreter/interpreter_test.go
@@ -2040,6 +2040,18 @@ func Test_Actions(t *testing.T) {
 			values:               []any{1},
 			executionErrContains: "duplicate key value violates unique constraint",
 		},
+		{
+			name: "call function in loop",
+			stmt: []string{
+				`CREATE ACTION call_function_in_loop() public view {
+					for $i in select 1 as a {
+						$a := abs($i.a);
+					}
+				}`,
+			},
+			action: "call_function_in_loop",
+			err:    engine.ErrQueryActive,
+		},
 	}
 
 	db := newTestDB(t, nil, nil)

--- a/node/engine/pg_generate/generate.go
+++ b/node/engine/pg_generate/generate.go
@@ -92,6 +92,8 @@ func (s *sqlGenerator) VisitExpressionFunctionCall(p0 *parse.ExpressionFunctionC
 		pgFmt, err = fn.PGFormatFunc(args)
 	case *engine.AggregateFunctionDefinition:
 		pgFmt, err = fn.PGFormatFunc(args, p0.Distinct)
+	case *engine.WindowFunctionDefinition:
+		pgFmt, err = fn.PGFormatFunc(args)
 	default:
 		panic("unknown function type " + fmt.Sprintf("%T", fn))
 	}

--- a/node/engine/pg_generate/generate_test.go
+++ b/node/engine/pg_generate/generate_test.go
@@ -342,6 +342,11 @@ func Test_PgGenerate(t *testing.T) {
 			sql:  `DROP INDEX IF EXISTS idx_department_name_id;`,
 			want: `DROP INDEX IF EXISTS kwil.idx_department_name_id;`,
 		},
+		{
+			name: "window function",
+			sql:  `SELECT col1, col2, row_number() OVER (PARTITION BY col1 ORDER BY col2) FROM tbl;`,
+			want: `SELECT col1, col2, row_number() OVER (PARTITION BY col1 ORDER BY col2 ASC NULLS LAST) FROM tbl;`,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
Fixes an error where the network can halt with a `conn busy` error. This is a short-term fix; it prevents users from making scalar function calls while looping over a SQL statement. We can fix this by having go implementations of the scalar functions, but getting go implementations that match Postgres's is very non-trivial, and will likely introduce bugs.