### PR TITLE
feat: run allow-listed actions as an agent wallet

### DIFF
--- a/node/txapp/maa_route.go
+++ b/node/txapp/maa_route.go
@@ -1,0 +1,207 @@
+package txapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"math/big"
+	"strings"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/trufnetwork/kwil-db/common"
+	"github.com/trufnetwork/kwil-db/core/types"
+	"github.com/trufnetwork/kwil-db/extensions/consensus"
+	"github.com/trufnetwork/kwil-db/node/engine"
+)
+
+// maaExecRoute handles PayloadTypeMAAExec: it lets an authorized signer run a
+// single allow-listed action AS a Modular Agent Address (MAA), with @caller
+// rewritten to the MAA for the inner call.
+//
+// Security model ("operate the wallet within limits"):
+//   - The MAA must be a known, joined instance (created by maa_join, issue #1).
+//   - The OUTER signer must be the rule's restricted address (the agent) OR the
+//     instance's unrestricted address (the owner); otherwise the signer has no
+//     authority over this MAA. The signer is read WHILE @caller is still the
+//     signer's own identity, before any rewrite.
+//   - The inner (namespace, action) must be in the rule's allow-list. This holds
+//     for BOTH roles (plan lifecycle 4a: the unrestricted owner acts "as the MAA
+//     [for] any allow-listed action"). Raw value-moving primitives are never
+//     allow-listed, so neither role can move funds out via this route. The
+//     owner's withdraw-with-commission is a separate action (issue #4); the
+//     restricted role's hard no-exit guarantee at any depth is the token
+//     boundary (issue #3).
+//   - The inner call is TOP-LEVEL, so SYSTEM-only ops (mint/issue/lock_admin/
+//     unlock) stay blocked even though @caller is now the MAA.
+//
+// Gas/nonce are paid by the OUTER signer; the MAA never pays gas. The MAA's
+// identity is assumed only for the duration of the inner action.
+type maaExecRoute struct {
+	maaAddress []byte
+	namespace  string
+	action     string
+	args       []any
+}
+
+var _ consensus.Route = (*maaExecRoute)(nil)
+
+func (d *maaExecRoute) Name() string {
+	return types.PayloadTypeMAAExec.String()
+}
+
+func (d *maaExecRoute) Price(ctx context.Context, app *common.App, tx *types.Transaction) (*big.Int, error) {
+	// The inner call does the real work, so price it like an action execution.
+	return big.NewInt(2000000000000000), nil
+}
+
+func (d *maaExecRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *types.Transaction) (types.TxCode, error) {
+	// ACTIVATION CHOKEPOINT (issue #7): once fork-height infrastructure lands,
+	// reject MAAExec before its activation height here, mirroring the
+	// MigrationStatus guards in transferRoute.PreTx. Until then availability is
+	// "this binary is deployed", which the coordinated rollout (#7) flag-days.
+
+	payload := &types.MAAExec{}
+	if err := payload.UnmarshalBinary(tx.Body.Payload); err != nil {
+		return types.CodeEncodingError, err
+	}
+	if len(payload.MAAAddress) != 20 {
+		return types.CodeEncodingError, fmt.Errorf("maa_address must be 20 bytes, got %d", len(payload.MAAAddress))
+	}
+	if payload.Action == "" {
+		return types.CodeEncodingError, fmt.Errorf("inner action must not be empty")
+	}
+
+	d.maaAddress = payload.MAAAddress
+	d.namespace = payload.Namespace
+	if d.namespace == "" {
+		d.namespace = engine.DefaultNamespace
+	}
+	d.action = payload.Action
+
+	// Decode the inner-action arguments once (mirrors executeActionRoute.PreTx).
+	d.args = make([]any, len(payload.Arguments))
+	for i, val := range payload.Arguments {
+		v, err := val.Decode()
+		if err != nil {
+			return types.CodeEncodingError, err
+		}
+		d.args[i] = v
+	}
+	return 0, nil
+}
+
+func (d *maaExecRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Transaction) (types.TxCode, string, error) {
+	// The outer signer's identity, as raw 20 address bytes. Compared by bytes (not
+	// strings) because the engine identifier is EIP-55 checksummed while the rule
+	// store emits lowercase hex — a string compare would be a consensus bug.
+	if !ethcommon.IsHexAddress(ctx.Caller) {
+		return types.CodeInvalidSender, "", fmt.Errorf("maa_exec requires an ethereum-address signer, got %q", ctx.Caller)
+	}
+	signer := ethcommon.HexToAddress(ctx.Caller).Bytes()
+
+	// 1) Resolve the MAA instance and its rule's restricted/unrestricted keys.
+	//    maa_get_instance JOINs the instance to its rule (issue #1 getter); a
+	//    missing row means this address was never joined -> not a known MAA.
+	var ruleID, restricted, unrestricted []byte
+	found := false
+	res, err := app.Engine.Call(makeEngineCtx(ctx), app.DB, engine.DefaultNamespace, "maa_get_instance",
+		[]any{d.maaAddress}, func(r *common.Row) error {
+			// columns: maa_address, rule_id, restricted_addr, unrestricted_addr, created_at
+			var derr error
+			if ruleID, derr = hexColumnToBytes(r, 1); derr != nil {
+				return derr
+			}
+			if restricted, derr = hexColumnToBytes(r, 2); derr != nil {
+				return derr
+			}
+			if unrestricted, derr = hexColumnToBytes(r, 3); derr != nil {
+				return derr
+			}
+			found = true
+			return nil
+		})
+	if err != nil {
+		return codeForEngineError(err), "", err
+	}
+	if res.Error != nil {
+		return types.CodeUnknownError, "", res.Error
+	}
+	if !found {
+		return types.CodeInvalidSender, "", fmt.Errorf("unknown MAA 0x%x: no joined instance", d.maaAddress)
+	}
+
+	// 2) Authorize the signer and determine its role (restricted vs unrestricted).
+	var role string
+	switch {
+	case bytes.Equal(signer, restricted):
+		role = "restricted"
+	case bytes.Equal(signer, unrestricted):
+		role = "unrestricted"
+	default:
+		return types.CodeInvalidSender, "", fmt.Errorf(
+			"signer 0x%x is neither the restricted nor the unrestricted key of MAA 0x%x", signer, d.maaAddress)
+	}
+	_ = role // role is recorded/used by issues #3/#4; allow-list below applies to both.
+
+	// 3) Enforce the allow-list (applies to both roles). The getter orders rows
+	//    deterministically; we only test membership, so there is no map iteration
+	//    or order dependence in the consensus path.
+	allowed := false
+	res, err = app.Engine.Call(makeEngineCtx(ctx), app.DB, engine.DefaultNamespace, "maa_get_allowed_actions",
+		[]any{ruleID}, func(r *common.Row) error {
+			ns, _ := r.Values[0].(string)
+			act, _ := r.Values[1].(string)
+			if ns == d.namespace && act == d.action {
+				allowed = true
+			}
+			return nil
+		})
+	if err != nil {
+		return codeForEngineError(err), "", err
+	}
+	if res.Error != nil {
+		return types.CodeUnknownError, "", res.Error
+	}
+	if !allowed {
+		return types.CodeInvalidSender, "", fmt.Errorf(
+			"action %s.%s is not in the allow-list for MAA 0x%x", d.namespace, d.action, d.maaAddress)
+	}
+
+	// 4) Re-enter the engine AS the MAA. Clone the tx context and rewrite @caller
+	//    to the MAA's checksummed address (the same format a real signer's
+	//    identifier takes). This is a TOP-LEVEL call, so the SYSTEM gate stays
+	//    active and SYSTEM-only ops remain unreachable.
+	childTx := *ctx
+	childTx.Caller = ethcommon.BytesToAddress(d.maaAddress).Hex()
+	childEngineCtx := &common.EngineContext{TxContext: &childTx, OverrideAuthz: false}
+
+	var logs string
+	res, err = app.Engine.Call(childEngineCtx, app.DB, d.namespace, d.action, d.args, func(r *common.Row) error {
+		return nil // results are discarded, like executeActionRoute
+	})
+	if res != nil && len(res.Logs) > 0 {
+		logs = res.FormatLogs()
+	}
+	if err != nil {
+		return codeForEngineError(err), logs, err
+	}
+	if res.Error != nil {
+		return types.CodeUnknownError, logs, res.Error
+	}
+	return 0, logs, nil
+}
+
+// hexColumnToBytes reads a "0x"-prefixed hex string column from a getter row and
+// decodes it to raw bytes. The MAA getters project addresses/ids as
+// '0x' || encode(col,'hex'), so this is the inverse.
+func hexColumnToBytes(r *common.Row, idx int) ([]byte, error) {
+	if idx >= len(r.Values) {
+		return nil, fmt.Errorf("row has %d columns, want index %d", len(r.Values), idx)
+	}
+	s, ok := r.Values[idx].(string)
+	if !ok {
+		return nil, fmt.Errorf("column %d is %T, want a hex string", idx, r.Values[idx])
+	}
+	return hex.DecodeString(strings.TrimPrefix(s, "0x"))
+}

