### PR TITLE
chore: support human-readable duration strings in blacklist config

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -304,7 +304,7 @@ func DefaultConfig() *Config {
 			Blacklist: BlacklistConfig{
 				Enable:                    true,
 				AutoBlacklistOnMaxRetries: true,
-				AutoBlacklistDuration:     time.Hour, // 1 hour default for retry exhaustion
+				AutoBlacklistDuration:     types.Duration(time.Hour), // 1 hour default for retry exhaustion
 			},
 		},
 		Consensus: ConsensusConfig{
@@ -454,9 +454,9 @@ type PeerConfig struct {
 // BlacklistConfig contains configuration options for peer blacklisting functionality.
 // Note: Blacklist data is always persisted to address book for restart survival
 type BlacklistConfig struct {
-	Enable                    bool          `toml:"enable" comment:"enable peer blacklisting functionality"`
-	AutoBlacklistOnMaxRetries bool          `toml:"auto_blacklist_on_max_retries" comment:"automatically blacklist peers that exhaust connection retries"`
-	AutoBlacklistDuration     time.Duration `toml:"auto_blacklist_duration" comment:"duration to blacklist peers that exhaust connection retries (0 = permanent)"`
+	Enable                    bool           `toml:"enable" comment:"enable peer blacklisting functionality"`
+	AutoBlacklistOnMaxRetries bool           `toml:"auto_blacklist_on_max_retries" comment:"automatically blacklist peers that exhaust connection retries"`
+	AutoBlacklistDuration     types.Duration `toml:"auto_blacklist_duration" comment:"duration to blacklist peers that exhaust connection retries (0 = permanent)"`
 }
 
 // Validate validates the BlacklistConfig and returns an error if the configuration is invalid.

--- a/node/peers/blacklist_logging_metrics_test.go
+++ b/node/peers/blacklist_logging_metrics_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/trufnetwork/kwil-db/config"
 	"github.com/trufnetwork/kwil-db/core/log"
+	"github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/kwil-db/node/metrics"
 
 	"github.com/libp2p/go-libp2p"
@@ -104,7 +105,7 @@ func TestBlacklistMetricsIntegration(t *testing.T) {
 	blacklistConfig := config.BlacklistConfig{
 		Enable:                    true,
 		AutoBlacklistOnMaxRetries: true,
-		AutoBlacklistDuration:     time.Hour,
+		AutoBlacklistDuration:     types.Duration(time.Hour),
 	}
 
 	// Create PeerMan config
@@ -182,7 +183,7 @@ func TestBlacklistMetricsIntegration(t *testing.T) {
 		// Simulate the auto-blacklist scenario directly (like in maintainMinPeers)
 		// Instead of using a real backoffer, simulate the condition where max attempts are reached
 		maxAttempts := 500
-		duration := pm.blacklistConfig.AutoBlacklistDuration
+		duration := time.Duration(pm.blacklistConfig.AutoBlacklistDuration)
 
 		// This simulates the exact metrics calls from maintainMinPeers
 		metrics.Node.AutoBlacklistEvent(context.Background(), "connection_exhaustion", int64(maxAttempts))
@@ -223,7 +224,7 @@ func TestBlacklistStructuredLogging(t *testing.T) {
 	blacklistConfig := config.BlacklistConfig{
 		Enable:                    true,
 		AutoBlacklistOnMaxRetries: true,
-		AutoBlacklistDuration:     time.Hour,
+		AutoBlacklistDuration:     types.Duration(time.Hour),
 	}
 
 	// Create PeerMan config with test logger
@@ -309,7 +310,7 @@ func TestBlacklistStructuredLogging(t *testing.T) {
 		logBuffer.Reset()
 
 		// Simulate auto-blacklist logging (this would normally be called from maintainMinPeers)
-		duration := pm.blacklistConfig.AutoBlacklistDuration
+		duration := time.Duration(pm.blacklistConfig.AutoBlacklistDuration)
 		attempts := 500
 
 		// This replicates the logging from maintainMinPeers

--- a/node/peers/blacklist_test.go
+++ b/node/peers/blacklist_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/trufnetwork/kwil-db/config"
 	"github.com/trufnetwork/kwil-db/core/log"
+	"github.com/trufnetwork/kwil-db/core/types"
 
 	"github.com/libp2p/go-libp2p"
 	"github.com/libp2p/go-libp2p/core/peer"
@@ -353,7 +354,7 @@ func TestAutoBlacklistOnMaxRetries(t *testing.T) {
 			BlacklistConfig: config.BlacklistConfig{
 				Enable:                    true,
 				AutoBlacklistOnMaxRetries: true,
-				AutoBlacklistDuration:     2 * time.Hour, // Test with 2 hour duration
+				AutoBlacklistDuration:     types.Duration(2 * time.Hour), // Test with 2 hour duration
 			},
 		}
 
@@ -385,7 +386,7 @@ func TestAutoBlacklistOnMaxRetries(t *testing.T) {
 
 		// Simulate the auto-blacklist logic from maintainMinPeers
 		if pm.blacklistConfig.Enable && pm.blacklistConfig.AutoBlacklistOnMaxRetries {
-			duration := pm.blacklistConfig.AutoBlacklistDuration
+			duration := time.Duration(pm.blacklistConfig.AutoBlacklistDuration)
 			pm.BlacklistPeer(testPeerID, "connection_exhaustion", duration) // configurable duration blacklist
 		}
 
@@ -423,7 +424,7 @@ func TestAutoBlacklistOnMaxRetries(t *testing.T) {
 			BlacklistConfig: config.BlacklistConfig{
 				Enable:                    true,
 				AutoBlacklistOnMaxRetries: true,
-				AutoBlacklistDuration:     0, // Permanent blacklist
+				AutoBlacklistDuration:     types.Duration(0), // Permanent blacklist
 			},
 		}
 
@@ -437,7 +438,7 @@ func TestAutoBlacklistOnMaxRetries(t *testing.T) {
 
 		// Simulate the auto-blacklist logic with permanent duration
 		if pm.blacklistConfig.Enable && pm.blacklistConfig.AutoBlacklistOnMaxRetries {
-			pm.BlacklistPeer(testPeerID, "connection_exhaustion", pm.blacklistConfig.AutoBlacklistDuration)
+			pm.BlacklistPeer(testPeerID, "connection_exhaustion", time.Duration(pm.blacklistConfig.AutoBlacklistDuration))
 		}
 
 		// Verify peer is now permanently blacklisted
@@ -462,8 +463,8 @@ func TestAutoBlacklistOnMaxRetries(t *testing.T) {
 			Logger:   log.DiscardLogger,
 			BlacklistConfig: config.BlacklistConfig{
 				Enable:                    true,
-				AutoBlacklistOnMaxRetries: false,     // Disabled
-				AutoBlacklistDuration:     time.Hour, // This won't be used since auto-blacklist is disabled
+				AutoBlacklistOnMaxRetries: false,                     // Disabled
+				AutoBlacklistDuration:     types.Duration(time.Hour), // This won't be used since auto-blacklist is disabled
 			},
 		}
 
@@ -479,7 +480,7 @@ func TestAutoBlacklistOnMaxRetries(t *testing.T) {
 		// Simulate the auto-blacklist logic from maintainMinPeers when auto-blacklist is disabled
 		// This should NOT blacklist the peer because AutoBlacklistOnMaxRetries=false
 		if pm.blacklistConfig.Enable && pm.blacklistConfig.AutoBlacklistOnMaxRetries {
-			duration := pm.blacklistConfig.AutoBlacklistDuration
+			duration := time.Duration(pm.blacklistConfig.AutoBlacklistDuration)
 			pm.BlacklistPeer(testPeerID, "connection_exhaustion", duration)
 		}
 		// If auto-blacklist is disabled, the above condition is false and no blacklisting occurs
@@ -502,7 +503,7 @@ func TestAutoBlacklistOnMaxRetries(t *testing.T) {
 			BlacklistConfig: config.BlacklistConfig{
 				Enable:                    false, // Disabled
 				AutoBlacklistOnMaxRetries: true,
-				AutoBlacklistDuration:     time.Hour, // This won't be used since blacklisting is disabled
+				AutoBlacklistDuration:     types.Duration(time.Hour), // This won't be used since blacklisting is disabled
 			},
 		}
 

--- a/node/peers/peers.go
+++ b/node/peers/peers.go
@@ -385,7 +385,7 @@ func (pm *PeerMan) maintainMinPeers(ctx context.Context) {
 
 						// Auto-blacklist peer that exhausted connection retries if enabled
 						if pm.blacklistConfig.Enable && pm.blacklistConfig.AutoBlacklistOnMaxRetries {
-							duration := pm.blacklistConfig.AutoBlacklistDuration
+							duration := time.Duration(pm.blacklistConfig.AutoBlacklistDuration)
 
 							// Enhanced structured logging for auto-blacklist
 							pm.log.Warn("Auto-blacklisted peer due to connection exhaustion",


### PR DESCRIPTION
Modified AutoBlacklistDuration field to use types.Duration instead of time.Duration, enabling human-readable duration strings in configuration files (e.g., "1h", "30m", "1h30m45s") instead of nanoseconds.

Changes:
- Changed AutoBlacklistDuration type from time.Duration to types.Duration in config/config.go
- Updated all usages to convert types.Duration to time.Duration when needed
- Modified test files to use types.Duration wrapper
- Added comprehensive test coverage for human-readable duration parsing

This improves user experience by allowing intuitive duration configuration like "1h" instead of "3600000000000" nanoseconds, while maintaining consistency with other duration fields in the config that already use types.Duration.

resolves: https://github.com/trufnetwork/kwil-db/issues/1577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Configuration now accepts human‑readable values for P2P blacklist auto-blacklist duration (e.g., “1h30m45s”); a value of 0 indicates a permanent blacklist.

- Refactor
  - Updated internal duration handling for P2P auto-blacklisting to a unified duration type without changing behavior.

- Tests
  - Added tests to validate parsing of auto-blacklist duration values from configuration, including complex durations and zero (permanent).
  - Updated existing tests to use the new duration type and explicit conversions where needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->