### PR TITLE
client,kwil-cli: skip auth option for query

### DIFF
--- a/cmd/kwil-cli/cmds/database/call.go
+++ b/cmd/kwil-cli/cmds/database/call.go
@@ -146,7 +146,9 @@ func (r *respCall) MarshalText() (text []byte, err error) {
 
 // buildExecutionInputs will build the inputs for an action execution/call.
 func buildExecutionInputs(ctx context.Context, client clientType.Client, namespace string, action string, inputs []map[string]string) ([][]any, error) {
-	params, err := GetParamList(ctx, client.Query, namespace, action)
+	params, err := GetParamList(ctx, func(ctx context.Context, query string, args map[string]any) (*types.QueryResult, error) {
+		return client.Query(ctx, query, args, false)
+	}, namespace, action)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/kwil-cli/cmds/database/query.go
+++ b/cmd/kwil-cli/cmds/database/query.go
@@ -28,6 +28,7 @@ kwil-cli database query "SELECT * FROM users WHERE age > 25" --namespace somedb`
 
 func queryCmd() *cobra.Command {
 	fmtConf := tableConfig{}
+	var noAuth bool
 	cmd := &cobra.Command{
 		Use:        `query <select_statement>`,
 		Short:      "Query a database using an ad-hoc SQL SELECT statement.",
@@ -53,7 +54,7 @@ func queryCmd() *cobra.Command {
 						}
 					}
 
-					data, err := client.Query(ctx, args[0], params)
+					data, err := client.Query(ctx, args[0], params, noAuth)
 					if err != nil {
 						return display.PrintErr(cmd, fmt.Errorf("error querying database: %w", err))
 					}
@@ -68,6 +69,7 @@ func queryCmd() *cobra.Command {
 		},
 	}
 
+	cmd.Flags().BoolVar(&noAuth, "no-auth", false, "Do not authenticate in query requests even if private key is configured.")
 	cmd.Flags().IntVarP(&fmtConf.width, "width", "w", 0, "Set the width of the table columns. Text beyond this width will be wrapped.")
 	cmd.Flags().BoolVar(&fmtConf.topAndBottomBorder, "row-border", false, "Show border lines between rows.")
 	cmd.Flags().IntVar(&fmtConf.maxRowWidth, "max-row-width", 0, "Set the maximum width of the row. Text beyond this width will be truncated.")

--- a/cmd/kwil-cli/cmds/exec-action.go
+++ b/cmd/kwil-cli/cmds/exec-action.go
@@ -102,8 +102,10 @@ func execActionCmd() *cobra.Command {
 				}
 
 				return client.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl clientType.Client, conf *config.KwilCliConfig) error {
-					// if named params are specified, we need to query the action to find their positions
-					paramList, err := GetParamList(ctx, cl.Query, namespace, args[0])
+					// if named params are specified (they are here with csv), we need to query the action to find their positions
+					paramList, err := GetParamList(ctx, func(ctx context.Context, query string, args map[string]any) (*types.QueryResult, error) {
+						return cl.Query(ctx, query, args, false)
+					}, namespace, args[0])
 					if err != nil {
 						return display.PrintErr(cmd, err)
 					}
@@ -136,7 +138,9 @@ func execActionCmd() *cobra.Command {
 			return client.DialClient(cmd.Context(), cmd, 0, func(ctx context.Context, cl clientType.Client, conf *config.KwilCliConfig) error {
 				// if named params are specified, we need to query the action to find their positions
 				if len(namedParams) > 0 {
-					paramList, err := GetParamList(ctx, cl.Query, namespace, args[0])
+					paramList, err := GetParamList(ctx, func(ctx context.Context, query string, args map[string]any) (*types.QueryResult, error) {
+						return cl.Query(ctx, query, args, false)
+					}, namespace, args[0])
 					if err != nil {
 						return display.PrintErr(cmd, err)
 					}

--- a/cmd/kwil-cli/cmds/query.go
+++ b/cmd/kwil-cli/cmds/query.go
@@ -82,7 +82,7 @@ func queryCmd() *cobra.Command {
 			}
 
 			return client.DialClient(cmd.Context(), cmd, dialFlags, func(ctx context.Context, cl clientType.Client, conf *config.KwilCliConfig) error {
-				res, err := cl.Query(ctx, sqlStmt, params)
+				res, err := cl.Query(ctx, sqlStmt, params, !rpcAuth)
 				if err != nil {
 					return display.PrintErr(cmd, err)
 				}
@@ -96,8 +96,8 @@ func queryCmd() *cobra.Command {
 	// this has to be StringArrayVar because if the user is passing an array, it will contain a comma, but it itself is a single parameter.
 	// If we use StringSliceVar, it will split the array into multiple parameters.
 	cmd.Flags().StringArrayVarP(&namedParams, "param", "p", nil, `named parameters that will be used in the query. format: "key:type=value"`)
-	cmd.Flags().BoolVar(&rpcAuth, "rpc-auth", false, "signals that the call is being made to a kwil node and should be authenticated with the private key")
-	cmd.Flags().BoolVar(&gwAuth, "gateway-auth", false, "signals that the call is being made to a gateway and should be authenticated with the private key")
+	cmd.Flags().BoolVar(&rpcAuth, "rpc-auth", false, "signals that the query is being made to a kwil node and should be authenticated with the private key")
+	cmd.Flags().BoolVar(&gwAuth, "gateway-auth", false, "signals that the query is being made to a gateway and should be authenticated with the private key")
 	display.BindTableFlags(cmd)
 	return cmd
 }

--- a/core/client/client.go
+++ b/core/client/client.go
@@ -347,13 +347,13 @@ func (c *Client) Call(ctx context.Context, namespace string, action string, inpu
 }
 
 // Query executes a query.
-func (c *Client) Query(ctx context.Context, query string, params map[string]any) (*types.QueryResult, error) {
+func (c *Client) Query(ctx context.Context, query string, params map[string]any, skipAuth bool) (*types.QueryResult, error) {
 	if params == nil {
 		params = make(map[string]any)
 	}
 
 	// if a private key is configured, we should automatically authenticate.
-	if c.Signer() != nil {
+	if !skipAuth && c.Signer() != nil {
 		challenge, err := c.challenge(ctx)
 		if err != nil {
 			return nil, err

--- a/core/client/example/main.go
+++ b/core/client/example/main.go
@@ -84,7 +84,7 @@ func main() {
 	fmt.Printf("Account %s balance = %v, nonce = %d\n", acctID, acctInfo.Balance, acctInfo.Nonce)
 
 	// List previously deployed namespaces.
-	qr, err := cl.Query(ctx, "select name from info.namespaces", nil)
+	qr, err := cl.Query(ctx, "select name from info.namespaces", nil, true)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/core/client/types/client.go
+++ b/core/client/types/client.go
@@ -23,7 +23,7 @@ type Client interface {
 	ExecuteSQL(ctx context.Context, sql string, params map[string]any, opts ...TxOpt) (types.Hash, error)
 	GetAccount(ctx context.Context, account *types.AccountID, status types.AccountStatus) (*types.Account, error)
 	Ping(ctx context.Context) (string, error)
-	Query(ctx context.Context, query string, params map[string]any) (*types.QueryResult, error)
+	Query(ctx context.Context, query string, params map[string]any, auth bool) (*types.QueryResult, error)
 	TxQuery(ctx context.Context, txHash types.Hash) (*types.TxQueryResponse, error)
 	WaitTx(ctx context.Context, txHash types.Hash, interval time.Duration) (*types.TxQueryResponse, error)
 	Transfer(ctx context.Context, to *types.AccountID, amount *big.Int, opts ...TxOpt) (types.Hash, error)

--- a/test/acceptance/act_test.go
+++ b/test/acceptance/act_test.go
@@ -358,7 +358,7 @@ func Test_Roundtrip(t *testing.T) {
 
 				res, err := client.Query(ctx, `SELECT * FROM data_types WHERE id = $id`, map[string]any{
 					"id": id,
-				})
+				}, true)
 				require.NoError(t, err)
 				err = res.Scan(func() error { return nil }, &outID, &outText, &outTextArr, &outInt, &outIntArr, &outNum, &outNumArr, &outBool, &outBoolArr, &outBytes, &outBytesArr, &outUUID, &outUUIDArr)
 				require.NoError(t, err)

--- a/test/setup/jsonrpc_cli_driver.go
+++ b/test/setup/jsonrpc_cli_driver.go
@@ -111,7 +111,7 @@ func (j *jsonRPCCLIDriver) Identifier() string {
 }
 
 func (j *jsonRPCCLIDriver) Call(ctx context.Context, namespace string, action string, inputs []any) (*types.CallResult, error) {
-	args := []string{"call-action", "--logs", "--rpc-auth"}
+	args := []string{"call-action", "--logs", "--rpc-auth"} // always assume private RPC mode
 	if j.usingGateway {
 		args = append(args, "--gateway-auth")
 	}
@@ -394,7 +394,7 @@ func (j *jsonRPCCLIDriver) Ping(ctx context.Context) (string, error) {
 	return r, err
 }
 
-func (j *jsonRPCCLIDriver) Query(ctx context.Context, query string, params map[string]any) (*types.QueryResult, error) {
+func (j *jsonRPCCLIDriver) Query(ctx context.Context, query string, params map[string]any, _ bool) (*types.QueryResult, error) {
 	args := []string{"query", query}
 	for k, v := range params {
 		encoded, err := types.EncodeValue(v)

--- a/test/specifications/dsl.go
+++ b/test/specifications/dsl.go
@@ -47,7 +47,7 @@ type ExecuteQueryDsl interface {
 	// ExecuteAction executes QUERY to a database
 	Execute(ctx context.Context, namespace string, actionName string, actionInputs [][]any, opts ...client.TxOpt) (types.Hash, error)
 	ExecuteSQL(ctx context.Context, sql string, params map[string]any, opts ...client.TxOpt) (types.Hash, error)
-	Query(ctx context.Context, query string, params map[string]any) (*types.QueryResult, error)
+	Query(ctx context.Context, query string, params map[string]any, auth bool) (*types.QueryResult, error)
 	// SupportBatch() bool
 }
 

--- a/test/specifications/namespace.go
+++ b/test/specifications/namespace.go
@@ -73,7 +73,7 @@ func AddUserSpecification(ctx context.Context, t *testing.T, execute ExecuteQuer
 }
 
 func ListUsersSpecification(ctx context.Context, t *testing.T, execute ExecuteQueryDsl, expectFailure bool, numUsers int) {
-	res, err := execute.Query(ctx, fmt.Sprintf("{%s}SELECT * FROM users;", namespace), nil)
+	res, err := execute.Query(ctx, fmt.Sprintf("{%s}SELECT * FROM users;", namespace), nil, false)
 	if expectFailure {
 		require.Error(t, err)
 		return
@@ -87,7 +87,7 @@ func ListUsersSpecification(ctx context.Context, t *testing.T, execute ExecuteQu
 
 func ListUsersEventuallySpecification(ctx context.Context, t *testing.T, execute ExecuteQueryDsl, expectFailure bool, numUsers int) {
 	require.Eventually(t, func() bool {
-		res, err := execute.Query(ctx, fmt.Sprintf("{%s}SELECT * FROM users;", namespace), nil)
+		res, err := execute.Query(ctx, fmt.Sprintf("{%s}SELECT * FROM users;", namespace), nil, false)
 		return expectFailure && err != nil || res != nil && len(res.Values) == numUsers
 	}, 2*time.Minute, 1*time.Second)
 }

--- a/test/stress/hammer.go
+++ b/test/stress/hammer.go
@@ -139,7 +139,7 @@ func hammer(ctx context.Context, key string, tag string, dbReady chan struct{}) 
 	asc := newActSchemaClient(h, namespace)
 
 	// try to use this namespace if it exists, otherwise deploy a new one
-	res, err := h.Client.Query(ctx, fmt.Sprintf(`select exists (select 1 from info.namespaces where name = '%s');`, namespace), nil)
+	res, err := h.Client.Query(ctx, fmt.Sprintf(`select exists (select 1 from info.namespaces where name = '%s');`, namespace), nil, true)
 	if err != nil {
 		return err
 	}

--- a/test/stress/transport.go
+++ b/test/stress/transport.go
@@ -62,11 +62,11 @@ func (tc *timedClient) Ping(ctx context.Context) (string, error) {
 	return tc.Client.Ping(ctx)
 }
 
-func (tc *timedClient) Query(ctx context.Context, query string, params map[string]any) (*types.QueryResult, error) {
+func (tc *timedClient) Query(ctx context.Context, query string, params map[string]any, skipAuth bool) (*types.QueryResult, error) {
 	if tc.showReqDur {
 		defer tc.printDur(time.Now(), "Query")
 	}
-	return tc.Client.Query(ctx, query, params)
+	return tc.Client.Query(ctx, query, params, skipAuth)
 }
 
 func (tc *timedClient) TxQuery(ctx context.Context, hash types.Hash) (*types.TxQueryResponse, error) {


### PR DESCRIPTION
Authenticated query became the default recently if the client has a Signer (private key) configured.

This provides a way to use legacy unauthenticated queries even when your client has a private key configured.

The use case is that very often a simple query into the `'info'` name space requires no authentication out of the box, but doing auth incurs an extra RPC round trip to get a challenge (and associated server overhead with creating, persisting, and verifying the challenge and signature).  In the specific case of stress testing, with enough keys it will fail to get a challenge.