### PR TITLE
chore: encode agent-wallet execution transactions

### DIFF
--- a/core/types/payloads.go
+++ b/core/types/payloads.go
@@ -51,6 +51,9 @@ const (
 	PayloadTypeCreateResolution    PayloadType = "create_resolution"
 	PayloadTypeApproveResolution   PayloadType = "approve_resolution"
 	PayloadTypeDeleteResolution    PayloadType = "delete_resolution"
+	// PayloadTypeMAAExec executes a single inner action as a Modular Agent
+	// Address (MAA). The mechanism is consensus-breaking; see MAAExec.
+	PayloadTypeMAAExec PayloadType = "maa_exec"
 )
 
 // payloadConcreteTypes associates a payload type with the concrete type of
@@ -69,6 +72,7 @@ var payloadConcreteTypes = map[PayloadType]Payload{
 	PayloadTypeValidatorVoteBodies: &ValidatorVoteBodies{},
 	PayloadTypeCreateResolution:    &CreateResolution{},
 	PayloadTypeApproveResolution:   &ApproveResolution{},
+	PayloadTypeMAAExec:             &MAAExec{},
 	// PayloadTypeDeleteResolution:    &DeleteResolution{},
 }
 
@@ -111,6 +115,7 @@ var payloadTypes = map[PayloadType]bool{
 	PayloadTypeCreateResolution:    true,
 	PayloadTypeApproveResolution:   true,
 	PayloadTypeDeleteResolution:    true,
+	PayloadTypeMAAExec:             true,
 }
 
 // Valid says if the payload type is known. This does not mean that the node