--- a/node/txapp/maa_route_test.go
+++ b/node/txapp/maa_route_test.go
@@ -1,0 +1,228 @@
+package txapp
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufnetwork/kwil-db/common"
+	"github.com/trufnetwork/kwil-db/core/types"
+	"github.com/trufnetwork/kwil-db/node/types/sql"
+)
+
+// These tests exercise the consensus-critical decisions of maaExecRoute in
+// isolation, against a fake engine: who may act as a MAA (role resolution by
+// RAW BYTES, since identifiers are checksummed but the rule store emits
+// lowercase hex), what they may run (allow-list), and that the inner call is
+// re-entered with @caller rewritten to the MAA. A real-engine end-to-end test
+// (create_rule -> join -> maa_exec an order-book action) belongs in the node
+// integration suite; here we pin the branch logic deterministically.
+
+var (
+	maaRestricted   = bytes.Repeat([]byte{0x11}, 20)
+	maaUnrestricted = bytes.Repeat([]byte{0x22}, 20)
+	maaAddr20       = bytes.Repeat([]byte{0x33}, 20)
+	maaRuleID32     = bytes.Repeat([]byte{0x55}, 32)
+	maaStranger     = bytes.Repeat([]byte{0x44}, 20)
+)
+
+func hexAddr0x(b []byte) string { return "0x" + hex.EncodeToString(b) }
+
+// fakeMAAEngine answers the two getter calls the route makes and captures the
+// inner action call so the test can assert it ran as the MAA.
+type fakeMAAEngine struct {
+	// instance config; if instanceKnown is false, maa_get_instance returns no rows.
+	instanceKnown bool
+	ruleID        []byte
+	restricted    []byte
+	unrestricted  []byte
+	// allow-list rows the rule exposes, as {namespace, action}.
+	allow [][2]string
+
+	// captured inner call
+	innerCalled    bool
+	innerCaller    string
+	innerNamespace string
+	innerAction    string
+	innerArgs      []any
+}
+
+func (f *fakeMAAEngine) Call(ctx *common.EngineContext, db sql.DB, namespace, action string, args []any, resultFn func(*common.Row) error) (*common.CallResult, error) {
+	switch action {
+	case "maa_get_instance":
+		if f.instanceKnown {
+			row := &common.Row{Values: []any{
+				hexAddr0x(maaAddr20),      // 0 maa_address
+				hexAddr0x(f.ruleID),       // 1 rule_id
+				hexAddr0x(f.restricted),   // 2 restricted_addr
+				hexAddr0x(f.unrestricted), // 3 unrestricted_addr
+				int64(100),                // 4 created_at
+			}}
+			if err := resultFn(row); err != nil {
+				return nil, err
+			}
+		}
+		return &common.CallResult{}, nil
+	case "maa_get_allowed_actions":
+		for _, a := range f.allow {
+			row := &common.Row{Values: []any{a[0], a[1], nil}}
+			if err := resultFn(row); err != nil {
+				return nil, err
+			}
+		}
+		return &common.CallResult{}, nil
+	default:
+		// the inner action, re-entered as the MAA
+		f.innerCalled = true
+		f.innerCaller = ctx.TxContext.Caller
+		f.innerNamespace = namespace
+		f.innerAction = action
+		f.innerArgs = args
+		return &common.CallResult{}, nil
+	}
+}
+
+func (f *fakeMAAEngine) CallWithoutEngineCtx(ctx context.Context, db sql.DB, namespace, action string, args []any, resultFn func(*common.Row) error) (*common.CallResult, error) {
+	return &common.CallResult{}, nil
+}
+func (f *fakeMAAEngine) Execute(ctx *common.EngineContext, db sql.DB, statement string, params map[string]any, fn func(*common.Row) error) error {
+	return nil
+}
+func (f *fakeMAAEngine) ExecuteWithoutEngineCtx(ctx context.Context, db sql.DB, statement string, params map[string]any, fn func(*common.Row) error) error {
+	return nil
+}
+
+// runMAAExec builds the payload, decodes it via PreTx, and runs InTx against the
+// fake engine. signer is the raw 20-byte address of the outer tx signer.
+func runMAAExec(t *testing.T, eng *fakeMAAEngine, signer []byte, namespace, action string, args ...any) (types.TxCode, error) {
+	t.Helper()
+
+	encArgs := make([]*types.EncodedValue, len(args))
+	for i, a := range args {
+		ev, err := types.EncodeValue(a)
+		require.NoError(t, err)
+		encArgs[i] = ev
+	}
+	payloadBytes, err := (types.MAAExec{
+		MAAAddress: maaAddr20,
+		Namespace:  namespace,
+		Action:     action,
+		Arguments:  encArgs,
+	}).MarshalBinary()
+	require.NoError(t, err)
+
+	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}
+	ctx := &common.TxContext{
+		Ctx:    context.Background(),
+		Caller: ethcommon.BytesToAddress(signer).Hex(), // checksummed, like a real signer
+	}
+	app := &common.App{Engine: eng}
+
+	route := &maaExecRoute{}
+	if code, err := route.PreTx(ctx, nil, tx); err != nil {
+		return code, err
+	}
+	code, _, err := route.InTx(ctx, app, tx)
+	return code, err
+}
+
+func newKnownEngine() *fakeMAAEngine {
+	return &fakeMAAEngine{
+		instanceKnown: true,
+		ruleID:        maaRuleID32,
+		restricted:    maaRestricted,
+		unrestricted:  maaUnrestricted,
+		allow:         [][2]string{{"main", "ob_place_order"}},
+	}
+}
+
+func TestMAAExecRoute_RestrictedRunsAllowlistedAction(t *testing.T) {
+	eng := newKnownEngine()
+	code, err := runMAAExec(t, eng, maaRestricted, "main", "ob_place_order", "0xabc")
+	require.NoError(t, err)
+	require.Equal(t, types.CodeOk, code)
+
+	require.True(t, eng.innerCalled, "inner action must run")
+	// @caller must be rewritten to the MAA (checksummed form of the 20-byte addr).
+	assert.Equal(t, ethcommon.BytesToAddress(maaAddr20).Hex(), eng.innerCaller)
+	// rewritten caller must decode back to the MAA's bytes.
+	assert.True(t, bytes.Equal(ethcommon.HexToAddress(eng.innerCaller).Bytes(), maaAddr20))
+	assert.Equal(t, "main", eng.innerNamespace)
+	assert.Equal(t, "ob_place_order", eng.innerAction)
+	require.Len(t, eng.innerArgs, 1)
+	// The engine decodes a text arg to *string (nullable-scalar convention); the
+	// route passes it through unchanged.
+	gotArg, ok := eng.innerArgs[0].(*string)
+	require.Truef(t, ok, "arg should decode to *string, got %T", eng.innerArgs[0])
+	assert.Equal(t, "0xabc", *gotArg)
+}
+
+func TestMAAExecRoute_UnrestrictedOwnerAlsoLimitedToAllowlist(t *testing.T) {
+	// The owner (unrestricted) may act as the MAA for allow-listed actions too.
+	eng := newKnownEngine()
+	code, err := runMAAExec(t, eng, maaUnrestricted, "main", "ob_place_order")
+	require.NoError(t, err)
+	require.Equal(t, types.CodeOk, code)
+	require.True(t, eng.innerCalled)
+	assert.Equal(t, ethcommon.BytesToAddress(maaAddr20).Hex(), eng.innerCaller)
+}
+
+func TestMAAExecRoute_DefaultsEmptyNamespaceToMain(t *testing.T) {
+	eng := newKnownEngine()
+	// Empty payload namespace must normalize to "main" for both the allow-list
+	// check and the inner call.
+	code, err := runMAAExec(t, eng, maaRestricted, "", "ob_place_order")
+	require.NoError(t, err)
+	require.Equal(t, types.CodeOk, code)
+	require.True(t, eng.innerCalled)
+	assert.Equal(t, "main", eng.innerNamespace)
+}
+
+func TestMAAExecRoute_UnknownMAARejected(t *testing.T) {
+	eng := newKnownEngine()
+	eng.instanceKnown = false // maa_get_instance returns no rows
+	code, err := runMAAExec(t, eng, maaRestricted, "main", "ob_place_order")
+	require.Error(t, err)
+	assert.Equal(t, types.CodeInvalidSender, code)
+	assert.False(t, eng.innerCalled, "inner action must NOT run for an unknown MAA")
+}
+
+func TestMAAExecRoute_UnauthorizedSignerRejected(t *testing.T) {
+	eng := newKnownEngine()
+	code, err := runMAAExec(t, eng, maaStranger, "main", "ob_place_order")
+	require.Error(t, err)
+	assert.Equal(t, types.CodeInvalidSender, code)
+	assert.False(t, eng.innerCalled, "a non-restricted, non-unrestricted signer must be rejected")
+}
+
+func TestMAAExecRoute_NonAllowlistedActionRejected(t *testing.T) {
+	eng := newKnownEngine()
+	// erc20.transfer is the canonical exit primitive: it is NOT allow-listed, so
+	// even the restricted agent cannot reach it through this route.
+	code, err := runMAAExec(t, eng, maaRestricted, "main", "transfer")
+	require.Error(t, err)
+	assert.Equal(t, types.CodeInvalidSender, code)
+	assert.False(t, eng.innerCalled, "a non-allow-listed action must NOT run")
+}
+
+func TestMAAExecRoute_BadAddressLengthRejectedInPreTx(t *testing.T) {
+	// A payload whose maa_address is not 20 bytes must be rejected at decode time.
+	payloadBytes, err := (types.MAAExec{
+		MAAAddress: bytes.Repeat([]byte{0x33}, 19),
+		Namespace:  "main",
+		Action:     "ob_place_order",
+	}).MarshalBinary()
+	require.NoError(t, err)
+	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}
+	ctx := &common.TxContext{Ctx: context.Background(), Caller: ethcommon.BytesToAddress(maaRestricted).Hex()}
+
+	route := &maaExecRoute{}
+	code, err := route.PreTx(ctx, nil, tx)
+	require.Error(t, err)
+	assert.Equal(t, types.CodeEncodingError, code)
+}

