### PR TITLE
chore(evm): Add Arbitrum One + Sepolia and Hardhat chain support

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -616,6 +616,7 @@ type ERC20BridgeConfig struct {
 	RPC                map[string]string `toml:"rpc" comment:"evm websocket RPC; format: chain_name='rpc_url'"`
 	BlockSyncChuckSize map[string]string `toml:"block_sync_chuck_size" comment:"rpc option block sync chunk size; format: chain_name='chunk_size'"`
 	Signer             map[string]string `toml:"signer" comment:"signer service configuration; format: ext_alias='file_path_to_private_key'"`
+	StartBlock         map[string]string `toml:"start_block" comment:"starting block number for sync; format: chain_name='block_number'. Used when eventstore has no last seen height."`
 }
 
 // Validate validates the bridge general config, other validations will be performed

--- a/node/exts/evm-sync/chains/chains.go
+++ b/node/exts/evm-sync/chains/chains.go
@@ -41,9 +41,14 @@ func init() {
 			RequiredConfirmations: 12,
 		},
 		ChainInfo{
-			Name:                  "arbitrumsepolia",
+			Name:                  "arbitrum_sepolia",
 			ID:                    "421614",
 			RequiredConfirmations: 2,
+		},
+		ChainInfo{
+			Name:                  "arbitrum_one",
+			ID:                    "42161",
+			RequiredConfirmations: 4,
 		},
 	)
 	if err != nil {
@@ -58,7 +63,8 @@ const (
 	Sepolia         Chain = "sepolia"
 	BaseSepolia     Chain = "base-sepolia"
 	Hardhat         Chain = "hardhat"
-	ArbitrumSepolia Chain = "arbitrumsepolia"
+	ArbitrumSepolia Chain = "arbitrum_sepolia"
+	ArbitrumOne     Chain = "arbitrum_one"
 )
 
 func (c Chain) String() string {
@@ -67,7 +73,7 @@ func (c Chain) String() string {
 
 func (c Chain) Valid() error {
 	switch c {
-	case Ethereum, Sepolia, BaseSepolia, Hardhat, ArbitrumSepolia:
+	case Ethereum, Sepolia, BaseSepolia, Hardhat, ArbitrumSepolia, ArbitrumOne:
 		return nil
 	default:
 		return fmt.Errorf("invalid chain: %s", c)

--- a/node/exts/evm-sync/chains/chains.go
+++ b/node/exts/evm-sync/chains/chains.go
@@ -35,6 +35,16 @@ func init() {
 			ID:                    "84532",
 			RequiredConfirmations: 12,
 		},
+		ChainInfo{
+			Name:                  "hardhat",
+			ID:                    "31337",
+			RequiredConfirmations: 12,
+		},
+		ChainInfo{
+			Name:                  "arbitrumsepolia",
+			ID:                    "421614",
+			RequiredConfirmations: 2,
+		},
 	)
 	if err != nil {
 		panic(err)
@@ -44,9 +54,11 @@ func init() {
 type Chain string
 
 const (
-	Ethereum    Chain = "ethereum"
-	Sepolia     Chain = "sepolia"
-	BaseSepolia Chain = "base-sepolia"
+	Ethereum        Chain = "ethereum"
+	Sepolia         Chain = "sepolia"
+	BaseSepolia     Chain = "base-sepolia"
+	Hardhat         Chain = "hardhat"
+	ArbitrumSepolia Chain = "arbitrumsepolia"
 )
 
 func (c Chain) String() string {
@@ -55,7 +67,7 @@ func (c Chain) String() string {
 
 func (c Chain) Valid() error {
 	switch c {
-	case Ethereum, Sepolia, BaseSepolia:
+	case Ethereum, Sepolia, BaseSepolia, Hardhat, ArbitrumSepolia:
 		return nil
 	default:
 		return fmt.Errorf("invalid chain: %s", c)


### PR DESCRIPTION
resolves: https://github.com/trufnetwork/kwil-db/issues/1675
resolves: https://github.com/trufnetwork/kwil-db/issues/1676
resolves: https://github.com/trufnetwork/kwil-db/issues/1677

## Description

This PR adds support for Arbitrum One, Arbitrum Sepolia and Hardhat chains to the EVM sync extension, and introduces a `StartBlock` configuration option to specify the starting block number for chain synchronization. Additionally, it includes several bug fixes and improvements to the listener implementation.

**Key Changes:**
- Added `hardhat` chain (chain ID: 31337) with 12 required confirmations
- Added `arbitrum_one` chain (chain ID: 42161) with 4 required confirmations
- Added `arbitrum_sepolia` chain (chain ID: 421614) with 2 required confirmations
- Added `StartBlock` configuration option to `ERC20BridgeConfig` for per-chain starting block configuration
- Fixed `BlockSyncChuckSize` to use the actual chain parameter instead of hardcoded Ethereum reference
- Fixed `processEvents` to update last seen height even when no logs are found
- Changed "received new block" log level from Info to Debug to reduce log verbosity

## Motivation and Context
This change is required to:
1. **Support additional EVM chains**: Enable kwil-db to sync with Arbitrum One, Arbitrum Sepolia testnet and Hardhat local development networks, expanding the supported chain ecosystem.
2. **Flexible sync configuration**: The `StartBlock` configuration allows operators to specify a custom starting block for initial synchronization or recovery scenarios, rather than always starting from block 0. This is particularly useful when:
   - Setting up a new instance and wanting to skip historical blocks
   - Recovering from a sync issue and needing to resume from a specific block
   - The eventstore has no last seen height (returns 0)

3. **Bug fixes**: Addresses issues where chain-specific configurations were incorrectly hardcoded and where the last seen height wasn't updated in certain edge cases.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

- [ ] Unit tests pass: `task test:unit`
- [x] Acceptance tests pass: `task test:act`
- [ ] Code formatted: `task fmt`
- [ ] Linting passes: `task lint`
- [x] Manual testing with Hardhat local network
- [x] Manual testing with Arbitrum Sepolia testnet
- [x] Verified StartBlock configuration works correctly when eventstore has no last seen height

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update (including inline docs)
- [ ] Other (please describe):

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. If a box does not apply, put `N/A`-->
<!--- For each box that has `N/A`, please explain why in the "Checklist Explanation" section. -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

### Checklist Explanation:
<!--- If any of the above boxes are not checked, please explain why here: -->

- **Documentation**: The `StartBlock` configuration option is documented inline in the code with a comment. If there's external documentation that needs updating, please let me know.
- **Tests**: Additional tests should be added to verify the new chain support and StartBlock functionality. This should include:
  - Unit tests for chain validation
  - Integration tests for StartBlock configuration
  - Tests for the bug fixes (BlockSyncChuckSize chain-specific behavior, last seen height update)

## How to Review this PR:
<!--- Please provide instructions on how to review this PR here (e.g. where to start, key design decisions, parts of the code that require special attention): -->

**Review Order:**
1. **`config/config.go`**: Review the new `StartBlock` configuration field and its TOML comment
2. **`node/exts/evm-sync/chains/chains.go`**: Verify the new chain definitions (Hardhat and Arbitrum Sepolia) and chain validation logic
3. **`node/exts/evm-sync/listener.go`**: Focus on:
   - The `StartBlock` configuration parsing and validation logic
   - The bug fix for `BlockSyncChuckSize` (line ~124: changed from hardcoded `chains.Ethereum.String()` to `chain.String()`)
   - The bug fix for updating last seen height when no logs are found
   - The StartBlock fallback logic when eventstore returns 0
   - Log level change from Info to Debug

**Key Design Decisions:**
- `StartBlock` defaults to 0 if not configured, maintaining backward compatibility
- `StartBlock` is only used when eventstore has no last seen height (returns 0), ensuring it doesn't override existing sync state
- Chain-specific configurations now properly use the chain parameter instead of hardcoded values

## Additional Information:
<!--- Anything else we should know when reviewing? -->

**Configuration Example:**
```toml
[erc20_bridge]
start_block = { hardhat = "1000", arbitrum_sepolia = "50000" }
rpc = { hardhat = "http://localhost:8545", arbitrum_sepolia = "https://sepolia-rollup.arbitrum.io/rpc" }
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for Hardhat (ID 31337) and Arbitrum Sepolia (ID 421614) blockchain networks.
  * Enabled per-chain block synchronization configuration with customizable starting block positions for each supported network.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->