### PR TITLE
chore: prevent precommit hang with buffer increase and timeout

### DIFF
--- a/.github/workflows/publish-postgres-image.yml
+++ b/.github/workflows/publish-postgres-image.yml
@@ -42,7 +42,9 @@ jobs:
           context: ./contrib/docker
           file: ./contrib/docker/postgres.dockerfile
           push: true
-          tags: ghcr.io/${{ github.repository_owner }}/kwil-postgres:${{ inputs.tag }}
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/kwil-postgres:${{ inputs.tag }}
+            ghcr.io/${{ github.repository_owner }}/kwil-postgres:latest
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/node/pg/db.go
+++ b/node/pg/db.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/trufnetwork/kwil-db/core/utils/random"
 	"github.com/trufnetwork/kwil-db/node/metrics"
@@ -627,6 +628,12 @@ func (db *DB) precommit(ctx context.Context, changes chan<- any) ([]byte, error)
 	// Wait for the "commit id" from the replication monitor.
 	// NOTE: activeTx is not moved to preparedTxns until commitID is received.
 	// If the wait fails, the caller can rollback the active tx (which has txid set).
+	//
+	// A timeout is used as a safety net: if the replication stream dies between
+	// PREPARE TRANSACTION and close(rm.done), there is a race where none of the
+	// other select cases fire, causing an infinite hang that freezes consensus.
+	timer := time.NewTimer(30 * time.Second)
+	defer timer.Stop()
 	select {
 	case commitID, ok := <-resChan:
 		if !ok {
@@ -641,6 +648,8 @@ func (db *DB) precommit(ctx context.Context, changes chan<- any) ([]byte, error)
 		return commitID, nil
 	case <-db.repl.done: // the replMon has died after we executed PREPARE TRANSACTION
 		return nil, errors.New("replication stream interrupted")
+	case <-timer.C:
+		return nil, errors.New("precommit timed out waiting for commit ID from replication monitor")
 	case <-ctx.Done():
 		return nil, ctx.Err()
 	}

--- a/node/pg/repl.go
+++ b/node/pg/repl.go
@@ -66,7 +66,12 @@ func startRepl(ctx context.Context, conn *pgconn.PgConn, publicationName, slotNa
 	// means: (1) there must only be one pg.DB instance per postgres database,
 	// and (2) other unsequenced writers such as a pg.Pool must not make updates
 	// to the sentry table that would cause a send with no receiver.
-	commitHash := make(chan []byte, 1)
+	// Buffer must accommodate all tracked commits in a single block.
+	// With per-transaction 2PC, each block produces up to maxTxnsPerBlock + 2
+	// prepared transactions (dirty marker + N user txns + envelope).
+	// A buffer of 1 caused the replication stream to die under load,
+	// leading to a consensus freeze (see INCIDENT_2PC_HANG_2026-04-13).
+	commitHash := make(chan []byte, 32)
 
 	// Tie captureRepl goroutine to a new context now that connections are established.
 	ctx2, cancel := context.WithCancel(context.Background())


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3644

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added timeout protection to prevent indefinite blocking when waiting for replication monitor responses during database operations.

* **Chores**
  * Enhanced Docker image publishing configuration to distribute multiple container image tag variants.
  * Optimized internal commit tracking buffer capacity to improve throughput and reduce blocking scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->