--- a/node/txapp/routes.go
+++ b/node/txapp/routes.go
@@ -34,6 +34,7 @@ func init() {
 		RegisterRoute(types.PayloadTypeValidatorVoteBodies, NewRoute(&validatorVoteBodiesRoute{})),
 		RegisterRoute(types.PayloadTypeCreateResolution, NewRoute(&createResolutionRoute{})),
 		RegisterRoute(types.PayloadTypeApproveResolution, NewRoute(&approveResolutionRoute{})),
+		RegisterRoute(types.PayloadTypeMAAExec, NewRoute(&maaExecRoute{})),
 	)
 	if err != nil {
 		panic(fmt.Sprintf("failed to register routes: %s", err))


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4036

Builds on the merged payload PR:

- https://github.com/trufnetwork/kwil-db/pull/1705

Adds `maaExecRoute`, which lets an authorized signer run a single allow-listed action **as** a Modular Agent Address (MAA), with `@caller` rewritten to the MAA for the inner call. This is the mechanism that lets an agent key operate its wallet within limits.

## Behavior
- The MAA must be a known, joined instance (created by `maa_join`); an unknown address is rejected.
- The outer signer must be the rule's restricted key (the agent) **or** the instance's unrestricted key (the owner). The decision is by **raw-byte** address comparison, because engine identifiers are EIP-55 checksummed while the rule store emits lowercase hex — a string compare would be a consensus bug.
- The inner call is **top-level**, so SYSTEM-only ops (mint / issue / lock_admin / unlock) stay blocked even though `@caller` is now the MAA.
- Gas and nonce are paid by the outer signer; the MAA never pays gas.

## Consensus-breaking
This registers the active route for the `maa_exec` payload (the payload type itself merged in #1705). Network-wide activation is by binary deployment for now.

## Tests
Fake-engine unit tests cover every branch: restricted and unrestricted happy paths (asserting `@caller` is rewritten to the MAA and arguments pass through), empty-namespace defaulting to `main`, and the three rejections — unknown MAA, unauthorized signer, and non-allow-listed action (each asserting the inner action does not run).
