### PR TITLE
chore: guard non-validator from signing singnatures

### DIFF
--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -1352,7 +1352,13 @@ func init() {
 							// Verify signature for non-custodial validator votes (nonce=0)
 							// This prevents forged votes from non-validators
 							const nonCustodialNonce = 0
+							// Built once on the non-custodial path and reused for both the
+							// membership gate below and the BFT power sum after voteEpoch —
+							// per-validator pubkey decompress + Keccak is otherwise paid twice.
+							var validatorEthMap map[ethcommon.Address]int64
 							if nonce == nonCustodialNonce {
+								validatorEthMap = buildValidatorEthAddressMap(app)
+
 								// Defense in depth: a vote_epoch tx is only authoritative if its
 								// caller is a current validator. The signature check below proves
 								// the caller owns the key, but says nothing about whether that key
@@ -1362,7 +1368,7 @@ func init() {
 								// bug); fixing that bug exposed that no membership gate exists
 								// here. Reject up front so non-validator votes never reach
 								// epoch_votes (and thus never appear in withdrawal proofs).
-								if !isActiveValidatorAddress(app, from) {
+								if _, ok := validatorEthMap[from]; !ok {
 									return fmt.Errorf("vote_epoch: caller %s is not in the active validator set", from.Hex())
 								}
 
@@ -1433,8 +1439,10 @@ func init() {
 									return fmt.Errorf("failed to calculate BFT threshold: %w", err)
 								}
 
-								// Sum voting power of all validators who voted for this epoch
-								votingPower, err := sumEpochVotingPower(ctx.TxContext.Ctx, app, epochID)
+								// Sum voting power of all validators who voted for this epoch.
+								// Reuses the validatorEthMap built above on the non-custodial path,
+								// so we don't pay the per-validator pubkey derivation cost twice.
+								votingPower, err := sumEpochVotingPower(ctx.TxContext.Ctx, app, epochID, validatorEthMap)
 								if err != nil {
 									if app.Service != nil && app.Service.Logger != nil {
 										app.Service.Logger.Errorf("failed to sum voting power for epoch %s: %v", epochID, err)
@@ -3278,7 +3286,11 @@ func calculateBFTThreshold(app *common.App) (int64, int64, error) {
 //
 // Note: This function cannot use ctx.TxContext because it's called from a handler.
 // It matches votes by Ethereum address, which requires validators to use EthPersonalSigner.
-func sumEpochVotingPower(ctx context.Context, app *common.App, epochID *types.UUID) (int64, error) {
+//
+// validatorPowerMap must be built by buildValidatorEthAddressMap. The vote_epoch handler
+// builds it once per invocation and shares it with the membership check to avoid
+// repeating the per-validator pubkey decompress + Keccak.
+func sumEpochVotingPower(ctx context.Context, app *common.App, epochID *types.UUID, validatorPowerMap map[ethcommon.Address]int64) (int64, error) {
 	const nonCustodialNonce = 0
 
 	// Get all votes for this epoch (stores Ethereum addresses as voters)
@@ -3289,43 +3301,6 @@ func sumEpochVotingPower(ctx context.Context, app *common.App, epochID *types.UU
 	`, epochID, nonCustodialNonce)
 	if err != nil {
 		return 0, fmt.Errorf("failed to query epoch votes: %w", err)
-	}
-
-	// For each vote, we need to find the corresponding validator
-	// Unfortunately, epoch_votes stores Ethereum addresses, not validator pubkeys
-	// We need to iterate through validators and match their Ethereum address
-	validators := app.Validators.GetValidators()
-
-	// Build a map of validator Ethereum addresses -> power
-	// This requires computing each validator's Ethereum address from their pubkey
-	validatorPowerMap := make(map[string]int64)
-	if app.Service != nil && app.Service.Logger != nil {
-		app.Service.Logger.Debugf("building validator power map from %d validators", len(validators))
-	}
-	for _, v := range validators {
-		if app.Service != nil && app.Service.Logger != nil {
-			app.Service.Logger.Debugf("validator: pubkey=%x, keytype=%s, power=%d", v.Identifier, v.KeyType, v.Power)
-		}
-		// Compute Ethereum address from validator pubkey
-		// Assumes validator is using secp256k1 key (EthPersonalSigner requirement)
-		if v.KeyType == kwilcrypto.KeyTypeSecp256k1 {
-			// Parse the pubkey and derive Ethereum address
-			ethAddr, err := ethAddressFromPubKey(v.Identifier)
-			if err != nil {
-				// Skip validators with invalid keys
-				if app.Service != nil && app.Service.Logger != nil {
-					app.Service.Logger.Warnf("failed to derive Ethereum address for validator %x: %v", v.Identifier, err)
-				}
-				continue
-			}
-			if app.Service != nil && app.Service.Logger != nil {
-				app.Service.Logger.Debugf("mapped validator %x -> eth address %s with power %d", v.Identifier, ethAddr.Hex(), v.Power)
-			}
-			validatorPowerMap[ethAddr.Hex()] = v.Power
-		}
-	}
-	if app.Service != nil && app.Service.Logger != nil {
-		app.Service.Logger.Debugf("validator power map has %d entries", len(validatorPowerMap))
 	}
 
 	// Sum voting power for all voters
@@ -3343,12 +3318,54 @@ func sumEpochVotingPower(ctx context.Context, app *common.App, epochID *types.UU
 		voter := ethcommon.BytesToAddress(voterBytes)
 
 		// Look up voting power
-		if power, ok := validatorPowerMap[voter.Hex()]; ok {
+		if power, ok := validatorPowerMap[voter]; ok {
 			votingPower += power
 		}
 	}
 
 	return votingPower, nil
+}
+
+// buildValidatorEthAddressMap returns a map from each active secp256k1 validator's
+// Ethereum address to its voting power. Returns an empty (non-nil) map if app or
+// app.Validators is nil so callers don't need separate nil-checks.
+//
+// Each call decompresses every secp256k1 validator pubkey and runs Keccak on it,
+// so callers in a single handler invocation should build the map once and pass it
+// around rather than calling this (or isActiveValidatorAddress, which delegates here)
+// repeatedly.
+func buildValidatorEthAddressMap(app *common.App) map[ethcommon.Address]int64 {
+	powerMap := make(map[ethcommon.Address]int64)
+	if app == nil || app.Validators == nil {
+		return powerMap
+	}
+	validators := app.Validators.GetValidators()
+	if app.Service != nil && app.Service.Logger != nil {
+		app.Service.Logger.Debugf("building validator power map from %d validators", len(validators))
+	}
+	for _, v := range validators {
+		if v.Power <= 0 {
+			continue
+		}
+		if v.KeyType != kwilcrypto.KeyTypeSecp256k1 {
+			continue
+		}
+		ethAddr, err := ethAddressFromPubKey(v.Identifier)
+		if err != nil {
+			if app.Service != nil && app.Service.Logger != nil {
+				app.Service.Logger.Warnf("failed to derive Ethereum address for validator %x: %v", v.Identifier, err)
+			}
+			continue
+		}
+		if app.Service != nil && app.Service.Logger != nil {
+			app.Service.Logger.Debugf("mapped validator %x -> eth address %s with power %d", v.Identifier, ethAddr.Hex(), v.Power)
+		}
+		powerMap[ethAddr] = v.Power
+	}
+	if app.Service != nil && app.Service.Logger != nil {
+		app.Service.Logger.Debugf("validator power map has %d entries", len(powerMap))
+	}
+	return powerMap
 }
 
 // ethAddressFromPubKey derives an Ethereum address from a secp256k1 public key.
@@ -3406,35 +3423,6 @@ func isLocalNodeActiveValidator(app *common.App) bool {
 			continue
 		}
 		if bytes.Equal(v.Identifier, identity) {
-			return true
-		}
-	}
-	return false
-}
-
-// isActiveValidatorAddress reports whether the supplied Ethereum address is the
-// derived address of a current secp256k1 validator with positive voting power.
-//
-// Defense-in-depth pair to isLocalNodeActiveValidator: even if some other node
-// (or a future bug) broadcasts a self-consistent vote_epoch tx, the action
-// rejects it instead of inserting a non-validator row into epoch_votes that
-// withdrawal proofs would later return.
-func isActiveValidatorAddress(app *common.App, addr ethcommon.Address) bool {
-	if app == nil || app.Validators == nil {
-		return false
-	}
-	for _, v := range app.Validators.GetValidators() {
-		if v.Power <= 0 {
-			continue
-		}
-		if v.KeyType != kwilcrypto.KeyTypeSecp256k1 {
-			continue
-		}
-		ethAddr, err := ethAddressFromPubKey(v.Identifier)
-		if err != nil {
-			continue
-		}
-		if ethAddr == addr {
 			return true
 		}
 	}

--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -108,6 +108,13 @@ var (
 	// runningSignersMu protects both runningSigners and runningSignerCancels maps
 	runningSignersMu sync.Mutex
 
+	// loggedSignerDisabled tracks instance IDs whose "not an active validator —
+	// bridge signer disabled" message has already been logged this process.
+	// Without this guard the EndBlock-driven re-check (which is what auto-starts
+	// signers on late validator promotion) would emit an INFO line every block
+	// on every sentry. The map is process-local; a restart re-arms the log.
+	loggedSignerDisabled sync.Map // key: types.UUID
+
 	// runningDepositListeners tracks which instance IDs have active deposit listeners
 	// to prevent duplicate listeners if OnStart is called multiple times (e.g., when adding a new bridge instance via USE statement)
 	runningDepositListeners = make(map[string]bool)
@@ -478,61 +485,10 @@ func init() {
 						getSingleton().instances.Set(*instance.ID, instance)
 					}
 
-					// Start validator signer services for non-custodial withdrawals
-					// This runs in background and submits validator signatures via transactions
-					for _, instance := range instances {
-						if instance.active && instance.synced {
-							instanceIDStr := instance.ID.String()
-
-							// Check if signer is already running for this instance
-							runningSignersMu.Lock()
-							alreadyRunning := runningSigners[instanceIDStr]
-							if !alreadyRunning {
-								runningSigners[instanceIDStr] = true
-							}
-							runningSignersMu.Unlock()
-
-							if alreadyRunning {
-								if app.Service != nil && app.Service.Logger != nil {
-									app.Service.Logger.Debugf("validator signer already running for instance %s, skipping", instance.ID)
-								}
-								continue
-							}
-
-							// Try to get validator signer
-							signer, err := getValidatorSigner(app, instance.ID)
-							if err != nil {
-								if app.Service != nil && app.Service.Logger != nil {
-									app.Service.Logger.Warnf("failed to get validator signer for instance %s: %v", instance.ID, err)
-								}
-								// Clean up tracking maps on error
-								runningSignersMu.Lock()
-								delete(runningSigners, instanceIDStr)
-								delete(runningSignerCancels, instanceIDStr)
-								runningSignersMu.Unlock()
-								continue
-							}
-							if signer != nil {
-								// Create cancellable context so we can stop the signer when instance is disabled
-								// Use context.Background() as parent so signer runs for node lifetime (until cancelled)
-								signerCtx, cancel := context.WithCancel(context.Background())
-
-								// Store cancel function for cleanup on disable
-								runningSignersMu.Lock()
-								runningSignerCancels[instanceIDStr] = cancel
-								runningSignersMu.Unlock()
-
-								// Start background signer with cancellable context
-								go signer.Start(signerCtx)
-							} else {
-								// No signer available, clean up tracking maps
-								runningSignersMu.Lock()
-								delete(runningSigners, instanceIDStr)
-								delete(runningSignerCancels, instanceIDStr)
-								runningSignersMu.Unlock()
-							}
-						}
-					}
+					// Start validator signer services for non-custodial withdrawals.
+					// Same helper is invoked from EndBlock so a node promoted to
+					// validator after startup auto-starts its signer next block.
+					ensureValidatorSignersForActiveSyncedInstances(app)
 
 					return nil
 				},
@@ -1895,7 +1851,7 @@ func init() {
 		}
 
 		// now that we are done with recursive calls, we can update the singleton
-		return getSingleton().ForEachInstance(false, func(id *types.UUID, info *rewardExtensionInfo) error {
+		updateErr := getSingleton().ForEachInstance(false, func(id *types.UUID, info *rewardExtensionInfo) error {
 			info.mu.RLock()
 			active := info.active
 			info.mu.RUnlock()
@@ -1919,6 +1875,14 @@ func init() {
 			}
 			return nil
 		})
+
+		// Bring up vote_epoch signers for any instance whose signer is not
+		// already running. This is what makes a node added to the validator
+		// set after process startup begin signing without an operator restart.
+		// On a sentry this is a cheap no-op past the membership check.
+		ensureValidatorSignersForActiveSyncedInstances(app)
+
+		return updateErr
 	})
 	if err != nil {
 		panic(err)
@@ -3183,6 +3147,11 @@ func scaleDownUint256(amount *types.Decimal, decimals uint16) (*types.Decimal, e
 // to ensure signatures map to the validator's registered identity in the validator set.
 // Returns nil if no validator signer is available, or if the local node is not
 // a current member of the active validator set (sentries / read-only nodes).
+//
+// Late-promotion safe: ensureValidatorSignersForActiveSyncedInstances calls
+// this from the EndBlock hook in addition to OnStart, so a node added to the
+// validator set after process startup automatically begins signing next block
+// without operator restart.
 func getValidatorSigner(app *common.App, instanceID *types.UUID) (*ValidatorSigner, error) {
 	// Use the ValidatorSigner from Service
 	// This provides controlled access to signing without exposing the raw private key
@@ -3193,14 +3162,19 @@ func getValidatorSigner(app *common.App, instanceID *types.UUID) (*ValidatorSign
 	// Only nodes in the active validator set should run the vote_epoch loop.
 	// See isLocalNodeActiveValidator for the incident this gate prevents.
 	if !isLocalNodeActiveValidator(app) {
-		// One-line operator confirmation that the gate engaged: emitted once per
-		// instance per startup (the caller skips reinit while a signer is
-		// already running), so it does not spam the journal on busy nodes.
-		if app.Service != nil && app.Service.Logger != nil {
-			app.Service.Logger.Infof("erc20-bridge: not an active validator — bridge signer disabled for instance %s", instanceID)
+		// Operator confirmation that the gate engaged. Logged at most once per
+		// instance per process — without this guard the EndBlock-driven re-check
+		// would fire this line every block on every sentry.
+		if _, alreadyLogged := loggedSignerDisabled.LoadOrStore(*instanceID, struct{}{}); !alreadyLogged {
+			if app.Service != nil && app.Service.Logger != nil {
+				app.Service.Logger.Infof("erc20-bridge: not an active validator — bridge signer disabled for instance %s", instanceID)
+			}
 		}
 		return nil, nil
 	}
+	// Validator: arm the log for the next demotion so a future
+	// promotion→demotion transition still produces operator output.
+	loggedSignerDisabled.Delete(*instanceID)
 
 	// Get Ethereum address for the validator
 	addressBytes, err := app.Service.ValidatorSigner.EthereumAddress()
@@ -3210,6 +3184,80 @@ func getValidatorSigner(app *common.App, instanceID *types.UUID) (*ValidatorSign
 
 	// Create ValidatorSigner with the interface
 	return NewValidatorSignerFromInterface(app, instanceID, app.Service.ValidatorSigner, addressBytes), nil
+}
+
+// ensureValidatorSignersForActiveSyncedInstances starts a vote_epoch signer
+// goroutine for every active+synced bridge instance whose signer is not
+// already running on this node. Safe to call repeatedly: the runningSigners
+// bookkeeping prevents duplicate goroutines, and getValidatorSigner returns
+// nil for non-validators (sentries) so calling here on a sentry is a no-op
+// past the cheap membership check.
+//
+// Invoked from two places:
+//   - OnStart, to bring up signers for the initial validator set
+//   - the EndBlock hook, so a node added to the validator set after process
+//     startup automatically begins signing on the next block without needing
+//     an operator restart
+//
+// Iterating the singleton (rather than a fresh DB read) is correct in both
+// callers: OnStart populates the singleton before invoking this helper, and
+// EndBlock runs after the singleton is fully populated.
+func ensureValidatorSignersForActiveSyncedInstances(app *common.App) {
+	_ = getSingleton().ForEachInstance(true, func(id *types.UUID, info *rewardExtensionInfo) error {
+		info.mu.RLock()
+		active := info.active
+		synced := info.synced
+		info.mu.RUnlock()
+		if !active || !synced {
+			return nil
+		}
+
+		instanceIDStr := id.String()
+
+		runningSignersMu.Lock()
+		alreadyRunning := runningSigners[instanceIDStr]
+		if !alreadyRunning {
+			runningSigners[instanceIDStr] = true
+		}
+		runningSignersMu.Unlock()
+
+		if alreadyRunning {
+			return nil
+		}
+
+		signer, err := getValidatorSigner(app, id)
+		if err != nil {
+			if app.Service != nil && app.Service.Logger != nil {
+				app.Service.Logger.Warnf("failed to get validator signer for instance %s: %v", id, err)
+			}
+			runningSignersMu.Lock()
+			delete(runningSigners, instanceIDStr)
+			delete(runningSignerCancels, instanceIDStr)
+			runningSignersMu.Unlock()
+			return nil
+		}
+
+		if signer == nil {
+			// Not a validator (or no validator signer available). Release the
+			// bookkeeping slot so a future call retries — this is exactly what
+			// makes EndBlock-driven late promotion work.
+			runningSignersMu.Lock()
+			delete(runningSigners, instanceIDStr)
+			delete(runningSignerCancels, instanceIDStr)
+			runningSignersMu.Unlock()
+			return nil
+		}
+
+		// context.Background() so the signer runs for the node's lifetime
+		// (until cancelled when the instance is disabled).
+		signerCtx, cancel := context.WithCancel(context.Background())
+		runningSignersMu.Lock()
+		runningSignerCancels[instanceIDStr] = cancel
+		runningSignersMu.Unlock()
+
+		go signer.Start(signerCtx)
+		return nil
+	})
 }
 
 // computeEpochMessageHash computes the message hash that validators sign.

--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -1353,6 +1353,19 @@ func init() {
 							// This prevents forged votes from non-validators
 							const nonCustodialNonce = 0
 							if nonce == nonCustodialNonce {
+								// Defense in depth: a vote_epoch tx is only authoritative if its
+								// caller is a current validator. The signature check below proves
+								// the caller owns the key, but says nothing about whether that key
+								// is in the active validator set. Sentries / read-only nodes also
+								// hold a nodekey-derived signing key, and pre-2026-04-25 their
+								// votes used to be silently dropped at verification time (V=31/32
+								// bug); fixing that bug exposed that no membership gate exists
+								// here. Reject up front so non-validator votes never reach
+								// epoch_votes (and thus never appear in withdrawal proofs).
+								if !isActiveValidatorAddress(app, from) {
+									return fmt.Errorf("vote_epoch: caller %s is not in the active validator set", from.Hex())
+								}
+
 								// Query epoch's reward_root and block_hash for signature verification
 								result, err := app.DB.Execute(ctx.TxContext.Ctx, `
 									SELECT reward_root, block_hash
@@ -3160,12 +3173,25 @@ func scaleDownUint256(amount *types.Decimal, decimals uint16) (*types.Decimal, e
 // getValidatorSigner returns a ValidatorSigner wrapper for the node's validator key.
 // For non-custodial validator voting, this MUST use the node's validator key (not bridge signer key)
 // to ensure signatures map to the validator's registered identity in the validator set.
-// Returns nil if no validator signer is available.
+// Returns nil if no validator signer is available, or if the local node is not
+// a current member of the active validator set (sentries / read-only nodes).
 func getValidatorSigner(app *common.App, instanceID *types.UUID) (*ValidatorSigner, error) {
 	// Use the ValidatorSigner from Service
 	// This provides controlled access to signing without exposing the raw private key
 	if app.Service.ValidatorSigner == nil {
 		return nil, nil // No validator signer available
+	}
+
+	// Only nodes in the active validator set should run the vote_epoch loop.
+	// See isLocalNodeActiveValidator for the incident this gate prevents.
+	if !isLocalNodeActiveValidator(app) {
+		// One-line operator confirmation that the gate engaged: emitted once per
+		// instance per startup (the caller skips reinit while a signer is
+		// already running), so it does not spam the journal on busy nodes.
+		if app.Service != nil && app.Service.Logger != nil {
+			app.Service.Logger.Infof("erc20-bridge: not an active validator — bridge signer disabled for instance %s", instanceID)
+		}
+		return nil, nil
 	}
 
 	// Get Ethereum address for the validator
@@ -3345,6 +3371,74 @@ func ethAddressFromPubKey(pubKey []byte) (ethcommon.Address, error) {
 	// Derive Ethereum address from public key
 	address := crypto.PubkeyToAddress(*pubkey)
 	return address, nil
+}
+
+// isLocalNodeActiveValidator reports whether the running node's validator key
+// is a current member of the active validator set with positive voting power.
+//
+// Used to gate the bridge's vote_epoch broadcast loop: every node has a
+// nodekey-backed ValidatorSigner, but only validators contribute power. Without
+// this gate, a sentry's vote_epoch tx is signature-valid but power-less — the
+// row lands in epoch_votes anyway and pollutes withdrawal proofs returned to
+// the bridge contract. (2026-04-25 incident: fixing the V=31/32 sig-format bug
+// caused the leader to start accepting the sentry's previously-rejected sigs,
+// which broke 1-of-1 contracts that received 2 sigs per proof.)
+//
+// Returns false when the node has no validator signer, no Validators API, an
+// empty identity, or the identity isn't in the active set. Non-secp256k1
+// validators are excluded — vote_epoch requires Ethereum-compatible signing.
+func isLocalNodeActiveValidator(app *common.App) bool {
+	if app == nil || app.Service == nil || app.Service.ValidatorSigner == nil {
+		return false
+	}
+	if app.Validators == nil {
+		return false
+	}
+	identity := app.Service.ValidatorSigner.Identity()
+	if len(identity) == 0 {
+		return false
+	}
+	for _, v := range app.Validators.GetValidators() {
+		if v.Power <= 0 {
+			continue
+		}
+		if v.KeyType != kwilcrypto.KeyTypeSecp256k1 {
+			continue
+		}
+		if bytes.Equal(v.Identifier, identity) {
+			return true
+		}
+	}
+	return false
+}
+
+// isActiveValidatorAddress reports whether the supplied Ethereum address is the
+// derived address of a current secp256k1 validator with positive voting power.
+//
+// Defense-in-depth pair to isLocalNodeActiveValidator: even if some other node
+// (or a future bug) broadcasts a self-consistent vote_epoch tx, the action
+// rejects it instead of inserting a non-validator row into epoch_votes that
+// withdrawal proofs would later return.
+func isActiveValidatorAddress(app *common.App, addr ethcommon.Address) bool {
+	if app == nil || app.Validators == nil {
+		return false
+	}
+	for _, v := range app.Validators.GetValidators() {
+		if v.Power <= 0 {
+			continue
+		}
+		if v.KeyType != kwilcrypto.KeyTypeSecp256k1 {
+			continue
+		}
+		ethAddr, err := ethAddressFromPubKey(v.Identifier)
+		if err != nil {
+			continue
+		}
+		if ethAddr == addr {
+			return true
+		}
+	}
+	return false
 }
 
 // getEpochSignatures retrieves all validator signatures for an epoch.

--- a/node/exts/erc20-bridge/erc20/validator_membership_test.go
+++ b/node/exts/erc20-bridge/erc20/validator_membership_test.go
@@ -158,9 +158,15 @@ func TestIsLocalNodeActiveValidator(t *testing.T) {
 }
 
 // TestIsActiveValidatorAddress covers the defense-in-depth gate inside the
-// vote_epoch action handler. The check converts each validator's pubkey into
-// an Ethereum address and matches against the caller's address.
+// vote_epoch action handler. The handler builds buildValidatorEthAddressMap
+// once per invocation and checks membership with a direct map lookup; this
+// test exercises the same lookup against the same helper.
 func TestIsActiveValidatorAddress(t *testing.T) {
+	isActiveValidatorAddress := func(app *common.App, addr ethcommon.Address) bool {
+		_, ok := buildValidatorEthAddressMap(app)[addr]
+		return ok
+	}
+
 	leader, leaderAddr, _ := genValidator(t, 1)
 	other, otherAddr, _ := genValidator(t, 1)
 	_, sentryAddr, _ := genValidator(t, 1)

--- a/node/exts/erc20-bridge/erc20/validator_membership_test.go
+++ b/node/exts/erc20-bridge/erc20/validator_membership_test.go
@@ -1,0 +1,225 @@
+//go:build kwiltest
+
+package erc20
+
+import (
+	"context"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	ethcrypto "github.com/ethereum/go-ethereum/crypto"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufnetwork/kwil-db/common"
+	kwilcrypto "github.com/trufnetwork/kwil-db/core/crypto"
+	"github.com/trufnetwork/kwil-db/core/crypto/auth"
+	"github.com/trufnetwork/kwil-db/core/log"
+	"github.com/trufnetwork/kwil-db/core/types"
+	"github.com/trufnetwork/kwil-db/node/types/sql"
+)
+
+// mockValidators is a minimal common.Validators implementation. Only
+// GetValidators is exercised by the membership helpers; the other methods
+// panic so an accidental dependency surfaces immediately.
+type mockValidators struct {
+	validators []*types.Validator
+}
+
+func (m *mockValidators) GetValidators() []*types.Validator { return m.validators }
+
+func (m *mockValidators) GetValidatorPower(context.Context, []byte, kwilcrypto.KeyType) (int64, error) {
+	panic("mockValidators.GetValidatorPower not used by these tests")
+}
+
+func (m *mockValidators) SetValidatorPower(context.Context, sql.Executor, []byte, kwilcrypto.KeyType, int64) error {
+	panic("mockValidators.SetValidatorPower not used by these tests")
+}
+
+// mockValidatorSigner is a minimal common.ValidatorSigner that only needs to
+// answer Identity() / EthereumAddress() for membership tests. Sign / signer
+// creation panic to surface accidental use.
+type mockValidatorSigner struct {
+	identity []byte
+	ethAddr  []byte
+}
+
+func (m *mockValidatorSigner) Sign(context.Context, []byte, string) ([]byte, error) {
+	panic("mockValidatorSigner.Sign not used by these tests")
+}
+
+func (m *mockValidatorSigner) EthereumAddress() ([]byte, error) { return m.ethAddr, nil }
+
+func (m *mockValidatorSigner) CreateSecp256k1Signer() (auth.Signer, error) {
+	panic("mockValidatorSigner.CreateSecp256k1Signer not used by these tests")
+}
+
+func (m *mockValidatorSigner) Identity() []byte { return m.identity }
+
+// genValidator returns a fresh secp256k1 keypair packaged as a *types.Validator
+// plus the derived eth address — exactly the shape app.Validators.GetValidators
+// returns at runtime.
+func genValidator(t *testing.T, power int64) (*types.Validator, ethcommon.Address, []byte) {
+	t.Helper()
+	key, err := ethcrypto.GenerateKey()
+	require.NoError(t, err)
+
+	pubBytes := ethcrypto.CompressPubkey(&key.PublicKey)
+	v := &types.Validator{
+		AccountID: types.AccountID{
+			Identifier: pubBytes,
+			KeyType:    kwilcrypto.KeyTypeSecp256k1,
+		},
+		Power: power,
+	}
+	return v, ethcrypto.PubkeyToAddress(key.PublicKey), pubBytes
+}
+
+func newAppWith(validators []*types.Validator, signer common.ValidatorSigner) *common.App {
+	return &common.App{
+		Service: &common.Service{
+			Logger:          log.New(),
+			ValidatorSigner: signer,
+		},
+		Validators: &mockValidators{validators: validators},
+	}
+}
+
+// TestIsLocalNodeActiveValidator covers the gate that decides whether the
+// bridge starts the vote_epoch broadcast loop on this node. Sentries (any node
+// whose nodekey isn't in the active validator set) must NOT start the loop —
+// this is the regression backstop for the 2026-04-25 sentry-vote pollution.
+func TestIsLocalNodeActiveValidator(t *testing.T) {
+	leader, _, leaderPub := genValidator(t, 1)
+	other, _, _ := genValidator(t, 1)
+	_, _, sentryPub := genValidator(t, 1)
+
+	t.Run("local pubkey is in active set", func(t *testing.T) {
+		app := newAppWith(
+			[]*types.Validator{leader, other},
+			&mockValidatorSigner{identity: leaderPub},
+		)
+		require.True(t, isLocalNodeActiveValidator(app))
+	})
+
+	t.Run("sentry pubkey not in active set", func(t *testing.T) {
+		app := newAppWith(
+			[]*types.Validator{leader, other},
+			&mockValidatorSigner{identity: sentryPub},
+		)
+		require.False(t, isLocalNodeActiveValidator(app))
+	})
+
+	t.Run("zero-power validator does not satisfy membership", func(t *testing.T) {
+		ghost, _, ghostPub := genValidator(t, 0)
+		app := newAppWith(
+			[]*types.Validator{leader, ghost},
+			&mockValidatorSigner{identity: ghostPub},
+		)
+		require.False(t, isLocalNodeActiveValidator(app))
+	})
+
+	t.Run("non-secp256k1 validator excluded", func(t *testing.T) {
+		ed := &types.Validator{
+			AccountID: types.AccountID{
+				Identifier: leaderPub, // same bytes, but wrong key type
+				KeyType:    kwilcrypto.KeyTypeEd25519,
+			},
+			Power: 1,
+		}
+		app := newAppWith(
+			[]*types.Validator{ed},
+			&mockValidatorSigner{identity: leaderPub},
+		)
+		require.False(t, isLocalNodeActiveValidator(app))
+	})
+
+	t.Run("nil ValidatorSigner returns false", func(t *testing.T) {
+		app := newAppWith([]*types.Validator{leader}, nil)
+		require.False(t, isLocalNodeActiveValidator(app))
+	})
+
+	t.Run("nil Validators returns false", func(t *testing.T) {
+		app := &common.App{
+			Service: &common.Service{
+				Logger:          log.New(),
+				ValidatorSigner: &mockValidatorSigner{identity: leaderPub},
+			},
+		}
+		require.False(t, isLocalNodeActiveValidator(app))
+	})
+
+	t.Run("empty identity returns false", func(t *testing.T) {
+		app := newAppWith(
+			[]*types.Validator{leader},
+			&mockValidatorSigner{identity: nil},
+		)
+		require.False(t, isLocalNodeActiveValidator(app))
+	})
+}
+
+// TestIsActiveValidatorAddress covers the defense-in-depth gate inside the
+// vote_epoch action handler. The check converts each validator's pubkey into
+// an Ethereum address and matches against the caller's address.
+func TestIsActiveValidatorAddress(t *testing.T) {
+	leader, leaderAddr, _ := genValidator(t, 1)
+	other, otherAddr, _ := genValidator(t, 1)
+	_, sentryAddr, _ := genValidator(t, 1)
+
+	app := newAppWith([]*types.Validator{leader, other}, nil)
+
+	t.Run("active validator address accepted", func(t *testing.T) {
+		require.True(t, isActiveValidatorAddress(app, leaderAddr))
+		require.True(t, isActiveValidatorAddress(app, otherAddr))
+	})
+
+	t.Run("non-validator address rejected", func(t *testing.T) {
+		require.False(t, isActiveValidatorAddress(app, sentryAddr))
+	})
+
+	t.Run("zero-power validator rejected", func(t *testing.T) {
+		ghost, ghostAddr, _ := genValidator(t, 0)
+		app := newAppWith([]*types.Validator{leader, ghost}, nil)
+		require.False(t, isActiveValidatorAddress(app, ghostAddr))
+	})
+
+	t.Run("nil Validators returns false", func(t *testing.T) {
+		app := &common.App{Service: &common.Service{Logger: log.New()}}
+		require.False(t, isActiveValidatorAddress(app, leaderAddr))
+	})
+}
+
+// TestGetValidatorSigner_NonValidatorReturnsNil is the integration backstop
+// for the gate: even with a non-nil ValidatorSigner, getValidatorSigner must
+// return (nil, nil) on a non-validator node so the caller's `if signer != nil`
+// check skips the broadcast goroutine. Without this, sentries broadcast votes
+// that the leader stores into epoch_votes — the 2026-04-25 incident shape.
+func TestGetValidatorSigner_NonValidatorReturnsNil(t *testing.T) {
+	leader, leaderAddr, _ := genValidator(t, 1)
+	_, sentryAddr, sentryPub := genValidator(t, 1)
+
+	t.Run("validator gets a signer", func(t *testing.T) {
+		app := newAppWith(
+			[]*types.Validator{leader},
+			&mockValidatorSigner{
+				identity: leader.Identifier,
+				ethAddr:  leaderAddr.Bytes(),
+			},
+		)
+		signer, err := getValidatorSigner(app, types.NewUUIDV5([]byte("test-instance")))
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+	})
+
+	t.Run("sentry gets nil signer", func(t *testing.T) {
+		app := newAppWith(
+			[]*types.Validator{leader},
+			&mockValidatorSigner{
+				identity: sentryPub,
+				ethAddr:  sentryAddr.Bytes(),
+			},
+		)
+		signer, err := getValidatorSigner(app, types.NewUUIDV5([]byte("test-instance")))
+		require.NoError(t, err)
+		require.Nil(t, signer)
+	})
+}

--- a/node/exts/erc20-bridge/erc20/validator_membership_test.go
+++ b/node/exts/erc20-bridge/erc20/validator_membership_test.go
@@ -229,3 +229,148 @@ func TestGetValidatorSigner_NonValidatorReturnsNil(t *testing.T) {
 		require.Nil(t, signer)
 	})
 }
+
+// TestGetValidatorSigner_LatePromotion verifies the doc claim that
+// getValidatorSigner is "late-promotion safe": a node that is a sentry at one
+// invocation and a validator at the next gets a real signer the second time
+// around. This is the behavior ensureValidatorSignersForActiveSyncedInstances
+// relies on when the EndBlock hook re-checks membership; without it, a
+// validator added after process startup would never sign vote_epoch txs.
+func TestGetValidatorSigner_LatePromotion(t *testing.T) {
+	leader, leaderAddr, _ := genValidator(t, 1)
+	promoted, promotedAddr, promotedPub := genValidator(t, 1)
+	instanceID := types.NewUUIDV5([]byte("test-instance-late-promotion"))
+	defer loggedSignerDisabled.Delete(*instanceID)
+
+	// mockValidators stays addressable so the test can flip the validator
+	// set in place — this is exactly the runtime shape the EndBlock re-check
+	// is designed for.
+	mock := &mockValidators{validators: []*types.Validator{leader}}
+	app := &common.App{
+		Service: &common.Service{
+			Logger: log.New(),
+			ValidatorSigner: &mockValidatorSigner{
+				identity: promotedPub,
+				ethAddr:  promotedAddr.Bytes(),
+			},
+		},
+		Validators: mock,
+	}
+	_ = leaderAddr // unused; only here for consistency with sibling tests
+
+	// Pre-promotion: this node is a sentry (its identity isn't in mock.validators).
+	signer, err := getValidatorSigner(app, instanceID)
+	require.NoError(t, err)
+	require.Nil(t, signer, "sentry must not get a signer pre-promotion")
+
+	// Promote: add this node's identity to the validator set.
+	mock.validators = append(mock.validators, promoted)
+
+	signer, err = getValidatorSigner(app, instanceID)
+	require.NoError(t, err)
+	require.NotNil(t, signer, "promoted validator must get a signer without restart")
+}
+
+// TestEnsureValidatorSignersHelper_SentryPathReleasesBookkeeping is the
+// targeted regression for the EndBlock-driven late-promotion path: the helper
+// must NOT permanently mark runningSigners[id]=true when getValidatorSigner
+// returns nil (sentry case), or subsequent calls would short-circuit and the
+// node-just-promoted-to-validator would never start signing. We also assert
+// the helper is a no-op past the membership check on a sentry: no signer
+// goroutine spawned, nothing left in runningSignerCancels.
+func TestEnsureValidatorSignersHelper_SentryPathReleasesBookkeeping(t *testing.T) {
+	ForTestingResetSingleton()
+	defer ForTestingResetSingleton()
+
+	leader, _, _ := genValidator(t, 1)
+	_, sentryAddr, sentryPub := genValidator(t, 1)
+
+	instanceID := types.NewUUIDV5([]byte("test-instance-helper-sentry"))
+	instanceIDStr := instanceID.String()
+
+	// Seed the singleton with an active+synced instance so the helper's
+	// iteration body runs (otherwise ForEachInstance would no-op).
+	_SINGLETON.instances.Set(*instanceID, &rewardExtensionInfo{
+		userProvidedData: userProvidedData{ID: instanceID},
+		active:           true,
+		synced:           true,
+	})
+
+	app := newAppWith(
+		[]*types.Validator{leader},
+		&mockValidatorSigner{identity: sentryPub, ethAddr: sentryAddr.Bytes()},
+	)
+
+	// Repeat the call several times to mirror how EndBlock would invoke it.
+	// On a sentry every call must leave the bookkeeping clean so that a
+	// future promotion (next block) can take a fresh slot.
+	for i := 0; i < 3; i++ {
+		ensureValidatorSignersForActiveSyncedInstances(app)
+
+		runningSignersMu.Lock()
+		_, runningSet := runningSigners[instanceIDStr]
+		_, cancelSet := runningSignerCancels[instanceIDStr]
+		runningSignersMu.Unlock()
+
+		require.False(t, runningSet, "iter %d: sentry call must not retain runningSigners slot", i)
+		require.False(t, cancelSet, "iter %d: sentry call must not spawn a signer goroutine", i)
+	}
+}
+
+// TestGetValidatorSigner_DisabledLogIsThrottled verifies the loggedSignerDisabled
+// guard. The EndBlock hook calls getValidatorSigner every block; without the
+// guard, sentries would emit the "not an active validator" INFO line every
+// block. The guard clears on promotion so a future demotion still produces
+// operator output.
+func TestGetValidatorSigner_DisabledLogIsThrottled(t *testing.T) {
+	leader, _, _ := genValidator(t, 1)
+	_, sentryAddr, sentryPub := genValidator(t, 1)
+	_, promotedAddr, promotedPub := genValidator(t, 1)
+
+	instanceID := types.NewUUIDV5([]byte("test-instance-log-guard"))
+	defer loggedSignerDisabled.Delete(*instanceID)
+
+	t.Run("sentry call sets the guard exactly once", func(t *testing.T) {
+		loggedSignerDisabled.Delete(*instanceID)
+		app := newAppWith(
+			[]*types.Validator{leader},
+			&mockValidatorSigner{identity: sentryPub, ethAddr: sentryAddr.Bytes()},
+		)
+
+		// First call: guard armed, "would have logged" (we only check state).
+		_, err := getValidatorSigner(app, instanceID)
+		require.NoError(t, err)
+		_, present := loggedSignerDisabled.Load(*instanceID)
+		require.True(t, present, "first sentry call must arm the log guard")
+
+		// Repeat calls: guard stays set, log would NOT fire again.
+		for i := 0; i < 3; i++ {
+			_, err := getValidatorSigner(app, instanceID)
+			require.NoError(t, err)
+		}
+		_, present = loggedSignerDisabled.Load(*instanceID)
+		require.True(t, present, "guard must remain set across repeat sentry calls")
+	})
+
+	t.Run("validator call clears the guard for future demotions", func(t *testing.T) {
+		// Pre-arm the guard, then call as validator.
+		loggedSignerDisabled.Store(*instanceID, struct{}{})
+
+		app := newAppWith(
+			[]*types.Validator{
+				{
+					AccountID: types.AccountID{Identifier: promotedPub, KeyType: kwilcrypto.KeyTypeSecp256k1},
+					Power:     1,
+				},
+			},
+			&mockValidatorSigner{identity: promotedPub, ethAddr: promotedAddr.Bytes()},
+		)
+
+		signer, err := getValidatorSigner(app, instanceID)
+		require.NoError(t, err)
+		require.NotNil(t, signer)
+
+		_, present := loggedSignerDisabled.Load(*instanceID)
+		require.False(t, present, "validator call must clear the guard so a future demotion logs again")
+	})
+}


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3752

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security**
  * Validator-membership gate added to voting so only active validators with positive voting power can submit epoch votes; non-validator nodes no longer run validator signer/broadcast routines.
* **Tests**
  * New test suite validating validator membership checks and signer behavior across active, non-active, zero-power, and absent-validator scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->