@@ -128,6 +133,7 @@ func (p PayloadType) Valid() bool {
 		PayloadTypeDeleteResolution,
 		PayloadTypeRawStatement,
 		PayloadTypeExecute,
+		PayloadTypeMAAExec,
 		// These should not come in user transactions, but they are not invalid
 		// payload types in general.
 		PayloadTypeValidatorVoteIDs,
@@ -397,6 +403,123 @@ func (a *ActionExecution) UnmarshalBinary(b []byte) error {
 
 	// ensure all args[i] have same length here or in caller?
 
+	return nil
+}
+
+// MAAExec is the payload that executes a single inner action as a Modular Agent
+// Address (MAA). The transaction is signed by the agent's component key
+// (restricted role) or the wallet owner (unrestricted role); the maaExecRoute
+// looks up the rule bound to MAAAddress, enforces the allow-list for the
+// signer's role, and re-enters the engine with @caller rewritten to MAAAddress.
+//
+// Unlike ActionExecution this carries exactly one call (no batching): the
+// allow-list decision and audit event are one-to-one with the transaction, and
+// the restricted role's authority is reasoned about per single action.
+//
+// This payload is consensus-breaking. It is recognized by every node carrying
+// this code, but is only meaningful where the maaExecRoute is registered;
+// network-wide activation is coordinated by the rollout (a height gate is the
+// chokepoint where activation is enforced).
+type MAAExec struct {
+	// MAAAddress is the 20-byte agent-wallet address whose identity (@caller)
+	// the inner action assumes. There is no inner signature; authority derives
+	// from the outer signer's role in the rule bound to this address.
+	MAAAddress []byte
+	// Namespace is the namespace of the inner action (e.g. "main").
+	Namespace string
+	// Action is the inner action name to execute as the MAA.
+	Action string
+	// Arguments are the inner action's arguments (a single call).
+	Arguments []*EncodedValue
+}
+
+var _ Payload = (*MAAExec)(nil)
+
+func (m MAAExec) Type() PayloadType {
+	return PayloadTypeMAAExec
+}
+
+const maaExecVersion = 0
+
+// MAAExec serialization (SerializationByteOrder = little endian throughout):
+//
+//   - uint16 version, presently 0 (maaExecVersion).
+//   - MAAAddress written with WriteBytes (a 4-byte length prefix + raw bytes).
+//   - Namespace written with WriteString.
+//   - Action written with WriteString.
+//   - uint16 number of arguments.
+//   - each EncodedValue serialized via its MarshalBinary, written with WriteBytes.
+func (m MAAExec) MarshalBinary() ([]byte, error) {
+	buf := &bytes.Buffer{}
+	if err := binary.Write(buf, SerializationByteOrder, uint16(maaExecVersion)); err != nil {
+		return nil, err
+	}
+	if err := WriteBytes(buf, m.MAAAddress); err != nil {
+		return nil, err
+	}
+	if err := WriteString(buf, m.Namespace); err != nil {
+		return nil, err
+	}
+	if err := WriteString(buf, m.Action); err != nil {
+		return nil, err
+	}
+	numArgs := len(m.Arguments)
+	if err := binary.Write(buf, SerializationByteOrder, uint16(numArgs)); err != nil {
+		return nil, err
+	}
+	for _, encVal := range m.Arguments {
+		encValBts, err := encVal.MarshalBinary()
+		if err != nil {
+			return nil, err
+		}
+		if err := WriteBytes(buf, encValBts); err != nil {
+			return nil, err
+		}
+	}
+	return buf.Bytes(), nil
+}
+
+func (m *MAAExec) UnmarshalBinary(b []byte) error {
+	rd := bytes.NewReader(b)
+	var version uint16
+	if err := binary.Read(rd, SerializationByteOrder, &version); err != nil {
+		return err
+	}
+	if version != maaExecVersion {
+		return fmt.Errorf("unsupported version %d", version)
+	}
+	maaAddress, err := ReadBytes(rd)
+	if err != nil {
+		return err
+	}
+	namespace, err := ReadString(rd)
+	if err != nil {
+		return err
+	}
+	action, err := ReadString(rd)
+	if err != nil {
+		return err
+	}
+	var numArgs uint16
+	if err := binary.Read(rd, SerializationByteOrder, &numArgs); err != nil {
+		return err
+	}
+	args := make([]*EncodedValue, numArgs)
+	for i := range args {
+		encValBts, err := ReadBytes(rd)
+		if err != nil {
+			return err
+		}
+		var ev EncodedValue
+		if err := ev.UnmarshalBinary(encValBts); err != nil {
+			return err
+		}
+		args[i] = &ev
+	}
+	m.MAAAddress = maaAddress
+	m.Namespace = namespace
+	m.Action = action
+	m.Arguments = args
 	return nil
 }
 

--- a/core/types/payloads.go
+++ b/core/types/payloads.go
@@ -15,6 +15,7 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
+	"math"
 	"math/big"
 	"reflect"
 	"strconv"
@@ -464,6 +465,9 @@ func (m MAAExec) MarshalBinary() ([]byte, error) {
 		return nil, err
 	}
 	numArgs := len(m.Arguments)
+	if numArgs > math.MaxUint16 {
+		return nil, fmt.Errorf("too many arguments to marshal: %d (max %d)", numArgs, math.MaxUint16)
+	}
 	if err := binary.Write(buf, SerializationByteOrder, uint16(numArgs)); err != nil {
 		return nil, err
 	}

--- a/core/types/payloads_maa_test.go
+++ b/core/types/payloads_maa_test.go
@@ -1,0 +1,154 @@
+package types
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+)
+
+// The MAAExec wire layout is a consensus contract: the node, kwil-js, and the
+// language SDKs must all serialize it identically (a single byte of divergence
+// rewrites which action runs, or under whose identity). These tests freeze that
+// layout. The golden vector below uses ZERO arguments so its bytes are fully
+// determined by the MAA-specific framing (version + maa_address + namespace +
+// action + count); argument encoding reuses the shared EncodedValue format that
+// every SDK already implements for ActionExecution and is covered by round-trip.
+
+func mustHex(t *testing.T, s string) []byte {
+	t.Helper()
+	b, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad hex %q: %v", s, err)
+	}
+	return b
+}
+
+func TestMAAExec_Type(t *testing.T) {
+	var p Payload = &MAAExec{}
+	if p.Type() != PayloadTypeMAAExec {
+		t.Fatalf("Type() = %q, want %q", p.Type(), PayloadTypeMAAExec)
+	}
+	if !PayloadTypeMAAExec.Valid() {
+		t.Fatal("PayloadTypeMAAExec should be Valid()")
+	}
+	// UnmarshalPayload must be able to instantiate it (i.e. it is in
+	// payloadConcreteTypes), otherwise broadcast txs can't be decoded.
+	got, err := UnmarshalPayload(PayloadTypeMAAExec, mustHex(t, goldenMAAExecHex))
+	if err != nil {
+		t.Fatalf("UnmarshalPayload: %v", err)
+	}
+	if _, ok := got.(*MAAExec); !ok {
+		t.Fatalf("UnmarshalPayload returned %T, want *MAAExec", got)
+	}
+}
+
+// goldenMAAExecHex is the frozen serialization of the zero-argument vector in
+// TestMAAExec_GoldenVector. SDKs assert byte-equality against this value.
+const goldenMAAExecHex = "0000" + // uint16 version = 0 (little-endian)
+	"14000000" + "1111111111111111111111111111111111111111" + // WriteBytes(maa_address): len=20, then 20 bytes
+	"04000000" + "6d61696e" + // WriteString("main"): len=4, then "main"
+	"0e000000" + "6f625f706c6163655f6f72646572" + // WriteString("ob_place_order"): len=14, then bytes
+	"0000" // uint16 numArgs = 0
+
+func TestMAAExec_GoldenVector(t *testing.T) {
+	m := MAAExec{
+		MAAAddress: bytes.Repeat([]byte{0x11}, 20),
+		Namespace:  "main",
+		Action:     "ob_place_order",
+		Arguments:  nil,
+	}
+	got, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	want := mustHex(t, goldenMAAExecHex)
+	if !bytes.Equal(got, want) {
+		t.Fatalf("MAAExec golden vector\n got %x\nwant %x", got, want)
+	}
+
+	var m2 MAAExec
+	if err := m2.UnmarshalBinary(got); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	if !bytes.Equal(m2.MAAAddress, m.MAAAddress) {
+		t.Fatalf("MAAAddress round-trip: got %x want %x", m2.MAAAddress, m.MAAAddress)
+	}
+	if m2.Namespace != m.Namespace || m2.Action != m.Action {
+		t.Fatalf("ns/action round-trip: got %q/%q want %q/%q", m2.Namespace, m2.Action, m.Namespace, m.Action)
+	}
+	if len(m2.Arguments) != 0 {
+		t.Fatalf("expected 0 args, got %d", len(m2.Arguments))
+	}
+}
+
+func TestMAAExec_RoundTripWithArgs(t *testing.T) {
+	arg0, err := EncodeValue("0xabc")
+	if err != nil {
+		t.Fatalf("EncodeValue(string): %v", err)
+	}
+	arg1, err := EncodeValue(int64(42))
+	if err != nil {
+		t.Fatalf("EncodeValue(int64): %v", err)
+	}
+	m := MAAExec{
+		MAAAddress: bytes.Repeat([]byte{0x22}, 20),
+		Namespace:  "main",
+		Action:     "maa_record_event",
+		Arguments:  []*EncodedValue{arg0, arg1},
+	}
+	bts, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+
+	var m2 MAAExec
+	if err := m2.UnmarshalBinary(bts); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	if !bytes.Equal(m2.MAAAddress, m.MAAAddress) || m2.Namespace != m.Namespace || m2.Action != m.Action {
+		t.Fatalf("scalar fields diverged after round-trip")
+	}
+	if len(m2.Arguments) != 2 {
+		t.Fatalf("expected 2 args, got %d", len(m2.Arguments))
+	}
+	// Re-marshalling must be byte-stable (the strongest equality check for the
+	// nested EncodedValue args without depending on their internal layout).
+	bts2, err := m2.MarshalBinary()
+	if err != nil {
+		t.Fatalf("re-MarshalBinary: %v", err)
+	}
+	if !bytes.Equal(bts, bts2) {
+		t.Fatalf("round-trip not byte-stable\n first %x\nsecond %x", bts, bts2)
+	}
+}
+
+func TestMAAExec_NilAndEmptyAddress(t *testing.T) {
+	// A nil MAAAddress must survive the WriteBytes(nil)=MaxUint32 sentinel and
+	// come back nil (distinct from an empty, present address).
+	m := MAAExec{MAAAddress: nil, Namespace: "", Action: "x"}
+	bts, err := m.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary: %v", err)
+	}
+	var m2 MAAExec
+	if err := m2.UnmarshalBinary(bts); err != nil {
+		t.Fatalf("UnmarshalBinary: %v", err)
+	}
+	if m2.MAAAddress != nil {
+		t.Fatalf("nil MAAAddress round-tripped to %x, want nil", m2.MAAAddress)
+	}
+	if m2.Namespace != "" || m2.Action != "x" {
+		t.Fatalf("ns/action diverged: %q/%q", m2.Namespace, m2.Action)
+	}
+}
+
+func TestMAAExec_RejectsBadVersion(t *testing.T) {
+	// Flip the leading version word to a value the decoder must reject.
+	bts := mustHex(t, goldenMAAExecHex)
+	binary.LittleEndian.PutUint16(bts[:2], 1)
+	var m MAAExec
+	if err := m.UnmarshalBinary(bts); err == nil {
+		t.Fatal("expected error for unsupported version, got nil")
+	}
+}

