### PR TITLE
feat: view database size natively

### DIFF
--- a/node/engine/functions.go
+++ b/node/engine/functions.go
@@ -967,6 +967,63 @@ var (
 			},
 			PGFormatFunc: defaultFormat("row_number"),
 		},
+		// PostgreSQL database size functions
+		"pg_database_size": &ScalarFunctionDefinition{
+			ValidateArgsFunc: func(args []*types.DataType) (*types.DataType, error) {
+				if len(args) != 1 {
+					return nil, wrapErrArgumentNumber(1, len(args))
+				}
+
+				if !args[0].Equals(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[0])
+				}
+
+				return types.IntType, nil
+			},
+			PGFormatFunc: defaultFormat("pg_database_size"),
+		},
+		"pg_total_relation_size": &ScalarFunctionDefinition{
+			ValidateArgsFunc: func(args []*types.DataType) (*types.DataType, error) {
+				if len(args) != 1 {
+					return nil, wrapErrArgumentNumber(1, len(args))
+				}
+
+				if !args[0].Equals(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[0])
+				}
+
+				return types.IntType, nil
+			},
+			PGFormatFunc: defaultFormat("pg_total_relation_size"),
+		},
+		"pg_relation_size": &ScalarFunctionDefinition{
+			ValidateArgsFunc: func(args []*types.DataType) (*types.DataType, error) {
+				if len(args) != 1 {
+					return nil, wrapErrArgumentNumber(1, len(args))
+				}
+
+				if !args[0].Equals(types.TextType) {
+					return nil, wrapErrArgumentType(types.TextType, args[0])
+				}
+
+				return types.IntType, nil
+			},
+			PGFormatFunc: defaultFormat("pg_relation_size"),
+		},
+		"pg_size_pretty": &ScalarFunctionDefinition{
+			ValidateArgsFunc: func(args []*types.DataType) (*types.DataType, error) {
+				if len(args) != 1 {
+					return nil, wrapErrArgumentNumber(1, len(args))
+				}
+
+				if !args[0].Equals(types.IntType) {
+					return nil, wrapErrArgumentType(types.IntType, args[0])
+				}
+
+				return types.TextType, nil
+			},
+			PGFormatFunc: defaultFormat("pg_size_pretty"),
+		},
 		// Table-valued functions
 		"unnest": &TableValuedFunctionDefinition{
 			ValidateArgsFunc: func(args []*types.DataType) ([]*NamedType, error) {

--- a/node/engine/functions_test.go
+++ b/node/engine/functions_test.go
@@ -3,6 +3,9 @@ package engine_test
 import (
 	"testing"
 
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/kwil-db/node/engine"
 )
 
@@ -46,4 +49,128 @@ func Test_AllFunctionsImplemented(t *testing.T) {
 			t.Errorf("function %s is not a scalar, aggregate, window, or table-valued function", name)
 		}
 	}
+}
+
+func TestPgDatabaseSizeFunction(t *testing.T) {
+	fn := engine.Functions["pg_database_size"]
+	require.NotNil(t, fn, "pg_database_size function should exist")
+
+	scalarFn, ok := fn.(*engine.ScalarFunctionDefinition)
+	require.True(t, ok, "pg_database_size should be a ScalarFunctionDefinition")
+
+	// Test valid arguments
+	validArgs := []*types.DataType{types.TextType}
+	returnType, err := scalarFn.ValidateArgs(validArgs)
+	require.NoError(t, err)
+	assert.True(t, returnType.Equals(types.IntType), "should return INT type")
+
+	// Test invalid argument count - no arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{})
+	assert.Error(t, err, "should error with no arguments")
+
+	// Test invalid argument count - too many arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.TextType, types.TextType})
+	assert.Error(t, err, "should error with too many arguments")
+
+	// Test invalid argument type
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.IntType})
+	assert.Error(t, err, "should error with wrong argument type")
+
+	// Test PostgreSQL format
+	result, err := scalarFn.PGFormatFunc([]string{"'database_name'"})
+	require.NoError(t, err)
+	assert.Equal(t, "pg_database_size('database_name')", result, "should format correctly")
+}
+
+func TestPgTotalRelationSizeFunction(t *testing.T) {
+	fn := engine.Functions["pg_total_relation_size"]
+	require.NotNil(t, fn, "pg_total_relation_size function should exist")
+
+	scalarFn, ok := fn.(*engine.ScalarFunctionDefinition)
+	require.True(t, ok, "pg_total_relation_size should be a ScalarFunctionDefinition")
+
+	// Test valid arguments
+	validArgs := []*types.DataType{types.TextType}
+	returnType, err := scalarFn.ValidateArgs(validArgs)
+	require.NoError(t, err)
+	assert.True(t, returnType.Equals(types.IntType), "should return INT type")
+
+	// Test invalid argument count - no arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{})
+	assert.Error(t, err, "should error with no arguments")
+
+	// Test invalid argument count - too many arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.TextType, types.TextType})
+	assert.Error(t, err, "should error with too many arguments")
+
+	// Test invalid argument type
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.IntType})
+	assert.Error(t, err, "should error with wrong argument type")
+
+	// Test PostgreSQL format
+	result, err := scalarFn.PGFormatFunc([]string{"'table_name'"})
+	require.NoError(t, err)
+	assert.Equal(t, "pg_total_relation_size('table_name')", result, "should format correctly")
+}
+
+func TestPgRelationSizeFunction(t *testing.T) {
+	fn := engine.Functions["pg_relation_size"]
+	require.NotNil(t, fn, "pg_relation_size function should exist")
+
+	scalarFn, ok := fn.(*engine.ScalarFunctionDefinition)
+	require.True(t, ok, "pg_relation_size should be a ScalarFunctionDefinition")
+
+	// Test valid arguments
+	validArgs := []*types.DataType{types.TextType}
+	returnType, err := scalarFn.ValidateArgs(validArgs)
+	require.NoError(t, err)
+	assert.True(t, returnType.Equals(types.IntType), "should return INT type")
+
+	// Test invalid argument count - no arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{})
+	assert.Error(t, err, "should error with no arguments")
+
+	// Test invalid argument count - too many arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.TextType, types.TextType})
+	assert.Error(t, err, "should error with too many arguments")
+
+	// Test invalid argument type
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.IntType})
+	assert.Error(t, err, "should error with wrong argument type")
+
+	// Test PostgreSQL format
+	result, err := scalarFn.PGFormatFunc([]string{"'table_name'"})
+	require.NoError(t, err)
+	assert.Equal(t, "pg_relation_size('table_name')", result, "should format correctly")
+}
+
+func TestPgSizePrettyFunction(t *testing.T) {
+	fn := engine.Functions["pg_size_pretty"]
+	require.NotNil(t, fn, "pg_size_pretty function should exist")
+
+	scalarFn, ok := fn.(*engine.ScalarFunctionDefinition)
+	require.True(t, ok, "pg_size_pretty should be a ScalarFunctionDefinition")
+
+	// Test valid arguments
+	validArgs := []*types.DataType{types.IntType}
+	returnType, err := scalarFn.ValidateArgs(validArgs)
+	require.NoError(t, err)
+	assert.True(t, returnType.Equals(types.TextType), "should return TEXT type")
+
+	// Test invalid argument count - no arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{})
+	assert.Error(t, err, "should error with no arguments")
+
+	// Test invalid argument count - too many arguments
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.IntType, types.IntType})
+	assert.Error(t, err, "should error with too many arguments")
+
+	// Test invalid argument type
+	_, err = scalarFn.ValidateArgs([]*types.DataType{types.TextType})
+	assert.Error(t, err, "should error with wrong argument type")
+
+	// Test PostgreSQL format
+	result, err := scalarFn.PGFormatFunc([]string{"1024"})
+	require.NoError(t, err)
+	assert.Equal(t, "pg_size_pretty(1024)", result, "should format correctly")
 }


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/truf-network/issues/1229

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for database size utilities compatible with PostgreSQL:
    - pg_database_size(name): returns database size.
    - pg_total_relation_size(name): returns total table size (including indexes).
    - pg_relation_size(name): returns table size.
    - pg_size_pretty(bytes): human-readable size formatting.
  * These functions can now be used in queries for size insights and readable outputs.

* **Tests**
  * Added comprehensive tests to validate argument handling, return types, and formatting for the new size functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->