### PR TITLE
data race accessing ce.leader

### DIFF
--- a/node/consensus/engine.go
+++ b/node/consensus/engine.go
@@ -218,7 +218,7 @@ type WhitelistFns struct {
 }
 
 // ProposalBroadcaster broadcasts the new block proposal message to the network
-type ProposalBroadcaster func(ctx context.Context, blk *ktypes.Block)
+type ProposalBroadcaster func(ctx context.Context, blk *ktypes.Block, senderPubkey []byte)
 
 // BlkAnnouncer broadcasts the new committed block to the network using the blockAnn message
 type BlkAnnouncer func(ctx context.Context, blk *ktypes.Block, ci *ktypes.CommitInfo)
@@ -916,7 +916,7 @@ func (ce *ConsensusEngine) rebroadcastBlkProposal(ctx context.Context) {
 
 	if ce.role.Load() == types.RoleLeader && ce.state.blkProp != nil {
 		ce.log.Debug("Rebroadcasting block proposal", "height", ce.state.blkProp.height)
-		go ce.proposalBroadcaster(ctx, ce.state.blkProp.blk)
+		go ce.proposalBroadcaster(ctx, ce.state.blkProp.blk, ce.pubKey.Bytes())
 	}
 }
 

--- a/node/consensus/engine_test.go
+++ b/node/consensus/engine_test.go
@@ -371,7 +371,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkProp",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -398,7 +398,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkProp",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -427,7 +427,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -436,7 +436,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk, nil)
+						val.NotifyBlockProposal(blkProp2.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -463,7 +463,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk, nil)
+						val.NotifyBlockProposal(blkProp2.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -472,7 +472,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -499,7 +499,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -518,7 +518,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew (ignored)",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Committed, 1, zeroHash)
@@ -535,7 +535,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -553,7 +553,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk, nil)
+						val.NotifyBlockProposal(blkProp2.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -580,7 +580,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -616,7 +616,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropOld",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -661,7 +661,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkProp",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp1.blk, nil)
+						val.NotifyBlockProposal(blkProp1.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp1.blkHash)
@@ -706,7 +706,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk, nil)
+						val.NotifyBlockProposal(blkProp2.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -745,7 +745,7 @@ func TestValidatorStateMachine(t *testing.T) {
 				{
 					name: "blkPropNew",
 					trigger: func(t *testing.T, leader, val *ConsensusEngine) {
-						val.NotifyBlockProposal(blkProp2.blk, nil)
+						val.NotifyBlockProposal(blkProp2.blk, leader.pubKey.Bytes(), nil)
 					},
 					verify: func(t *testing.T, leader, val *ConsensusEngine) error {
 						return verifyStatus(t, val, Executed, 0, blkProp2.blkHash)
@@ -1022,7 +1022,7 @@ func mockBlkRequester(ctx context.Context, height int64) (types.Hash, []byte, *k
 	return types.Hash{}, nil, nil, 0, types.ErrBlkNotFound
 }
 
-func mockBlockPropBroadcaster(_ context.Context, blk *ktypes.Block) {}
+func mockBlockPropBroadcaster(_ context.Context, blk *ktypes.Block, sender []byte) {}
 
 func mockVoteBroadcaster(msg *types.AckRes) error {
 	return nil

--- a/node/consensus/leader.go
+++ b/node/consensus/leader.go
@@ -128,7 +128,7 @@ func (ce *ConsensusEngine) proposeBlock(ctx context.Context) error {
 	ce.state.blkProp = blkProp
 
 	// Broadcast the block proposal to the network
-	go ce.proposalBroadcaster(ctx, blkProp.blk)
+	go ce.proposalBroadcaster(ctx, blkProp.blk, ce.pubKey.Bytes())
 
 	// update the stateInfo
 	ce.stateInfo.mtx.Lock()

--- a/node/consensus/messages.go
+++ b/node/consensus/messages.go
@@ -130,7 +130,7 @@ func (ce *ConsensusEngine) sendResetMsg(msg *resetMsg) {
 
 // NotifyBlockProposal is used by the p2p stream handler to notify the consensus engine of a block proposal.
 // Only a validator should receive block proposals and notify the consensus engine, whereas others should ignore this message.
-func (ce *ConsensusEngine) NotifyBlockProposal(blk *ktypes.Block, doneFn func()) {
+func (ce *ConsensusEngine) NotifyBlockProposal(blk *ktypes.Block, sender []byte, doneFn func()) {
 	if ce.role.Load() == types.RoleLeader {
 		return
 	}
@@ -150,7 +150,7 @@ func (ce *ConsensusEngine) NotifyBlockProposal(blk *ktypes.Block, doneFn func())
 	go ce.sendConsensusMessage(&consensusMessage{
 		MsgType: blkProp.Type(),
 		Msg:     blkProp,
-		Sender:  ce.leader.Bytes(),
+		Sender:  sender,
 		done:    done,
 	})
 }

--- a/node/consensus_test.go
+++ b/node/consensus_test.go
@@ -5,10 +5,16 @@ import (
 	"testing"
 	"time"
 
+	"github.com/kwilteam/kwil-db/core/crypto"
 	"github.com/kwilteam/kwil-db/node/types"
 )
 
 func TestBlockProp_MarshalUnmarshal(t *testing.T) {
+	_, pub, err := crypto.GenerateEd25519Key(nil)
+	if err != nil {
+		t.Fatalf("failed to generate key: %v", err)
+	}
+
 	tests := []struct {
 		name    string
 		bp      blockProp
@@ -17,11 +23,12 @@ func TestBlockProp_MarshalUnmarshal(t *testing.T) {
 		{
 			name: "valid block proposal",
 			bp: blockProp{
-				Height:    100,
-				Hash:      [32]byte{1, 2, 3},
-				PrevHash:  [32]byte{4, 5, 6},
-				Stamp:     time.Now().Unix(),
-				LeaderSig: []byte{7, 8, 9, 10},
+				Height:       100,
+				Hash:         [32]byte{1, 2, 3},
+				PrevHash:     [32]byte{4, 5, 6},
+				Stamp:        time.Now().Unix(),
+				LeaderSig:    []byte{7, 8, 9, 10},
+				SenderPubKey: pub.Bytes(),
 			},
 			wantErr: false,
 		},

--- a/node/interfaces.go
+++ b/node/interfaces.go
@@ -18,7 +18,7 @@ type ConsensusEngine interface {
 	InCatchup() bool
 
 	AcceptProposal(height int64, blkID, prevBlkID types.Hash, leaderSig []byte, timestamp int64) bool
-	NotifyBlockProposal(blk *ktypes.Block, done func())
+	NotifyBlockProposal(blk *ktypes.Block, sender []byte, done func())
 
 	AcceptCommit(height int64, blkID types.Hash, hdr *ktypes.BlockHeader, ci *ktypes.CommitInfo, leaderSig []byte) bool
 	NotifyBlockCommit(blk *ktypes.Block, ci *ktypes.CommitInfo, blkID types.Hash, doneFn func())

--- a/node/node.go
+++ b/node/node.go
@@ -352,8 +352,8 @@ func (n *Node) Start(ctx context.Context) error {
 		defer cancel()
 
 		broadcastFns := consensus.BroadcastFns{
-			ProposalBroadcaster: func(ctx context.Context, blk *ktypes.Block) {
-				n.announceBlkProp(ctx, blk, n.host.ID())
+			ProposalBroadcaster: func(ctx context.Context, blk *ktypes.Block, senderPubkey []byte) {
+				n.announceBlkProp(ctx, blk, senderPubkey, n.host.ID())
 			},
 			TxAnnouncer: func(ctx context.Context, txID types.Hash) {
 				n.announceTx(ctx, txID, n.host.ID())

--- a/node/node_test.go
+++ b/node/node_test.go
@@ -341,7 +341,7 @@ func (ce *dummyCE) NotifyResetState(height int64, txIDs []types.Hash, sender []b
 	}
 }
 
-func (ce *dummyCE) NotifyBlockProposal(blk *ktypes.Block, _ func()) {
+func (ce *dummyCE) NotifyBlockProposal(blk *ktypes.Block, pubkey []byte, _ func()) {
 	if ce.blockPropHandler != nil {
 		ce.blockPropHandler(blk)
 		return
@@ -396,8 +396,8 @@ func (ce *dummyCE) Fake() *faker {
 
 type faker dummyCE
 
-func (f *faker) Propose(ctx context.Context, blk *ktypes.Block) {
-	f.proposerBroadcaster(ctx, blk)
+func (f *faker) Propose(ctx context.Context, blk *ktypes.Block, pubkey []byte) {
+	f.proposerBroadcaster(ctx, blk, pubkey)
 }
 
 // func (f *faker) ACK(ack bool, height int64, blkID types.Hash, appHash *types.Hash, sig []byte) error {


### PR DESCRIPTION
This PR fixes a data race issue in the consensus engine that occurs when accessing the `ce.leader` field. The issue arises when block proposal handling and role updates happen concurrently. Specifically, `ce.leader` is incorrectly accessed in `NotifyBlockProposal` to set the block proposal's sender as the current leader. This is problematic not only because the field is accessed without proper locking but also because it assumes that the proposal always comes from the current leader, which is not guaranteed (maybe a leader change scenario)

The fix involves including the sender information directly in the block proposal message, and accessing `ce.leader` fields in the stream handlers and their CE counterparts.