### PR TITLE
fix poor use of DB getting height for account and numAccounts RPCS

### DIFF
--- a/core/rpc/json/user/responses.go
+++ b/core/rpc/json/user/responses.go
@@ -21,7 +21,6 @@ type AccountResponse struct {
 	ID      *types.AccountID `json:"id,omitempty"`
 	Balance string           `json:"balance"`
 	Nonce   int64            `json:"nonce"`
-	Height  int64            `json:"height"`
 }
 
 type NumAccountsResponse struct {

--- a/node/accounts/accounts.go
+++ b/node/accounts/accounts.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	AccountsLRUCacheSize = 1000
+	AccountsLRUCacheSize = 4000
 )
 
 // Accounts represents an in-memory cache of accounts stored in a PostgreSQL database.

--- a/node/block_processor/interfaces.go
+++ b/node/block_processor/interfaces.go
@@ -47,7 +47,7 @@ type TxApp interface {
 
 	Price(ctx context.Context, dbTx sql.DB, tx *ktypes.Transaction, chainContext *common.ChainContext) (*big.Int, error)
 	AccountInfo(ctx context.Context, dbTx sql.DB, identifier *ktypes.AccountID, pending bool) (balance *big.Int, nonce int64, err error)
-	NumAccounts(ctx context.Context, dbTx sql.Executor) (int64, error)
+	NumAccounts(ctx context.Context, dbTx sql.Executor) (count, height int64, error error)
 }
 
 // Question:

--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -882,17 +882,7 @@ func (bp *BlockProcessor) AccountInfo(ctx context.Context, db sql.DB, identifier
 	return bp.txapp.AccountInfo(ctx, db, identifier, pending)
 }
 
