### PR TITLE
fix(bridge): multiple issues

### DIFF
--- a/core/types/decimal.go
+++ b/core/types/decimal.go
@@ -365,7 +365,7 @@ func (z *Decimal) Mod(x, y *Decimal) (*Decimal, error) {
 }
 
 // Cmp compares two decimals.
-// It returns -1 if x < y, 0 if x == y, and 1 if x > y.
+// It returns -1 if z < x, 0 if z == x, and 1 if z > x.
 func (z *Decimal) Cmp(x *Decimal) (int, error) {
 	d := apd.New(0, 0)
 	_, err := z.context().Cmp(d, &z.dec, &x.dec)

--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -737,7 +737,8 @@ func init() {
 							// the read lock before we can acquire the write lock, which
 							// we do at the end of this
 
-							left, err := types.DecimalSub(info.ownedBalance, amount)
+							//NOTE: we don't want to use types.DecimalSub() since it will use max precision/scale
+							left, err := info.ownedBalance.Sub(info.ownedBalance, amount)
 							if err != nil {
 								info.mu.RUnlock()
 								return err
@@ -1436,7 +1437,7 @@ func (e *extensionInfo) issueTokens(ctx context.Context, app *common.App, id *ty
 	// the read lock before we can acquire the write lock, which
 	// we do at the end of this
 
-	newBal, err := types.DecimalSub(info.ownedBalance, amount)
+	newBal, err := info.ownedBalance.Sub(info.ownedBalance, amount)
 	if err != nil {
 		info.mu.RUnlock()
 		return err

--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -1403,6 +1403,20 @@ func (e *extensionInfo) lockTokens(ctx context.Context, app *common.App, id *typ
 		return err
 	}
 
+	bal, err := balanceOf(ctx, app, id, fromAddr)
+	if err != nil {
+		return err
+	}
+
+	cmp, err := bal.Cmp(amount)
+	if err != nil {
+		return err
+	}
+
+	if cmp < 0 {
+		return fmt.Errorf("insufficient balance")
+	}
+
 	err = transferTokensFromUserToNetwork(ctx, app, id, fromAddr, amount)
 	if err != nil {
 		return err

--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -1284,7 +1284,7 @@ func init() {
 			}
 
 			// if previous epoch exists and not confirmed, we do nothing.
-			app.Service.Logger.Debug("log previous epoch is not confirmed yet, skip finalize current epoch")
+			app.Service.Logger.Debug("previous epoch is not confirmed yet, skip finalize current epoch")
 			return nil
 		})
 		if err != nil {

--- a/node/exts/erc20-bridge/erc20/meta_sql.go
+++ b/node/exts/erc20-bridge/erc20/meta_sql.go
@@ -604,11 +604,12 @@ func canVoteEpoch(ctx context.Context, app *common.App, epochID *types.UUID) (ok
 }
 
 // voteEpoch vote an epoch by submitting signature.
+// This is idempotent.
 func voteEpoch(ctx context.Context, app *common.App, epochID *types.UUID,
 	voter ethcommon.Address, nonce int64, signature []byte) error {
 	return app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
 	{kwil_erc20_meta}INSERT into epoch_votes(epoch_id, voter, nonce, signature)
-    VALUES ($epoch_id, $voter, $nonce, $signature);
+    VALUES ($epoch_id, $voter, $nonce, $signature) ON CONFLICT DO NOTHING;
 	`, map[string]any{
 		"epoch_id":  epochID,
 		"voter":     voter.Bytes(),

--- a/node/exts/erc20-bridge/signersvc/eth.go
+++ b/node/exts/erc20-bridge/signersvc/eth.go
@@ -142,7 +142,7 @@ func (s *Safe) latestMetadata(ctx context.Context) (*safeMetadata, error) {
 }
 
 func (s *Safe) metadata(ctx context.Context, blockNumber *big.Int) (*safeMetadata, error) {
-	if IsMulticall3Deployed(s.chainID.Uint64(), blockNumber) {
+	if IsMulticall3Deployed(s.chainID.String(), blockNumber) {
 		return s.getSafeMetadata3(ctx, blockNumber)
 	}
 
@@ -175,7 +175,7 @@ func (s *Safe) getSafeMetadataSeq(ctx context.Context, blockNumber *big.Int) (*s
 
 // getSafeMetadata3 retrieves safe wallet metadata in one go, using multicall3
 func (s *Safe) getSafeMetadata3(ctx context.Context, blockNumber *big.Int) (*safeMetadata, error) {
-	res, err := Aggregate3(ctx, s.chainID.Uint64(), []abigen.Multicall3Call3{
+	res, err := Aggregate3(ctx, s.chainID.String(), []abigen.Multicall3Call3{
 		{
 			Target:       s.addr,
 			AllowFailure: false,

--- a/node/exts/erc20-bridge/signersvc/multicall.go
+++ b/node/exts/erc20-bridge/signersvc/multicall.go
@@ -10,26 +10,28 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 
 	"github.com/kwilteam/kwil-db/node/exts/erc20-bridge/abigen"
+	"github.com/kwilteam/kwil-db/node/exts/evm-sync/chains"
 )
 
 // Multicall https://github.com/mds1/multicall
 // https://etherscan.io/address/0xcA11bde05977b3631167028862bE2a173976CA11
 
-const (
-	EthNetworkMainnet = 1
-	EthNetworkSepolia = 11155111
-)
-
 var (
 	AddressMulticall3 = common.HexToAddress("0xcA11bde05977b3631167028862bE2a173976CA11")
+
+	chainEthereum, _    = chains.GetChainInfo(chains.Ethereum)
+	chainSepolia, _     = chains.GetChainInfo(chains.Sepolia)
+	chainBaseSepolia, _ = chains.GetChainInfo(chains.BaseSepolia)
 )
 
-var deployedAtMap = map[uint64]uint64{
-	EthNetworkMainnet: 14353601, // https://etherscan.io/tx/0x00d9fcb7848f6f6b0aae4fb709c133d69262b902156c85a473ef23faa60760bd
-	EthNetworkSepolia: 751532,   // https://sepolia.etherscan.io/tx/0x6313b2cee1ddd9a77a8a1edf93495a9eb3c51a4d85479f4f8fec0090ad82596b
+// Find multicall3 deployments on different networks: https://www.multicall3.com/deployments
+var deployedAtMap = map[string]uint64{
+	chainEthereum.ID:    14353601, // https://etherscan.io/tx/0x00d9fcb7848f6f6b0aae4fb709c133d69262b902156c85a473ef23faa60760bd
+	chainSepolia.ID:     751532,   // https://sepolia.etherscan.io/tx/0x6313b2cee1ddd9a77a8a1edf93495a9eb3c51a4d85479f4f8fec0090ad82596b
+	chainBaseSepolia.ID: 1059647,  // https://base-sepolia.blockscout.com/tx/0x07471adfe8f4ec553c1199f495be97fc8be8e0626ae307281c22534460184ed1
 }
 
-func IsMulticall3Deployed(chainID uint64, blockNumber *big.Int) bool {
+func IsMulticall3Deployed(chainID string, blockNumber *big.Int) bool {
 	deployedAt, exists := deployedAtMap[chainID]
 	if !exists {
 		return false
@@ -44,10 +46,10 @@ func IsMulticall3Deployed(chainID uint64, blockNumber *big.Int) bool {
 
 // Aggregate3 aggregates multicall result.
 // based on https://github.com/RSS3-Network/Node/blob/947b387f11857144c48250dd95804b5069731153/provider/ethereum/contract/multicall3/contract.go
-func Aggregate3(ctx context.Context, chainID uint64, calls []abigen.Multicall3Call3,
+func Aggregate3(ctx context.Context, chainID string, calls []abigen.Multicall3Call3,
 	blockNumber *big.Int, contractBackend bind.ContractCaller) ([]*abigen.Multicall3Result, error) {
 	if !IsMulticall3Deployed(chainID, blockNumber) {
-		return nil, fmt.Errorf("multicall3 is not deployed on chainID %d yet", chainID)
+		return nil, fmt.Errorf("multicall3 is not deployed on chainID %s yet", chainID)
 	}
 
 	abi, err := abigen.Multicall3MetaData.GetAbi()

--- a/node/exts/erc20-bridge/signersvc/signer.go
+++ b/node/exts/erc20-bridge/signersvc/signer.go
@@ -212,7 +212,7 @@ func (s *bridgeSigner) sync(ctx context.Context) {
 	}
 
 	if s.canSkip(finalizedEpoch, safeMeta) {
-		s.logger.Info("skip epoch", "id", finalizedEpoch.ID.String(), "height", finalizedEpoch.EndHeight)
+		s.logger.Info("skip epoch", "id", finalizedEpoch.ID.String(), "height", finalizedEpoch.EndHeight, "nonce", safeMeta.nonce)
 		return
 	}
 

--- a/node/exts/erc20-bridge/signersvc/signer.go
+++ b/node/exts/erc20-bridge/signersvc/signer.go
@@ -73,7 +73,8 @@ func newBridgeSigner(kwil bridgeSignerClient, safe *Safe, target string, txSigne
 // - signer has voted this epoch with the same nonce as current safe nonce
 func (s *bridgeSigner) canSkip(epoch *Epoch, safeMeta *safeMetadata) bool {
 	if !slices.Contains(safeMeta.owners, s.signerAddr) {
-		s.logger.Warn("signer is not safe owner", "signer", s.signerAddr.String(), "owners", safeMeta.owners)
+		s.logger.Info("skip voting epoch: signer is not safe owner", "id", epoch.ID.String(),
+			"signer", s.signerAddr.String(), "owners", safeMeta.owners)
 		return true
 	}
 
@@ -84,6 +85,7 @@ func (s *bridgeSigner) canSkip(epoch *Epoch, safeMeta *safeMetadata) bool {
 	for i, voter := range epoch.Voters {
 		if voter == s.signerAddr.String() &&
 			safeMeta.nonce.Cmp(big.NewInt(epoch.VoteNonces[i])) == 0 {
+			s.logger.Info("skip voting epoch: already voted", "id", epoch.ID.String(), "nonce", safeMeta.nonce)
 			return true
 		}
 	}
@@ -212,7 +214,6 @@ func (s *bridgeSigner) sync(ctx context.Context) {
 	}
 
 	if s.canSkip(finalizedEpoch, safeMeta) {
-		s.logger.Info("skip epoch", "id", finalizedEpoch.ID.String(), "height", finalizedEpoch.EndHeight, "nonce", safeMeta.nonce)
 		return
 	}
 

--- a/node/exts/erc20-bridge/signersvc/signer.go
+++ b/node/exts/erc20-bridge/signersvc/signer.go
@@ -191,7 +191,10 @@ func (s *bridgeSigner) sync(ctx context.Context) {
 	}
 
 	if len(epochs) == 1 {
-		// the very first round of epoch, we wait until there are 2 active epochs
+		// Two reasons there is only one active epoches
+		// 1. the very first epoch is just created
+		// 2. the previous epoch is confirmed, but currently there are no rewards/issuances in the current epoch
+		// In either case, we wait until there are 2 active epoches, which means the 1st one is ready to be voted.
 		return
 	}
 

--- a/node/exts/erc20-bridge/signersvc/signer.go
+++ b/node/exts/erc20-bridge/signersvc/signer.go
@@ -194,7 +194,7 @@ func (s *bridgeSigner) sync(ctx context.Context) {
 		// Two reasons there is only one active epoches
 		// 1. the very first epoch is just created
 		// 2. the previous epoch is confirmed, but currently there are no rewards/issuances in the current epoch
-		// In either case, we wait until there are 2 active epoches, which means the 1st one is ready to be voted.
+		// In either case, we wait until there are 2 active epoches; and the 1st one(finalized) is ready to be voted.
 		return
 	}
 

--- a/node/exts/evm-sync/chains/chains.go
+++ b/node/exts/evm-sync/chains/chains.go
@@ -30,6 +30,11 @@ func init() {
 			ID:                    "11155111",
 			RequiredConfirmations: 12,
 		},
+		ChainInfo{
+			Name:                  "base-sepolia",
+			ID:                    "84532",
+			RequiredConfirmations: 12,
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -39,8 +44,9 @@ func init() {
 type Chain string
 
 const (
-	Ethereum Chain = "ethereum"
-	Sepolia  Chain = "sepolia"
+	Ethereum    Chain = "ethereum"
+	Sepolia     Chain = "sepolia"
+	BaseSepolia Chain = "base-sepolia"
 )
 
 func (c Chain) String() string {
@@ -49,7 +55,7 @@ func (c Chain) String() string {
 
 func (c Chain) Valid() error {
 	switch c {
-	case Ethereum, Sepolia:
+	case Ethereum, Sepolia, BaseSepolia:
 		return nil
 	default:
 		return fmt.Errorf("invalid chain: %s", c)

--- a/node/exts/evm-sync/listener.go
+++ b/node/exts/evm-sync/listener.go
@@ -111,23 +111,19 @@ func getChainConf(cfg config.ERC20BridgeConfig, chain chains.Chain) (*chainConfi
 		return nil, err
 	}
 
-	var ok bool
-	var provider string
-	var syncChunk string
-	switch chain {
-	case chains.Ethereum, chains.Sepolia:
-		provider, ok = cfg.RPC[chain.String()]
-		if !ok {
-			return nil, fmt.Errorf("local configuration does not have an '%s' config", chain.String())
-		}
+	err = chain.Valid()
+	if err != nil {
+		return nil, err
+	}
 
-		syncChunk, ok = cfg.BlockSyncChuckSize[chains.Ethereum.String()]
-		if !ok {
-			syncChunk = "1000000"
-		}
-	default:
-		// suggests an internal bug where we have not added a case for a new chain
-		return nil, fmt.Errorf("unknown chain %s", chain)
+	provider, ok := cfg.RPC[chain.String()]
+	if !ok {
+		return nil, fmt.Errorf("local configuration does not have an '%s' config", chain.String())
+	}
+
+	syncChunk, ok := cfg.BlockSyncChuckSize[chains.Ethereum.String()]
+	if !ok {
+		syncChunk = "1000000"
 	}
 
 	blockSyncChunkSize, err := strconv.ParseInt(syncChunk, 10, 64)

--- a/node/exts/evm-sync/listener.go
+++ b/node/exts/evm-sync/listener.go
@@ -206,10 +206,16 @@ func (i *individualListener) listen(ctx context.Context, eventstore listeners.Ev
 
 		err = i.processEvents(ctx, startBlock, toBlock, eventstore, logger)
 		if err != nil {
-			return err
+			// NOTE: this will cause the listener stops.
+			return fmt.Errorf("sync up blocks failed, %w", err)
 		}
 
 		startBlock = toBlock
+
+		// naive way to avoid reaching the RPC ratelimit, as most of them calculate limit(computing) by per second.
+		// depends on network and RPC service, this loop might easily reach provided RPC ratelimit
+		// for example, at the time of write, Arbitrum has 314m blocks, whereas Ethereum has 22m blocks.
+		time.Sleep(time.Millisecond * 500)
 	}
 
 	logger.Info(fmt.Sprintf("synced up to block %d", lastConfirmedBlock))
@@ -244,7 +250,6 @@ func (i *individualListener) listen(ctx context.Context, eventstore listeners.Ev
 
 func (i *individualListener) processEvents(ctx context.Context, from, to int64, eventStore listeners.EventStore, logger log.Logger) error {
 	logs, err := i.getLogsFunc(ctx, i.client.client, uint64(from), uint64(to), logger)
-	/// THIS IS WHERE I LEFT
 	if err != nil {
 		return err
 	}

--- a/node/exts/ordered-sync/synchronizer.go
+++ b/node/exts/ordered-sync/synchronizer.go
@@ -175,8 +175,13 @@ func (c *cachedSync) resolve(ctx context.Context, app *common.App, block *common
 // It ensures that the point and previous point are not less than the previous point in time.
 func (c *cachedSync) storeDataPoint(ctx context.Context, app *common.App, dp *ResolutionMessage) error {
 	if dp.PreviousPointInTime != nil {
-		if dp.PointInTime <= *dp.PreviousPointInTime {
+		if dp.PointInTime < *dp.PreviousPointInTime {
 			return fmt.Errorf("point in time must be greater than previous point in time")
+		}
+		if dp.PointInTime == *dp.PreviousPointInTime {
+			logger := app.Service.Logger.New("orderedsync")
+			logger.Info("point in time already exists, skip store", "topic", dp.Topic)
+			return nil
 		}
 	}
 


### PR DESCRIPTION
This fix the issue where a vote is casted again, the signer should skip vote, but server should handle this

This pr fixes multiple issues:
- [890f74b](https://github.com/kwilteam/kwil-db/pull/1465/commits/890f74b706a218f8dd630e984099508186cee3c6) fix epoch conflict when a vote is re-casted
- [a10fac5](https://github.com/kwilteam/kwil-db/pull/1465/commits/a10fac518895eb124d51b818d8f85bb2447b5a80) a naive but effitive way to avoid eth RPC provider throttle.
-  [0f3c3a3](https://github.com/kwilteam/kwil-db/pull/1465/commits/0f3c3a35ff0a46a543a8474f9694932c155e7e6d) fix decimal operation lose precision issue, due to a mis use of function
- [bb06f91](https://github.com/kwilteam/kwil-db/pull/1465/commits/bb06f91963050c5eaaef64fb4741fbddc35de8f8) add check user balance before 'lock'
- [adc182c](https://github.com/kwilteam/kwil-db/pull/1465/commits/adc182c478511fd54dce4bb0e9a7090fd66d05d8) avoid using array_agg on multiple columns
- [7288f38](https://github.com/kwilteam/kwil-db/pull/1465/commits/7288f3850f42184699078a09246e8fbe9741e629) skip block data point

Also add support for base-sepolia network