### PR TITLE
test: multi-key stress tool

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -434,7 +434,6 @@ func WaitForTx(ctx context.Context, txQuery func(context.Context, types.Hash) (*
 		if err != nil {
 			// Only error out if it's something other than not found.
 			if !errors.Is(err, rpcclient.ErrNotFound) {
-				fmt.Println("not found, still trying")
 				return nil, err
 			} // else not found, try again next time
 		} else if resp.Height > 0 {

--- a/test/stress/harness.go
+++ b/test/stress/harness.go
@@ -83,6 +83,9 @@ func (h *harness) underNonceLock(ctx context.Context, fn func(int64) error) erro
 				h.printf("nonce %d was wrong, reverted to %d\n", nonce, h.nonce)
 				return err
 			}
+			if errors.Is(err, context.Canceled) {
+				return err
+			}
 
 			// For other bcast errors like mempool full, the tx was rejected,
 			// but we already advanced nonce. Try to reset the nonce to what we

--- a/test/stress/scheme.go
+++ b/test/stress/scheme.go
@@ -96,7 +96,7 @@ func (asc *actSchemaClient) getOrCreateUserProfile(ctx context.Context, namespac
 			username := row[0].(string)
 			if username != "" {
 				asc.username = username
-				h.logger.Info(fmt.Sprintf("Found me in list_users: %v", asc.username))
+				h.printf("Found me in list_users: %v", asc.username)
 				return nil
 			}
 		}
@@ -120,7 +120,7 @@ func (asc *actSchemaClient) getOrCreateUserProfile(ctx context.Context, namespac
 	if err != nil {
 		return fmt.Errorf("failed to parse UUID: %w", err)
 	}
-	h.logger.Info(fmt.Sprintf("Added me to users table: %v / %v", userUUID, asc.username))
+	h.printf("Added me to users table: %v / %v", userUUID, asc.username)
 
 	return nil
 }


### PR DESCRIPTION
`-cl N` runs with `N` simultaneous instances with different keys.

The first one is special if `-key` is used.  The first one is responsible for deploying the namespace, or ensuring it is already deployed.  Only then do the rest follow.

For instance, to start 40 concurrent clients with unique keys, each doing 10 action executions ("posts") per block, with a post content length of up to 1461 bytes (variable length with (`-vl`), on a namespaces (`stress_xqbsioz1`) which should already exists since no key is given for the first client: 

```
./stress -ec 10 -el 1462 -ns stress_xqbsioz1 -vl -host http://44.x.y.z:8484 -cb -ei 1ms -ne -cl 40
```