### PR TITLE
Fix the contention on the DB read accesses

### DIFF
--- a/app/node/build.go
+++ b/app/node/build.go
@@ -94,7 +94,7 @@ func buildServer(ctx context.Context, d *coreDependencies) *server {
 	migrator := buildMigrator(d, ctx, db, accounts, vs)
 
 	// BlockProcessor
-	bp := buildBlockProcessor(ctx, d, db, txApp, accounts, vs, snapshotStore, es, migrator, bs)
+	bp := buildBlockProcessor(ctx, d, db, txApp, accounts, vs, snapshotStore, es, migrator, bs, mp)
 
 	// Consensus
 	ce := buildConsensusEngine(ctx, d, db, mp, bs, bp)
@@ -443,10 +443,10 @@ func buildTxApp(ctx context.Context, d *coreDependencies, db *pg.DB, accounts *a
 	return txapp
 }
 
-func buildBlockProcessor(ctx context.Context, d *coreDependencies, db *pg.DB, txapp *txapp.TxApp, accounts *accounts.Accounts, vs *voting.VoteStore, ss *snapshotter.SnapshotStore, es *voting.EventStore, migrator *migrations.Migrator, bs *store.BlockStore) *blockprocessor.BlockProcessor {
+func buildBlockProcessor(ctx context.Context, d *coreDependencies, db *pg.DB, txapp *txapp.TxApp, accounts *accounts.Accounts, vs *voting.VoteStore, ss *snapshotter.SnapshotStore, es *voting.EventStore, migrator *migrations.Migrator, bs *store.BlockStore, mp *mempool.Mempool) *blockprocessor.BlockProcessor {
 	signer := auth.GetNodeSigner(d.privKey)
 
-	bp, err := blockprocessor.NewBlockProcessor(ctx, db, txapp, accounts, vs, ss, es, migrator, bs, d.genesisCfg, signer, d.logger.New("BP"))
+	bp, err := blockprocessor.NewBlockProcessor(ctx, db, txapp, accounts, vs, ss, es, migrator, bs, mp, d.genesisCfg, signer, d.logger.New("BP"))
 	if err != nil {
 		failBuild(err, "failed to create block processor")
 	}

--- a/node/block_processor/interfaces.go
+++ b/node/block_processor/interfaces.go
@@ -7,6 +7,7 @@ import (
 	"github.com/kwilteam/kwil-db/common"
 	"github.com/kwilteam/kwil-db/config"
 	ktypes "github.com/kwilteam/kwil-db/core/types"
+	"github.com/kwilteam/kwil-db/node/mempool"
 	"github.com/kwilteam/kwil-db/node/migrations"
 	"github.com/kwilteam/kwil-db/node/snapshotter"
 	"github.com/kwilteam/kwil-db/node/txapp"
@@ -24,6 +25,7 @@ type DB interface {
 	sql.ReadTxMaker
 	sql.SnapshotTxMaker
 	sql.DelayedReadTxMaker
+	sql.ReservedReadTxMaker
 }
 
 type Accounts interface {
@@ -34,6 +36,10 @@ type ValidatorModule interface {
 	GetValidators() []*ktypes.Validator
 	ValidatorUpdates() map[string]*ktypes.Validator
 	LoadValidatorSet(ctx context.Context, db sql.Executor) error
+}
+
+type Mempool interface {
+	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
 }
 
 type TxApp interface {

--- a/node/consensus/blocksync.go
+++ b/node/consensus/blocksync.go
@@ -139,7 +139,7 @@ SYNC:
 
 		err := ce.applyBlock(ctx, rawBlk, ci, blkID) // fatal
 		if err != nil {
-			return fmt.Errorf("failed to apply block: %w", err)
+			return fmt.Errorf("failed to apply block at height: %d: error: %w", height, err)
 		}
 
 		cnt++
@@ -153,7 +153,7 @@ SYNC:
 		height++
 	}
 
-	ce.log.Info("Block sync completed", "startHeight", startHeight, "endHeight", height, "elapsed", time.Since(t0))
+	ce.log.Info("Block sync completed", "startHeight", startHeight, "endHeight", height-1, "elapsed", time.Since(t0))
 	return nil
 }
 
@@ -207,7 +207,7 @@ func (ce *ConsensusEngine) applyBlock(ctx context.Context, rawBlk []byte, ci *kt
 	}
 
 	if err := ce.processAndCommit(ctx, blk, ci, blkID, true); err != nil {
-		return fmt.Errorf("failed to apply block: %w", err)
+		return err
 	}
 
 	return nil

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -155,14 +155,15 @@ func generateTestCEConfig(t *testing.T, nodes int, leaderDB bool) ([]*Config, ma
 
 		ev := &mockEventStore{}
 		m := &mockMigrator{}
+		mp := mempool.New(mempoolSz)
 
-		bp, err := blockprocessor.NewBlockProcessor(ctx, db, txapp, accounts, v, ss, ev, m, bs, genCfg, signer, logger.New(fmt.Sprintf("BP%d", i)))
+		bp, err := blockprocessor.NewBlockProcessor(ctx, db, txapp, accounts, v, ss, ev, m, bs, mp, genCfg, signer, logger.New(fmt.Sprintf("BP%d", i)))
 		assert.NoError(t, err)
 
 		ceConfigs[i] = &Config{
 			PrivateKey:     privKeys[i],
 			Leader:         pubKeys[0],
-			Mempool:        mempool.New(mempoolSz),
+			Mempool:        mp,
 			BlockStore:     bs,
 			BlockProcessor: bp,
 			// ValidatorSet:          validatorSet,

--- a/node/consensus/follower.go
+++ b/node/consensus/follower.go
@@ -428,7 +428,10 @@ func (ce *ConsensusEngine) processAndCommit(ctx context.Context, blk *ktypes.Blo
 		// dump the statehashes from the block processor for debugging
 		sh := ce.blockProcessor.StateHashes()
 		if syncing {
-			ce.log.Info("AppState updates", "updates", sh.String())
+			ce.log.Info("AppState updates: ",
+				"prevAppHash", sh.PrevApp[:8], "changesets", sh.Changeset[:8],
+				"validatorset", sh.ValUpdates[:8], "accounts", sh.Accounts[:8],
+				"txResults", sh.TxResults[:8], "params", sh.ParamUpdates[:8])
 		}
 
 		haltR := fmt.Sprintf("processAndCommit: AppHash mismatch, halting the node. expected: %s, received: %s", ce.state.blockRes.appHash, ci.AppHash)

--- a/node/consensus/interfaces.go
+++ b/node/consensus/interfaces.go
@@ -5,7 +5,6 @@ import (
 	"time"
 
 	blockprocessor "github.com/kwilteam/kwil-db/node/block_processor"
-	"github.com/kwilteam/kwil-db/node/mempool"
 
 	ktypes "github.com/kwilteam/kwil-db/core/types"
 	"github.com/kwilteam/kwil-db/node/types"
@@ -25,7 +24,6 @@ type DB interface {
 type Mempool interface {
 	PeekN(maxTxns, totalSizeLimit int) []*types.Tx
 	Remove(txid types.Hash)
-	RecheckTxs(ctx context.Context, checkFn mempool.CheckFn)
 	Store(*types.Tx) (have, rejected bool)
 	TxsAvailable() bool
 	Size() (totalBytes, numTxns int)
@@ -52,6 +50,7 @@ type BlockProcessor interface {
 	Close() error
 
 	CheckTx(ctx context.Context, tx *types.Tx, height int64, blockTime time.Time, recheck bool) error
+	RecheckTxs(ctx context.Context, height int64, blockTime time.Time) error
 
 	GetValidators() []*ktypes.Validator
 	ConsensusParams() *ktypes.NetworkParameters

--- a/node/consensus/leader.go
+++ b/node/consensus/leader.go
@@ -173,7 +173,8 @@ func (ce *ConsensusEngine) proposeBlock(ctx context.Context) error {
 
 			// Recheck the transactions in the mempool
 			ce.mempoolMtx.PriorityLock()
-			ce.mempool.RecheckTxs(ctx, ce.recheckTxFn(ce.lastBlockInternal()))
+			lh, t := ce.lastBlockInternal()
+			ce.blockProcessor.RecheckTxs(ctx, lh, t)
 			ce.mempoolMtx.Unlock()
 
 			// signal ce to start a new round

--- a/node/node_live_test.go
+++ b/node/node_live_test.go
@@ -119,7 +119,7 @@ func TestSingleNodeMocknet(t *testing.T) {
 	require.NoError(t, err)
 
 	bpl := log.New(log.WithName("BP1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured))
-	bp, err := blockprocessor.NewBlockProcessor(ctx, db1, txapp, accounts, vsReal, ss, es, migrator, bs1, genCfg, signer1, bpl)
+	bp, err := blockprocessor.NewBlockProcessor(ctx, db1, txapp, accounts, vsReal, ss, es, migrator, bs1, mp1, genCfg, signer1, bpl)
 	require.NoError(t, err)
 
 	ceCfg1 := &consensus.Config{
@@ -280,7 +280,7 @@ func TestDualNodeMocknet(t *testing.T) {
 	require.NoError(t, err)
 
 	bpl1 := log.New(log.WithName("BP1"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured))
-	bp1, err := blockprocessor.NewBlockProcessor(ctx, db1, txapp1, accounts1, vstore1, ss, es1, migrator, bs1, genCfg, signer1, bpl1)
+	bp1, err := blockprocessor.NewBlockProcessor(ctx, db1, txapp1, accounts1, vstore1, ss, es1, migrator, bs1, mp1, genCfg, signer1, bpl1)
 	require.NoError(t, err)
 
 	ceCfg1 := &consensus.Config{
@@ -353,7 +353,7 @@ func TestDualNodeMocknet(t *testing.T) {
 	require.NoError(t, err)
 
 	bpl2 := log.New(log.WithName("BP2"), log.WithWriter(os.Stdout), log.WithLevel(log.LevelDebug), log.WithFormat(log.FormatUnstructured))
-	bp2, err := blockprocessor.NewBlockProcessor(ctx, db2, txapp2, accounts2, vstore2, ss, es2, migrator2, bs2, genCfg, signer2, bpl2)
+	bp2, err := blockprocessor.NewBlockProcessor(ctx, db2, txapp2, accounts2, vstore2, ss, es2, migrator2, bs2, mp2, genCfg, signer2, bpl2)
 	require.NoError(t, err)
 
 	ceCfg2 := &consensus.Config{

--- a/node/services/jsonrpc/usersvc/service.go
+++ b/node/services/jsonrpc/usersvc/service.go
@@ -55,7 +55,6 @@ type NodeApp interface {
 }
 
 type Validators interface {
-	SetValidatorPower(ctx context.Context, tx sql.Executor, pubKey []byte, pubKeyType crypto.KeyType, power int64) error
 	GetValidatorPower(ctx context.Context, pubKey []byte, pubKeyType crypto.KeyType) (int64, error)
 	GetValidators() []*types.Validator
 }

--- a/node/types/sql/sql.go
+++ b/node/types/sql/sql.go
@@ -119,6 +119,10 @@ type DelayedReadTxMaker interface {
 	BeginDelayedReadTx() OuterReadTx
 }
 
+type ReservedReadTxMaker interface {
+	BeginReservedReadTx(ctx context.Context) (Tx, error)
+}
+
 // PreparedTx is an outermost database transaction that uses two-phase commit
 // with the Precommit method.
 //


### PR DESCRIPTION
This PR fixes, the DB read access contention that's holding back the consensus engine from making progress. CE will now use reservedReads for DB access within the consensus path. 

Also fixes the `Closed the DB with an active transaction` issue in the failure scenarios during catchup. 
