### PR TITLE
engine: fix bug where in-line selects can be revoked

### DIFF
--- a/node/engine/interpreter/context.go
+++ b/node/engine/interpreter/context.go
@@ -36,6 +36,8 @@ type executionContext struct {
 	// This is used to prevent nested queries, which can cause
 	// a deadlock or unexpected behavior.
 	queryActive bool
+	// inAction is true if the execution is currently in an action.
+	inAction bool
 }
 
 // subscope creates a new subscope execution context.
@@ -51,6 +53,7 @@ func (e *executionContext) subscope(namespace string) *executionContext {
 		db:             e.db,
 		interpreter:    e.interpreter,
 		logs:           e.logs,
+		inAction:       true,
 	}
 }
 
@@ -58,6 +61,10 @@ func (e *executionContext) subscope(namespace string) *executionContext {
 // and returns an error if they do not.
 func (e *executionContext) checkPrivilege(priv privilege) error {
 	if e.engineCtx.OverrideAuthz {
+		return nil
+	}
+
+	if e.inAction {
 		return nil
 	}
 


### PR DESCRIPTION
Fixes a bug where in-line SELECT statements would improperly have access control rules added.

If an in-line SELECT (a SELECT that is not a standalone statement, but instead part of a for loop or return) is used and SELECT is revoked, then the engine would improperly complain that the user did not have the correct privilege. This was not caught previously because the only time this is possible is if SELECT is used in FOR or RETURN, and any test we have that checks for revoking SELECT privileges did not also try to execute an action that uses either FOR or RETURN SELECT with a private key that does not have permission to execute ad-hoc SELECTs.

The issue is fixed by simply adding an additional piece of logic that informs out interpreter if we are in an action, and if so, disabling privilege checks.