### PR TITLE
chore: prevent crash on WAL UPDATE without old tuple

### DIFF
--- a/node/pg/repl_changeset.go
+++ b/node/pg/repl_changeset.go
@@ -504,25 +504,31 @@ func (c *changesetIoWriter) decodeUpdate(update *pglogrepl.UpdateMessageV2, rela
 		RelationIdx: idx,
 	}
 
-	// write old tuple
-	tup, err := convertPgxTuple(update.OldTuple, relation, c.oidToType)
-	if err != nil {
-		return err
+	// pglogrepl: an UPDATE may carry 'K' (key), 'O' (old tuple), or neither —
+	// the latter when REPLICA IDENTITY is DEFAULT/INDEX/NOTHING and the key
+	// columns did not change. Leave ce.OldTuple unset in that case.
+	if update.OldTuple != nil {
+		tup, err := convertPgxTuple(update.OldTuple, relation, c.oidToType)
+		if err != nil {
+			return err
+		}
+		ce.OldTuple = tup.Columns
 	}
-	ce.OldTuple = tup.Columns
 
 	// write new tuple
-	tup, err = convertPgxTuple(update.NewTuple, relation, c.oidToType)
+	tup, err := convertPgxTuple(update.NewTuple, relation, c.oidToType)
 	if err != nil {
 		return err
 	}
-	// de-duplicate unchanged data
-	for i, old := range ce.OldTuple {
-		updated := tup.Columns[i]
-		if old.ValueType == updated.ValueType &&
-			bytes.Equal(old.Data, updated.Data) {
-			tup.Columns[i].ValueType = UnchangedUpdate
-			tup.Columns[i].Data = nil
+	// de-duplicate unchanged data only when we have an old tuple to compare
+	if ce.OldTuple != nil {
+		for i, old := range ce.OldTuple {
+			updated := tup.Columns[i]
+			if old.ValueType == updated.ValueType &&
+				bytes.Equal(old.Data, updated.Data) {
+				tup.Columns[i].ValueType = UnchangedUpdate
+				tup.Columns[i].Data = nil
+			}
 		}
 	}
 	ce.NewTuple = tup.Columns
@@ -537,17 +543,20 @@ func (c *changesetIoWriter) decodeDelete(delete *pglogrepl.DeleteMessageV2, rela
 	}
 
 	idx := c.registerMetadata(relation)
-
-	// write old tuple
-	tup, err := convertPgxTuple(delete.OldTuple, relation, c.oidToType)
-	if err != nil {
-		return err
-	}
-
 	ce := &ChangesetEntry{
 		RelationIdx: idx,
-		OldTuple:    tup.Columns,
 		// NewTuple is empty for delete
+	}
+
+	// pglogrepl normally always carries an OldTuple for DELETE; defend against
+	// the same nil-tuple shape that was hit on UPDATE so an upstream change in
+	// PG/replica identity behavior cannot crash the consumer.
+	if delete.OldTuple != nil {
+		tup, err := convertPgxTuple(delete.OldTuple, relation, c.oidToType)
+		if err != nil {
+			return err
+		}
+		ce.OldTuple = tup.Columns
 	}
 
 	c.csChan <- ce

--- a/node/pg/repl_changeset.go
+++ b/node/pg/repl_changeset.go
@@ -400,13 +400,21 @@ func (ce *ChangesetEntry) applyDeletes(ctx context.Context, tx sql.DB, rel *Rela
 		return fmt.Errorf("relation %s.%s has no columns", rel.Schema, rel.Table)
 	}
 
-	var deleteSql strings.Builder
-	fmt.Fprintf(&deleteSql, "DELETE FROM %s.%s WHERE ", rel.Schema, rel.Table)
-
 	record, _, err := ce.DecodeTuples(rel)
 	if err != nil {
 		return err
 	}
+
+	// Guard against an OldTuple-less DELETE (decodeDelete now tolerates that
+	// shape defensively). Without this check we would build a bare
+	// "DELETE FROM x.y WHERE " string and let Postgres reject it as a syntax
+	// error — surfacing a clearer message here keeps the failure mode obvious.
+	if len(record) == 0 {
+		return fmt.Errorf("refusing to apply DELETE on %s.%s: changeset entry carries no old tuple", rel.Schema, rel.Table)
+	}
+
+	var deleteSql strings.Builder
+	fmt.Fprintf(&deleteSql, "DELETE FROM %s.%s WHERE ", rel.Schema, rel.Table)
 
 	var args []any
 	cnt := 1
@@ -513,6 +521,14 @@ func (c *changesetIoWriter) decodeUpdate(update *pglogrepl.UpdateMessageV2, rela
 			return err
 		}
 		ce.OldTuple = tup.Columns
+	} else {
+		// With OldTuple nil, ChangesetEntry.Kind() reports Insert (len(OldTuple)==0,
+		// len(NewTuple)>0), so ApplyChangesetEntry routes this to applyInserts and
+		// the row's update is silently dropped (ON CONFLICT DO NOTHING) on the
+		// receiving network. Surface this so operators know to set the source
+		// table's REPLICA IDENTITY to FULL.
+		logger.Warn("UPDATE with no old tuple will be applied as INSERT and may be dropped",
+			"schema", relation.Namespace, "table", relation.RelationName)
 	}
 
 	// write new tuple

--- a/node/pg/repl_changeset_test.go
+++ b/node/pg/repl_changeset_test.go
@@ -6,10 +6,172 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/jackc/pglogrepl"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/trufnetwork/kwil-db/core/types"
 )
+
+// newTestChangesetWriter builds a changesetIoWriter wired to a buffered channel
+// so tests can drive decodeInsert/decodeUpdate/decodeDelete without a live
+// Postgres connection. The OID-to-type map covers the OID used by the test
+// relations below.
+func newTestChangesetWriter(buffer int) (*changesetIoWriter, chan any) {
+	csChan := make(chan any, buffer)
+	cs := &changesetIoWriter{
+		csChan: csChan,
+		oidToType: map[uint32]*datatype{
+			23: {KwilType: types.IntType}, // pg int4; SerializeChangeset never invoked for Null tuple cols
+		},
+		metadata: &changesetMetadata{relationIdx: map[[2]string]int{}},
+	}
+	return cs, csChan
+}
+
+func testRelation() *pglogrepl.RelationMessageV2 {
+	return &pglogrepl.RelationMessageV2{
+		RelationMessage: pglogrepl.RelationMessage{
+			RelationID:   1,
+			Namespace:    "main",
+			RelationName: "primitive_events",
+			Columns: []*pglogrepl.RelationMessageColumn{
+				{Name: "id", DataType: 23},
+			},
+		},
+	}
+}
+
+// TestDecodeUpdate_NilOldTuple is the regression test for the mainnet leader
+// SIGSEGV in convertPgxTuple at repl_changeset.go:581. Postgres' logical decoder
+// emits UPDATE messages with OldTuple==nil whenever the source table has
+// REPLICA IDENTITY DEFAULT/INDEX/NOTHING and the key columns are unchanged.
+// Pre-fix, decodeUpdate dereferenced that nil and crashed the process; this
+// test asserts the consumer is now nil-tolerant.
+func TestDecodeUpdate_NilOldTuple(t *testing.T) {
+	cs, csChan := newTestChangesetWriter(4)
+	relation := testRelation()
+
+	update := &pglogrepl.UpdateMessageV2{
+		UpdateMessage: pglogrepl.UpdateMessage{
+			RelationID: 1,
+			OldTuple:   nil, // the WAL shape that previously crashed the leader
+			NewTuple: &pglogrepl.TupleData{
+				ColumnNum: 1,
+				Columns: []*pglogrepl.TupleDataColumn{
+					{DataType: pglogrepl.TupleDataTypeNull},
+				},
+			},
+		},
+	}
+
+	require.NotPanics(t, func() {
+		require.NoError(t, cs.decodeUpdate(update, relation))
+	})
+
+	// First message off the channel is the registered relation, second is the
+	// changeset entry. The entry must have no OldTuple but a populated NewTuple.
+	msg := <-csChan
+	_, isRel := msg.(*Relation)
+	require.True(t, isRel, "first csChan element should be *Relation, got %T", msg)
+
+	ce, ok := (<-csChan).(*ChangesetEntry)
+	require.True(t, ok)
+	assert.Nil(t, ce.OldTuple, "OldTuple must remain unset when WAL omits it")
+	require.Len(t, ce.NewTuple, 1)
+	assert.Equal(t, NullValue, ce.NewTuple[0].ValueType)
+}
+
+// TestDecodeUpdate_FullReplicaIdentity confirms that the dedup loop still
+// runs (and marks identical columns as UnchangedUpdate) when the WAL carries
+// both an old and a new tuple — i.e., REPLICA IDENTITY FULL behaves as before.
+func TestDecodeUpdate_FullReplicaIdentity(t *testing.T) {
+	cs, csChan := newTestChangesetWriter(4)
+	relation := testRelation()
+
+	tupleNull := func() *pglogrepl.TupleData {
+		return &pglogrepl.TupleData{
+			ColumnNum: 1,
+			Columns: []*pglogrepl.TupleDataColumn{
+				{DataType: pglogrepl.TupleDataTypeNull},
+			},
+		}
+	}
+
+	update := &pglogrepl.UpdateMessageV2{
+		UpdateMessage: pglogrepl.UpdateMessage{
+			RelationID:   1,
+			OldTupleType: pglogrepl.UpdateMessageTupleTypeOld,
+			OldTuple:     tupleNull(),
+			NewTuple:     tupleNull(),
+		},
+	}
+
+	require.NoError(t, cs.decodeUpdate(update, relation))
+
+	<-csChan // discard relation
+	ce := (<-csChan).(*ChangesetEntry)
+	require.Len(t, ce.OldTuple, 1)
+	require.Len(t, ce.NewTuple, 1)
+	assert.Equal(t, NullValue, ce.OldTuple[0].ValueType)
+	// Identical tuples → NewTuple column is collapsed to UnchangedUpdate.
+	assert.Equal(t, UnchangedUpdate, ce.NewTuple[0].ValueType)
+	assert.Nil(t, ce.NewTuple[0].Data)
+}
+
+// TestDecodeDelete_NilOldTuple covers the defense-in-depth nil-check on
+// decodeDelete. Postgres normally always emits an old tuple for DELETE, but
+// since the same convertPgxTuple deref pattern existed there too, we lock in
+// that the consumer no longer panics if a future PG/replication change ever
+// produces an OldTuple-less DELETE.
+func TestDecodeDelete_NilOldTuple(t *testing.T) {
+	cs, csChan := newTestChangesetWriter(4)
+	relation := testRelation()
+
+	del := &pglogrepl.DeleteMessageV2{
+		DeleteMessage: pglogrepl.DeleteMessage{
+			RelationID: 1,
+			OldTuple:   nil,
+		},
+	}
+
+	require.NotPanics(t, func() {
+		require.NoError(t, cs.decodeDelete(del, relation))
+	})
+
+	<-csChan // relation
+	ce, ok := (<-csChan).(*ChangesetEntry)
+	require.True(t, ok)
+	assert.Nil(t, ce.OldTuple)
+	assert.Nil(t, ce.NewTuple)
+}
+
+// TestDecodeDelete_WithOldTuple confirms the normal DELETE path still records
+// the old tuple unchanged.
+func TestDecodeDelete_WithOldTuple(t *testing.T) {
+	cs, csChan := newTestChangesetWriter(4)
+	relation := testRelation()
+
+	del := &pglogrepl.DeleteMessageV2{
+		DeleteMessage: pglogrepl.DeleteMessage{
+			RelationID:   1,
+			OldTupleType: pglogrepl.DeleteMessageTupleTypeOld,
+			OldTuple: &pglogrepl.TupleData{
+				ColumnNum: 1,
+				Columns: []*pglogrepl.TupleDataColumn{
+					{DataType: pglogrepl.TupleDataTypeNull},
+				},
+			},
+		},
+	}
+
+	require.NoError(t, cs.decodeDelete(del, relation))
+
+	<-csChan // relation
+	ce := (<-csChan).(*ChangesetEntry)
+	require.Len(t, ce.OldTuple, 1)
+	assert.Equal(t, NullValue, ce.OldTuple[0].ValueType)
+	assert.Nil(t, ce.NewTuple)
+}
 
 func TestChangesetEntry_Serialize(t *testing.T) {
 	tests := []struct {

--- a/node/pg/repl_changeset_test.go
+++ b/node/pg/repl_changeset_test.go
@@ -2,6 +2,7 @@ package pg
 
 import (
 	"bytes"
+	"context"
 	"encoding/binary"
 	"strings"
 	"testing"
@@ -79,6 +80,11 @@ func TestDecodeUpdate_NilOldTuple(t *testing.T) {
 	assert.Nil(t, ce.OldTuple, "OldTuple must remain unset when WAL omits it")
 	require.Len(t, ce.NewTuple, 1)
 	assert.Equal(t, NullValue, ce.NewTuple[0].ValueType)
+	// Document the downstream consequence: with no OldTuple, Kind() classifies
+	// this entry as Insert and ApplyChangesetEntry will route it to applyInserts
+	// (ON CONFLICT DO NOTHING) on the receiving network. decodeUpdate logs a
+	// warning for operator visibility — see the else-branch in decodeUpdate.
+	assert.Equal(t, CSEntryKindInsert, ce.Kind())
 }
 
 // TestDecodeUpdate_FullReplicaIdentity confirms that the dedup loop still
@@ -171,6 +177,22 @@ func TestDecodeDelete_WithOldTuple(t *testing.T) {
 	require.Len(t, ce.OldTuple, 1)
 	assert.Equal(t, NullValue, ce.OldTuple[0].ValueType)
 	assert.Nil(t, ce.NewTuple)
+}
+
+// TestApplyDeletes_RefusesEmptyOldTuple locks in the guard against building a
+// bare "DELETE FROM x.y WHERE " SQL string. The guard returns before tx is
+// touched, so a nil sql.DB is safe to pass here.
+func TestApplyDeletes_RefusesEmptyOldTuple(t *testing.T) {
+	rel := &Relation{
+		Schema:  "main",
+		Table:   "primitive_events",
+		Columns: []*Column{{Name: "id", Type: types.IntType}},
+	}
+	ce := &ChangesetEntry{RelationIdx: 0} // OldTuple unset
+
+	err := ce.applyDeletes(context.Background(), nil, rel)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "no old tuple")
 }
 
 func TestChangesetEntry_Serialize(t *testing.T) {


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/3757

already live on mainnet

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of PostgreSQL replication messages when certain data is absent, preventing potential crashes during DELETE and UPDATE operations.
  * Enhanced value deduplication logic for UPDATE operations.

* **Tests**
  * Added regression tests for edge cases in replication message handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->