### PR TITLE
chore: skip event votes on catchup

### DIFF
--- a/node/block_processor/processor.go
+++ b/node/block_processor/processor.go
@@ -481,7 +481,8 @@ func (bp *BlockProcessor) ExecuteBlock(ctx context.Context, req *ktypes.BlockExe
 	bp.recordBlockExecEndTime()
 
 	// Broadcast any voteID events that have not been broadcasted yet
-	if bp.broadcastTxFn != nil {
+	// Skip broadcasting during catch-up/sync since the node cannot process new transactions
+	if bp.broadcastTxFn != nil && !syncing {
 		if err = bp.BroadcastVoteIDTx(ctx, bp.consensusTx); err != nil {
 			return nil, fmt.Errorf("failed to broadcast the voteID transactions: %w", err)
 		}


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

This commit updates the block processor to prevent broadcasting of voteID transactions when the node is in catch-up or synchronization mode. The change ensures that the node does not attempt to process new transactions during these states, enhancing stability and preventing potential errors.

Changes:
- Added a condition to check the syncing state before broadcasting voteID transactions.

This improvement contributes to more reliable block execution during synchronization phases.

## Related Issue
<!--- If this pull requests links to an issue, please link to it here: -->

- fix #1628 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where vote transactions were being broadcast during node synchronization. Transactions are now correctly withheld while the node is catching up with the network, preventing unnecessary network traffic and ensuring proper synchronization behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->