### PR TITLE
testing: detect new execution error field in testing framework

### DIFF
--- a/testing/testing.go
+++ b/testing/testing.go
@@ -349,7 +349,7 @@ func (e *TestCase) runExecution(ctx context.Context, platform *Platform) error {
 		}
 		if e.ErrMsg != "" {
 			expectsErr = true
-			if !strings.Contains(err.Error(), e.ErrMsg) {
+			if !strings.Contains(res.Error.Error(), e.ErrMsg) {
 				return fmt.Errorf(`expected error message to contain substring "%s", received error: %w`, e.ErrMsg, err)
 			}
 		}

--- a/testing/testing.go
+++ b/testing/testing.go
@@ -312,7 +312,7 @@ func (e *TestCase) runExecution(ctx context.Context, platform *Platform) error {
 	platform.Logger.Logf(`executing action "%s" against namespace "%s"`, e.Action, e.Namespace)
 
 	var results [][]any
-	_, err := platform.Engine.Call(&common.EngineContext{
+	res, err := platform.Engine.Call(&common.EngineContext{
 		TxContext: &common.TxContext{
 			Ctx:    ctx,
 			Signer: []byte(caller),
@@ -332,6 +332,11 @@ func (e *TestCase) runExecution(ctx context.Context, platform *Platform) error {
 		return nil
 	})
 	if err != nil {
+		return err
+	}
+
+	// check for an execution error
+	if res.Error != nil {
 		// if error is not nil, the test should only pass if either
 		// Err or ErrMsg or both is set
 		expectsErr := false


### PR DESCRIPTION
Resolves an issue raised by the idOS team here: https://kwilteam.slack.com/archives/C0578NPEU21/p1741700425614239
