### PR TITLE
engine: fix window function ranking bug

### DIFF
--- a/node/engine/planner/logical/planner.go
+++ b/node/engine/planner/logical/planner.go
@@ -692,7 +692,7 @@ func (s *scopeContext) selectCore(node *parse.SelectCore) (preProjectPlan Plan, 
 			return nil, nil, nil, nil, nil, fmt.Errorf(`%w: window "%s" is already defined`, ErrWindowAlreadyDefined, window.Name)
 		}
 
-		win, err := s.planWindow(plan, rel, window.Window, groupingTerms)
+		win, err := s.planWindow(plan, rel, window.Window, groupingTerms, window.Name)
 		if err != nil {
 			return nil, nil, nil, nil, nil, err
 		}
@@ -846,7 +846,7 @@ func (s *scopeContext) makeOnWindowFunc(unnamedWindows *[]*Window, namedWindows 
 			panic(fmt.Sprintf("unexpected window type %T", ewfc.Window))
 		case *parse.WindowImpl:
 			// it is an anonymous window, so we need to create a new window node
-			window, err := s.planWindow(plan, rel, win, groupingTerms)
+			window, err := s.planWindow(plan, rel, win, groupingTerms, ewfc.FunctionCall.Name)
 			if err != nil {
 				return nil, nil, err
 			}
@@ -1011,7 +1011,7 @@ func (s *scopeContext) selectCoreWithoutFrom(cols []parse.ResultColumn, isDistin
 }
 
 // planWindow plans a window function.
-func (s *scopeContext) planWindow(plan Plan, rel *Relation, win *parse.WindowImpl, groupingTerms map[string]*IdentifiedExpr) (*Window, error) {
+func (s *scopeContext) planWindow(plan Plan, rel *Relation, win *parse.WindowImpl, groupingTerms map[string]*IdentifiedExpr, function string) (*Window, error) {
 	var partitionBy []Expression
 	for _, partition := range win.PartitionBy {
 		partition, _, err := s.expr(partition, rel, groupingTerms)
@@ -1022,26 +1022,37 @@ func (s *scopeContext) planWindow(plan Plan, rel *Relation, win *parse.WindowImp
 		partitionBy = append(partitionBy, partition)
 	}
 
-	// * Default ordering is commented out because it actually is not needed.
 	// Adding ordering to a window function actually changes the definition of the window,
 	// and thus deviates from the user's intent. This is due to how window functions
 	// take into account "peer rows", which is best defined in the Apache Drill documentation:
 	// https://drill.apache.org/docs/sql-window-functions-introduction/
+	// Therefore, we only apply default ordering if the function is strictly a window function.
+	// If it is an aggregate, we do not need to apply default ordering.
 
-	// Adding win
 	// to add default ordering, we need to order by every column in the target relation.
 	// This is extremely inefficient, but it is the only way to guarantee that the default ordering
 	// is applied.
-	// if s.plan.applyDefaultOrdering {
-	// 	for _, field := range rel.Fields {
-	// 		win.OrderBy = append(win.OrderBy, &parse.OrderingTerm{
-	// 			Expression: &parse.ExpressionColumn{
-	// 				Table:  field.Parent,
-	// 				Column: field.Name,
-	// 			},
-	// 		})
-	// 	}
-	// }
+	if s.plan.applyDefaultOrdering {
+		isWindow := false
+
+		// if the function is an aggregate, we do not apply default ordering
+		if fn, ok := engine.Functions[function]; ok {
+			if _, ok := fn.(*engine.WindowFunctionDefinition); ok {
+				isWindow = true
+			}
+		}
+
+		if isWindow {
+			for _, field := range rel.Fields {
+				win.OrderBy = append(win.OrderBy, &parse.OrderingTerm{
+					Expression: &parse.ExpressionColumn{
+						Table:  field.Parent,
+						Column: field.Name,
+					},
+				})
+			}
+		}
+	}
 
 	var orderBy []*SortExpression
 	if len(win.OrderBy) > 0 {

--- a/node/engine/planner/logical/planner.go
+++ b/node/engine/planner/logical/planner.go
@@ -1022,19 +1022,26 @@ func (s *scopeContext) planWindow(plan Plan, rel *Relation, win *parse.WindowImp
 		partitionBy = append(partitionBy, partition)
 	}
 
+	// * Default ordering is commented out because it actually is not needed.
+	// Adding ordering to a window function actually changes the definition of the window,
+	// and thus deviates from the user's intent. This is due to how window functions
+	// take into account "peer rows", which is best defined in the Apache Drill documentation:
+	// https://drill.apache.org/docs/sql-window-functions-introduction/
+
+	// Adding win
 	// to add default ordering, we need to order by every column in the target relation.
 	// This is extremely inefficient, but it is the only way to guarantee that the default ordering
 	// is applied.
-	if s.plan.applyDefaultOrdering {
-		for _, field := range rel.Fields {
-			win.OrderBy = append(win.OrderBy, &parse.OrderingTerm{
-				Expression: &parse.ExpressionColumn{
-					Table:  field.Parent,
-					Column: field.Name,
-				},
-			})
-		}
-	}
+	// if s.plan.applyDefaultOrdering {
+	// 	for _, field := range rel.Fields {
+	// 		win.OrderBy = append(win.OrderBy, &parse.OrderingTerm{
+	// 			Expression: &parse.ExpressionColumn{
+	// 				Table:  field.Parent,
+	// 				Column: field.Name,
+	// 			},
+	// 		})
+	// 	}
+	// }
 
 	var orderBy []*SortExpression
 	if len(win.OrderBy) > 0 {

--- a/node/engine/planner/logical/planner_test.go
+++ b/node/engine/planner/logical/planner_test.go
@@ -292,7 +292,7 @@ func Test_Planner(t *testing.T) {
 			wt: "Return: name [text], sum [numeric(1000,0)]\n" +
 				"└─Project: users.name; {#ref(A)}\n" +
 				"  └─Sort: 1 asc nulls last; 2 asc nulls last\n" +
-				"    └─Window [partition_by=users.name] [order_by=users.age desc nulls last, users.id asc nulls last, users.name asc nulls last, users.age asc nulls last]: {#ref(A) = sum(users.age)}\n" +
+				"    └─Window [partition_by=users.name] [order_by=users.age desc nulls last]: {#ref(A) = sum(users.age)}\n" +
 				"      └─Scan Table: users [physical]\n",
 			defaultOrdering: true,
 		},


### PR DESCRIPTION
This PR fixes a bug found by @outerlook where default ordering applied to window functions actually changed the functional output of a window function. Ordering on window functions actually changes the window itself, thus leading to a semantically different execution result.

This PR removes the orderings applied to aggregates used in functions altogether, as further investigation has shown that they actually aren't necessary. I've included in the code a link to a resource that explains how window functions break ties, and why default ordering is thus not a problem.