-// Height is provided to obtain the current height atomically with a call to
-// another method such as AccountInfo via a single database transaction.
-func (bp *BlockProcessor) Height(ctx context.Context, db sql.Executor) (int64, error) {
-	height, _, _, err := meta.GetChainState(ctx, db)
-	if err != nil {
-		return 0, fmt.Errorf("failed to get chain state: %w", err)
-	}
-	return height, nil
-}
-
-func (bp *BlockProcessor) NumAccounts(ctx context.Context, db sql.Executor) (int64, error) {
+func (bp *BlockProcessor) NumAccounts(ctx context.Context, db sql.Executor) (count, height int64, err error) {
 	return bp.txapp.NumAccounts(ctx, db)
 }
 

--- a/node/block_processor/transactions_test.go
+++ b/node/block_processor/transactions_test.go
@@ -675,8 +675,8 @@ func (m *mockTxApp) AccountInfo(ctx context.Context, db sql.DB, acctID *types.Ac
 	return accountBalance, 0, nil
 }
 
-func (a *mockTxApp) NumAccounts(ctx context.Context, tx sql.Executor) (int64, error) {
-	return 1, nil
+func (a *mockTxApp) NumAccounts(ctx context.Context, tx sql.Executor) (int64, int64, error) {
+	return 1, 1, nil
 }
 
 func (m *mockTxApp) ApplyMempool(ctx *common.TxContext, db sql.DB, tx *types.Transaction) error {

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -1077,8 +1077,8 @@ func (d *dummyTxApp) GenesisInit(ctx context.Context, db sql.DB, _ *config.Genes
 func (d *dummyTxApp) AccountInfo(ctx context.Context, dbTx sql.DB, identifier *ktypes.AccountID, pending bool) (balance *big.Int, nonce int64, err error) {
 	return big.NewInt(0), 0, nil
 }
-func (a *dummyTxApp) NumAccounts(ctx context.Context, tx sql.Executor) (int64, error) {
-	return 1, nil
+func (a *dummyTxApp) NumAccounts(ctx context.Context, tx sql.Executor) (int64, int64, error) {
+	return 1, 1, nil
 }
 
 func (d *dummyTxApp) ApplyMempool(ctx *common.TxContext, db sql.DB, tx *ktypes.Transaction) error {

--- a/node/nogossip.go
+++ b/node/nogossip.go
@@ -79,7 +79,7 @@ func (n *Node) txAnnStreamHandler(s network.Stream) {
 
 	ctx := context.Background()
 	if err := n.ce.QueueTx(ctx, ntx); err != nil {
-		n.log.Warnf("tx %v failed check: %v from peer: %s", txHash, err, s.Conn().RemotePeer())
+		n.log.Warnf("tx %v (sz %d) failed check: %v from peer: %s", txHash, len(rawTx), err, s.Conn().RemotePeer())
 		return
 	}
 

--- a/node/services/jsonrpc/usersvc/service.go
+++ b/node/services/jsonrpc/usersvc/service.go
@@ -47,9 +47,8 @@ type BlockchainTransactor interface {
 }
 
 type NodeApp interface {
-	Height(context.Context, sql.Executor) (int64, error)
 	AccountInfo(ctx context.Context, db sql.DB, account *types.AccountID, pending bool) (balance *big.Int, nonce int64, err error)
-	NumAccounts(ctx context.Context, db sql.Executor) (int64, error)
+	NumAccounts(ctx context.Context, db sql.Executor) (count, height int64, err error)
 	Price(ctx context.Context, dbTx sql.DB, tx *types.Transaction) (*big.Int, error)
 	GetMigrationMetadata(ctx context.Context) (*types.MigrationMetadata, error)
 }
@@ -616,11 +615,6 @@ func (svc *Service) Account(ctx context.Context, req *userjson.AccountRequest) (
 	readTx := svc.db.BeginDelayedReadTx()
 	defer readTx.Rollback(ctx)
 
-	height, err := svc.nodeApp.Height(ctx, readTx)
-	if err != nil {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorAccountInternal, "failed to get height", nil)
-	}
-
 	balance, nonce, err := svc.nodeApp.AccountInfo(ctx, readTx, req.ID, uncommitted)
 	if err != nil {
 		return nil, jsonrpc.NewError(jsonrpc.ErrorAccountInternal, "account info error", nil)
@@ -636,18 +630,13 @@ func (svc *Service) Account(ctx context.Context, req *userjson.AccountRequest) (
 		ID:      ident, // nil for non-existent account
 		Nonce:   nonce,
 		Balance: balance.String(),
-		Height:  height,
 	}, nil
 }
 
 func (svc *Service) NumAccounts(ctx context.Context, req *userjson.NumAccountsRequest) (*userjson.NumAccountsResponse, *jsonrpc.Error) {
 	readTx := svc.db.BeginDelayedReadTx()
 	defer readTx.Rollback(ctx)
-	height, err := svc.nodeApp.Height(ctx, readTx)
-	if err != nil {
-		return nil, jsonrpc.NewError(jsonrpc.ErrorAccountInternal, "failed to get height", nil)
-	}
-	num, err := svc.nodeApp.NumAccounts(ctx, readTx)
+	num, height, err := svc.nodeApp.NumAccounts(ctx, readTx)
 	if err != nil {
 		svc.log.Error("failed to count accounts", "error", err)
 		return nil, jsonrpc.NewError(jsonrpc.ErrorAccountInternal, "failed to count accounts", nil)

--- a/node/services/jsonrpc/usersvc/user.openrpc.json
+++ b/node/services/jsonrpc/usersvc/user.openrpc.json
@@ -505,9 +505,6 @@
           "balance": {
             "type": "string"
           },
-          "height": {
-            "type": "integer"
-          },
           "id": {
             "type": "object",
             "$ref": "#/components/schemas/accountID"

--- a/node/txapp/txapp.go
+++ b/node/txapp/txapp.go
@@ -22,6 +22,7 @@ import (
 	"github.com/kwilteam/kwil-db/extensions/hooks"
 	"github.com/kwilteam/kwil-db/extensions/resolutions"
 	"github.com/kwilteam/kwil-db/node/accounts"
+	"github.com/kwilteam/kwil-db/node/meta"
 	"github.com/kwilteam/kwil-db/node/types/sql"
 	"github.com/kwilteam/kwil-db/node/voting"
 )
@@ -626,8 +627,17 @@ func (r *TxApp) AccountInfo(ctx context.Context, db sql.DB, acctID *types.Accoun
 	return a.Balance, a.Nonce, nil
 }
 
-func (r *TxApp) NumAccounts(ctx context.Context, db sql.Executor) (int64, error) {
-	return r.Accounts.NumAccounts(ctx, db)
+func (r *TxApp) NumAccounts(ctx context.Context, db sql.Executor) (int64, int64, error) {
+	// TODO: provide a cache for this information so RPC doesn't have to hit DB.
+	count, err := r.Accounts.NumAccounts(ctx, db)
+	if err != nil {
+		return 0, 0, err
+	}
+	height, _, _, err := meta.GetChainState(ctx, db)
+	if err != nil {
+		return 0, 0, err
+	}
+	return count, height, nil
 }
 
 // UpdateValidator updates a validator's power.


### PR DESCRIPTION
This addresses a poor last minute design change to the RPC's `AccountResponse` which added a height field.  It turns out that this completely defeated the important account info caching at different levels, actually guaranteeing the use of a DB read-only transaction to service a `user.account` RPC.  This reverts that change.

This also modifies how the `NumAccount` method works so that it gets height along with count in the same DB transaction rather than making that the caller's (`Service`) job.