### PR TITLE
chore: bypass false error on successful unuse

### DIFF
--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -557,7 +557,9 @@ func init() {
 
 							if !info.active {
 								info.mu.RUnlock()
-								return fmt.Errorf("reward extension with id %s is already disabled", id)
+								// Already disabled - this is idempotent, return success
+								// This allows UNUSE to complete namespace cleanup even when called multiple times
+								return nil
 							}
 
 							err := setActiveStatus(ctx.TxContext.Ctx, app, id, false)


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3041

Part of testing testnet, I got error when syncing, it should be good next

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test verifying UNUSE operations can be safely called multiple times on the same extension without errors, with proper cleanup behavior and no re-initialization on subsequent calls.

* **Bug Fixes**
  * Enhanced disable handler to support idempotent operations - disabling an already-disabled extension now succeeds gracefully rather than returning an error.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->