--- a/core/types/payloads_maa_test.go
+++ b/core/types/payloads_maa_test.go
@@ -141,6 +141,28 @@ func TestMAAExec_NilAndEmptyAddress(t *testing.T) {
 	if m2.Namespace != "" || m2.Action != "x" {
 		t.Fatalf("ns/action diverged: %q/%q", m2.Namespace, m2.Action)
 	}
+
+	// An explicit empty (non-nil) MAAAddress must round-trip as a present,
+	// zero-length slice -- NOT collapse to nil (WriteBytes encodes len 0, the
+	// MaxUint32 sentinel is reserved for nil).
+	mEmpty := MAAExec{MAAAddress: []byte{}, Namespace: "", Action: "x"}
+	btsEmpty, err := mEmpty.MarshalBinary()
+	if err != nil {
+		t.Fatalf("MarshalBinary (empty): %v", err)
+	}
+	var m3 MAAExec
+	if err := m3.UnmarshalBinary(btsEmpty); err != nil {
+		t.Fatalf("UnmarshalBinary (empty): %v", err)
+	}
+	if m3.MAAAddress == nil {
+		t.Fatal("empty MAAAddress round-tripped to nil, want a non-nil zero-length slice")
+	}
+	if len(m3.MAAAddress) != 0 {
+		t.Fatalf("empty MAAAddress round-tripped to len %d, want 0", len(m3.MAAAddress))
+	}
+	if m3.Namespace != "" || m3.Action != "x" {
+		t.Fatalf("ns/action diverged (empty): %q/%q", m3.Namespace, m3.Action)
+	}
 }
 
 func TestMAAExec_RejectsBadVersion(t *testing.T) {


### PR DESCRIPTION
Partially toward letting an agent key operate its wallet within limits:

resolves: https://github.com/truflation/website/issues/4036

Adds the `MAAExec` transaction payload: the wire format for executing a single inner action as a Modular Agent Address (MAA). It is the foundation the execution route builds on. The route lands in a stacked follow-up PR that carries the closing keyword for #4036.

## Contents
- `PayloadTypeMAAExec` (`"maa_exec"`) and `MAAExec{ MAAAddress, Namespace, Action, Arguments }`, with little-endian `Marshal`/`UnmarshalBinary` modeled on `ActionExecution` (a single call, not batched).
- Registered in `payloadConcreteTypes`, `payloadTypes`, and `Valid()` so the type decodes and is recognized across the node.
- Golden-vector and round-trip tests that freeze the wire layout (the language SDKs mirror these exact bytes).

No route is registered in this PR, so a `maa_exec` transaction has no handler and is inert (rejected as an unroutable type) until the follow-up. No behavior change for existing transactions.
