### PR TITLE
feat: use @leader contextual variable

### DIFF
--- a/core/client/README.md
+++ b/core/client/README.md
@@ -345,15 +345,18 @@ Actions have access to several built-in contextual variables that provide inform
 - **`@caller`** - The address of the account executing the action
 - **`@txid`** - The unique transaction identifier
 - **`@height`** - The current block height
-- **`@leader`** - The address of the current block leader (validator)
+- **`@block_timestamp`** - The timestamp (Unix seconds) of the current block
+- **`@leader`** - The current block proposer's public key as a lowercase hex-encoded string
 
-These variables can be used for authorization, logging, and generating unique identifiers. For example:
+These variables can be used for authorization, logging, and generating unique identifiers.
+
+NOTE: `@leader` is the proposer's public key in hex. Depending on the authenticator in use, `@caller` may be a derived address (e.g., an Ethereum 0x… address) and not equal to the raw public key hex. Only compare `@caller` to `@leader` if your `@caller` representation matches this encoding, or perform the appropriate conversion in your application.
 
 ```sql
 -- Authorization: Only allow the current leader to execute certain operations
 CREATE ACTION i_am_action($param_one INT, $param_two INT) public {
-    IF @caller != @leader {
-        ERROR('Only the leader node can execute this operations');
+    IF @caller != @leader { -- ensure both use the same representation before comparing
+        ERROR('Only the leader node can execute this operation');
     }
     -- ... your logic
 };

--- a/node/engine/interpreter/context.go
+++ b/node/engine/interpreter/context.go
@@ -555,7 +555,9 @@ func (e *executionContext) getVariable(name string) (Value, error) {
 			if e.engineCtx.InvalidTxCtx {
 				return nil, engine.ErrInvalidTxCtx
 			}
-			// Get leader from block context proposer
+			// Get leader from block context proposer.
+			// Returns lowercase hex of the proposer's public key bytes.
+			// Returns an empty string if the proposer is not available.
 			if e.engineCtx.TxContext.BlockContext.Proposer == nil {
 				return makeText(""), nil
 			}

--- a/node/engine/interpreter/context_test.go
+++ b/node/engine/interpreter/context_test.go
@@ -184,7 +184,7 @@ func TestLeaderVariableInvalidTxContext(t *testing.T) {
 // Helper function to create an Ed25519 key for testing
 func mustCreateEd25519Key(t *testing.T) crypto.PublicKey {
 	t.Helper()
-	// Generate an Ed25519 key for testing
+	// Generate an Ed25519 key for testing (not deterministic across runs)
 	_, pubKey, err := crypto.GenerateEd25519Key(nil)
 	require.NoError(t, err)
 	return pubKey
@@ -193,7 +193,7 @@ func mustCreateEd25519Key(t *testing.T) crypto.PublicKey {
 // Helper function to create a secp256k1 key for testing
 func mustCreateSecp256k1Key(t *testing.T) crypto.PublicKey {
 	t.Helper()
-	// Generate a secp256k1 key for testing
+	// Generate a secp256k1 key for testing (not deterministic across runs)
 	_, pubKey, err := crypto.GenerateSecp256k1Key(nil)
 	require.NoError(t, err)
 	return pubKey
@@ -283,6 +283,10 @@ func TestLeaderAuthorizationScenarios(t *testing.T) {
 			leaderText := leader.(*textValue).String
 
 			// Simulate leader-only authorization check (with hex normalization)
+			// NOTE: We set TxContext.Caller to the hex-encoded public key here
+			// to match @leader's raw pubkey hex. In production, @caller is
+			// derived via the Authenticator (e.g. Ethereum 0x… address)
+			// and will not equal the raw public key hex string.
 			isAuthorized := normalizeHex(callerText) == normalizeHex(leaderText)
 
 			// Verify the authorization result matches expectation


### PR DESCRIPTION
feat: use @leader contextual variable

Implements @leader contextual variable for secure leader-only authorization. Uses BlockContext.Proposer for deterministic leader identification, ensuring consistency with other contextual variable like @height.

Technical Implementation:
- Add @leader case to contextual variable system in interpreter
- Use BlockContext.Proposer as data source (same as @height, @block_timestamp)
- Return hex-encoded proposer public key as TEXT type
- Fail-safe behavior: empty string when proposer unavailable

Key Features:
- Deterministic: same block context always returns same leader
- Thread-safe: derived from immutable block execution context
- Zero dependencies: no interface changes or consensus modifications

Testing:
- Unit tests for core @leader functionality
- Multi-validator authorization scenario tests
- Edge case handling (nil proposer, invalid context)
- Consistency tests with other contextual variables
- Deterministic behavior verification

Files Modified:
- node/engine/interpreter/context.go: Added @leader contextual variable
- node/engine/interpreter/context_test.go: Comprehensive test coverage
- core/client/README.md: Updated contextual variables documentation

resolves: https://github.com/trufnetwork/kwil-db/issues/1583
resolves: https://github.com/trufnetwork/kwil-db/issues/1584


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced a new contextual variable: @leader, enabling leader-aware logic in actions.

* **Documentation**
  * Added a “Contextual Variables” section covering @caller, @txid, @height, and @leader with guidance and examples; note: the section was inserted twice.

* **Tests**
  * Added comprehensive tests for @leader covering determinism, interactions with other variables, authorization scenarios, proposer variants, and invalid-context behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->