### PR TITLE
chore: keep a restricted agent from draining the agent wallet

### DIFF
--- a/common/common.go
+++ b/common/common.go
@@ -174,6 +174,18 @@ type TxContext struct {
 	Caller string
 	// Authenticator is the authenticator used to sign the transaction.
 	Authenticator string
+	// MAARestricted marks an execution that runs AS a Modular Agent Address
+	// (MAA) on behalf of the rule's RESTRICTED key (the agent). It is set
+	// exclusively by the maa_exec transaction route (node/txapp) when it
+	// rewrites Caller to the MAA address, and — because the engine threads
+	// TxContext by pointer through every nested action and precompile call —
+	// it is visible to token boundaries at ANY call depth, letting them
+	// reject operations that move the caller's funds out (e.g. erc20
+	// transfer/bridge). Kuneiform cannot assign system variables, so SQL code
+	// can never set or clear it; it is Go-only. Consensus-relevant: it
+	// changes execution outcomes, so its activation rides the maa_exec route
+	// rollout.
+	MAARestricted bool
 	// values is a map of values that can be set and retrieved by extensions.
 	values map[string]any
 }

--- a/node/exts/erc20-bridge/erc20/cross_node_determinism_test.go
+++ b/node/exts/erc20-bridge/erc20/cross_node_determinism_test.go
@@ -61,9 +61,15 @@ func TestCrossNodeMerkleConsistency(t *testing.T) {
 	var blockHash [32]byte
 	copy(blockHash[:], crypto.Keccak256([]byte("block-100")))
 
-	// Node 1: Process withdrawals in original order
+	// Node 1: Process withdrawals in original order.
+	// Each node runs in its own function literal so its deferred tx rollback
+	// fires at the END of the node's block, not at the end of the test. db1 and
+	// db2 point at the same physical database, so if node 1's tx stayed open
+	// (a function-scoped defer) its genesis DDL would hold catalog locks that
+	// deadlock node 2's genesis. Serializing the two txns keeps the "two nodes"
+	// intent while letting each release before the next begins.
 	var node1Root []byte
-	{
+	func() {
 		tx1, err := db1.BeginTx(ctx)
 		require.NoError(t, err)
 		defer tx1.Rollback(ctx)
@@ -127,11 +133,12 @@ func TestCrossNodeMerkleConsistency(t *testing.T) {
 		_, _, root, _, err := genMerkleTreeForEpoch(ctx, app1, epochID1, escrowAddr, blockHash)
 		require.NoError(t, err)
 		node1Root = root
-	}
+	}()
 
-	// Node 2: Process same withdrawals in REVERSE order
+	// Node 2: Process same withdrawals in REVERSE order (see node 1 on why this
+	// is a function literal — its tx must roll back before node 1's would).
 	var node2Root []byte
-	{
+	func() {
 		tx2, err := db2.BeginTx(ctx)
 		require.NoError(t, err)
 		defer tx2.Rollback(ctx)
@@ -196,7 +203,7 @@ func TestCrossNodeMerkleConsistency(t *testing.T) {
 		_, _, root, _, err := genMerkleTreeForEpoch(ctx, app2, epochID2, escrowAddr, blockHash)
 		require.NoError(t, err)
 		node2Root = root
-	}
+	}()
 
 	// CRITICAL VERIFICATION: Both nodes computed IDENTICAL Merkle root
 	require.Equal(t, node1Root, node2Root,
@@ -345,8 +352,12 @@ func TestRewardAggregationDeterminism(t *testing.T) {
 			})
 			require.NoError(t, err)
 
-			// Set initial balance for testing (1 billion tokens)
-			testBalance, err := erc20ValueFromBigInt(big.NewInt(1000000000))
+			// Set the network balance high enough to cover every case, including
+			// the near-uint256 "Large numbers" amounts (issueReward debits this
+			// balance, which has a CHECK(balance >= 0)). 1e30 > the largest sum.
+			bigBalance, ok := new(big.Int).SetString("1000000000000000000000000000000", 10)
+			require.True(t, ok)
+			testBalance, err := erc20ValueFromBigInt(bigBalance)
 			require.NoError(t, err)
 			err = app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
 				{kwil_erc20_meta}UPDATE reward_instances

--- a/node/exts/erc20-bridge/erc20/determinism_test.go
+++ b/node/exts/erc20-bridge/erc20/determinism_test.go
@@ -187,6 +187,21 @@ func TestMerkleTreeDeterminismWithShuffledRewards(t *testing.T) {
 		err = createEpoch(ctx, app, pending, instanceID)
 		require.NoError(t, err)
 
+		// Fund the network balance before issuing: issueReward debits
+		// reward_instances.balance, which has a CHECK(balance >= 0). 1e9 covers
+		// the test withdrawals (which sum to well under that).
+		fundBalance, err := erc20ValueFromBigInt(big.NewInt(1000000000))
+		require.NoError(t, err)
+		err = app.Engine.ExecuteWithoutEngineCtx(ctx, app.DB, `
+			{kwil_erc20_meta}UPDATE reward_instances
+			SET balance = $balance
+			WHERE id = $instance_id
+		`, map[string]any{
+			"instance_id": instanceID,
+			"balance":     fundBalance,
+		}, nil)
+		require.NoError(t, err)
+
 		// Shuffle withdrawal order randomly
 		shuffled := make([]withdrawal, len(testWithdrawals))
 		copy(shuffled, testWithdrawals)

--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -835,6 +835,12 @@ func init() {
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.SYSTEM},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
+							// SYSTEM blocks only a bare top-level call; wrapped in an
+							// action body this IS reachable, so gate restricted MAAs.
+							if err := maaRestrictedGuard(ctx, "issue"); err != nil {
+								return err
+							}
+
 							id := inputs[0].(*types.UUID)
 							user := inputs[1].(string)
 							amount := inputs[2].(*types.Decimal)
@@ -854,6 +860,12 @@ func init() {
 						// There is no security risk if somebody calls this directly
 						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
+							// MAA token boundary: a restricted agent must never move
+							// the MAA's funds out, at any call depth.
+							if err := maaRestrictedGuard(ctx, "transfer"); err != nil {
+								return err
+							}
+
 							id := inputs[0].(*types.UUID)
 							to := inputs[1].(string)
 							amount := inputs[2].(*types.Decimal)
@@ -926,6 +938,13 @@ func init() {
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.SYSTEM},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
+							// SYSTEM blocks only a bare top-level call; wrapped in an
+							// action body this IS reachable, and it debits an ARBITRARY
+							// user — gate restricted MAAs (plain lock stays available).
+							if err := maaRestrictedGuard(ctx, "lock_admin"); err != nil {
+								return err
+							}
+
 							id := inputs[0].(*types.UUID)
 							user := inputs[1].(string)
 							amount := inputs[2].(*types.Decimal)
@@ -1041,6 +1060,13 @@ func init() {
 						},
 						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
+							// MAA token boundary: bridge is the L1 off-ramp, and an
+							// omitted amount means the WHOLE caller balance — a
+							// restricted agent must never reach it, at any depth.
+							if err := maaRestrictedGuard(ctx, "bridge"); err != nil {
+								return err
+							}
+
 							id := inputs[0].(*types.UUID)
 							recipient := inputs[1].(string)
 							if recipient == "" {
@@ -1981,6 +2007,24 @@ func callDisable(ctx *common.EngineContext, app *common.App, id *types.UUID) err
 }
 
 // lockTokens locks tokens from a user's balance and gives them to the network.
+// maaRestrictedGuard rejects erc20 operations that are forbidden while the
+// execution runs AS a Modular Agent Address under its RESTRICTED key (the
+// agent), marked by TxContext.MAARestricted (set only by the maa_exec route
+// in node/txapp). This is the token-boundary half of the MAA safety promise:
+// the agent can operate the wallet — lock collateral, trade, receive unlocks —
+// but can never move funds out of it, at ANY call depth, no matter which
+// action wraps the call. Gated: transfer and bridge (they debit the caller,
+// i.e. the MAA, toward a parameter-controlled recipient / off to L1), plus
+// the privileged issue and lock_admin (no agent flow needs them). NOT gated:
+// lock (escrow into the network bucket — order placement needs it) and unlock
+// (the network crediting a user — matching, refunds and settlement need it).
+func maaRestrictedGuard(ctx *common.EngineContext, op string) error {
+	if ctx.TxContext != nil && ctx.TxContext.MAARestricted {
+		return fmt.Errorf("%s is not allowed under a restricted agent (MAA) execution: the restricted key cannot move funds out of the agent wallet", op)
+	}
+	return nil
+}
+
 func (e *extensionInfo) lockTokens(ctx context.Context, app *common.App, id *types.UUID, from string, amount *types.Decimal) error {
 	fromAddr, err := ethAddressFromHex(from)
 	if err != nil {

--- a/node/exts/erc20-bridge/erc20/meta_extension_maa_guard_test.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension_maa_guard_test.go
@@ -1,0 +1,219 @@
+//go:build kwiltest
+
+package erc20
+
+import (
+	"context"
+	"testing"
+
+	ethcommon "github.com/ethereum/go-ethereum/common"
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufnetwork/kwil-db/common"
+	"github.com/trufnetwork/kwil-db/core/types"
+	"github.com/trufnetwork/kwil-db/extensions/precompiles"
+	"github.com/trufnetwork/kwil-db/node/exts/evm-sync/chains"
+	orderedsync "github.com/trufnetwork/kwil-db/node/exts/ordered-sync"
+)
+
+// These tests pin the token-boundary half of the MAA safety promise: when an
+// execution runs AS a Modular Agent Address under its RESTRICTED key
+// (TxContext.MAARestricted, set only by the maa_exec route), the exit
+// primitives — transfer, bridge — and the privileged ops an action body can
+// wrap — issue, lock_admin — must be rejected by the method handlers
+// themselves, regardless of call depth or which action wraps them. lock and
+// unlock must stay available, or allow-listed trading (collateral escrow,
+// matching payouts, refunds) breaks. The guard must fire before any state is
+// read or written, so the rejection cases below run with no usable App at all.
+
+const maaGuardErr = "restricted agent (MAA) execution"
+
+// maaMetaMethod instantiates the registered kwil_erc20_meta precompile and
+// returns the named method, so tests exercise the REAL registered handlers.
+func maaMetaMethod(t *testing.T, name string) precompiles.Method {
+	t.Helper()
+	init, ok := precompiles.RegisteredPrecompiles()[RewardMetaExtensionName]
+	require.True(t, ok, "meta extension must be registered")
+	p, err := init(context.Background(), nil, nil, RewardMetaExtensionName, nil)
+	require.NoError(t, err)
+	for _, m := range p.Methods {
+		if m.Name == name {
+			return m
+		}
+	}
+	t.Fatalf("method %q not found on %s", name, RewardMetaExtensionName)
+	return precompiles.Method{}
+}
+
+func maaEngineCtx(restricted bool, caller string) *common.EngineContext {
+	return &common.EngineContext{
+		TxContext: &common.TxContext{
+			Ctx:           context.Background(),
+			TxID:          "1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef",
+			Caller:        caller,
+			MAARestricted: restricted,
+			BlockContext:  &common.BlockContext{Height: 500, Timestamp: 1600000500},
+		},
+	}
+}
+
+func maaNoResult([]any) error { return nil }
+
+func maaDec(t *testing.T, s string) *types.Decimal {
+	t.Helper()
+	return types.MustParseDecimalExplicit(s, 78, 0)
+}
+
+// TestMAARestrictedGuard_BlocksExitPrimitives: under a restricted MAA
+// execution, the four gated methods must be rejected by the guard BEFORE any
+// instance/balance state is touched (app is nil — reaching state would panic,
+// proving nothing ran past the guard).
+func TestMAARestrictedGuard_BlocksExitPrimitives(t *testing.T) {
+	id := uuidForChainAndEscrow("1", "0x00000000000000000000000000000000000000cc")
+	maa := ethcommon.HexToAddress("0x3333333333333333333333333333333333333333").Hex()
+	other := ethcommon.HexToAddress("0x4444444444444444444444444444444444444444").Hex()
+	ctx := maaEngineCtx(true, maa)
+
+	for _, tc := range []struct {
+		method string
+		inputs []any
+	}{
+		{"transfer", []any{&id, other, maaDec(t, "10")}},
+		{"bridge", []any{&id, other, maaDec(t, "10")}},
+		// bridge with an omitted amount means "withdraw the WHOLE caller
+		// balance" — the guard must fire before that branch is reachable.
+		{"bridge", []any{&id, other, nil}},
+		{"issue", []any{&id, other, maaDec(t, "10")}},
+		{"lock_admin", []any{&id, other, maaDec(t, "10")}},
+	} {
+		err := maaMetaMethod(t, tc.method).Handler(ctx, nil, tc.inputs, maaNoResult)
+		require.Error(t, err, "%s must be rejected under restricted MAA execution", tc.method)
+		require.ErrorContains(t, err, maaGuardErr, "%s must fail with the guard error", tc.method)
+	}
+}
+
+// TestMAARestrictedGuard_LockAndUnlockNotGated: lock (collateral escrow) and
+// unlock (network paying a user) must NOT carry the guard — trading depends on
+// them. With a negative amount the handlers reach their own validation, which
+// sits past the point where a guard would fire, and do so without touching any
+// state (app is nil).
+func TestMAARestrictedGuard_LockAndUnlockNotGated(t *testing.T) {
+	id := uuidForChainAndEscrow("1", "0x00000000000000000000000000000000000000cc")
+	maa := ethcommon.HexToAddress("0x3333333333333333333333333333333333333333").Hex()
+	ctx := maaEngineCtx(true, maa)
+
+	err := maaMetaMethod(t, "lock").Handler(ctx, nil, []any{&id, maaDec(t, "-1")}, maaNoResult)
+	require.ErrorContains(t, err, "amount cannot be negative", "lock must run its own validation, not the guard")
+	require.NotContains(t, err.Error(), maaGuardErr)
+
+	err = maaMetaMethod(t, "unlock").Handler(ctx, nil, []any{&id, maa, maaDec(t, "-1")}, maaNoResult)
+	require.ErrorContains(t, err, "amount cannot be negative", "unlock must run its own validation, not the guard")
+	require.NotContains(t, err.Error(), maaGuardErr)
+}
+
+// TestMAARestrictedGuard_InactiveWhenUnflagged: without the flag (a normal
+// signer, or the unrestricted owner acting as the MAA), the gated handlers
+// proceed past the guard into their own logic.
+func TestMAARestrictedGuard_InactiveWhenUnflagged(t *testing.T) {
+	id := uuidForChainAndEscrow("1", "0x00000000000000000000000000000000000000cc")
+	// An invalid caller makes transfer fail at its own address parsing —
+	// which sits past the guard — without touching any state.
+	ctx := maaEngineCtx(false, "not-an-address")
+
+	err := maaMetaMethod(t, "transfer").Handler(ctx, nil, []any{&id, "also-not-an-address", maaDec(t, "10")}, maaNoResult)
+	require.Error(t, err)
+	require.NotContains(t, err.Error(), maaGuardErr, "unflagged execution must not trip the guard")
+}
+
+// TestMAARestrictedBoundary_TradingSurvivesExitsBlocked is the DB-backed
+// matrix: with a real instance and balances, a restricted MAA execution can
+// still lock collateral and have the network pay a counterparty (the
+// matching-engine shape), while transfer/bridge are rejected and move nothing;
+// the same transfer succeeds once unflagged (the owner path).
+func TestMAARestrictedBoundary_TradingSurvivesExitsBlocked(t *testing.T) {
+	ctx := context.Background()
+	db, err := newTestDB()
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx, err := db.BeginTx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx)
+
+	orderedsync.ForTestingReset()
+	defer orderedsync.ForTestingReset()
+	ForTestingResetSingleton()
+	defer ForTestingResetSingleton()
+
+	app := setup(t, tx)
+
+	// Instance + epoch, synced and active in the singleton (withdrawal-test idiom).
+	id := newUUID()
+	chainInfo, ok := chains.GetChainInfoByID("1")
+	require.True(t, ok, "chain 1 should be registered")
+	upd := &userProvidedData{
+		ID:                 id,
+		ChainInfo:          &chainInfo,
+		EscrowAddress:      ethcommon.HexToAddress("0x00000000000000000000000000000000000000cc"),
+		DistributionPeriod: 3600,
+	}
+	require.NoError(t, createNewRewardInstance(ctx, app, upd))
+	require.NoError(t, setRewardSynced(ctx, app, id, 1, &syncedRewardData{
+		Erc20Address:  ethcommon.HexToAddress("0x00000000000000000000000000000000000000bb"),
+		Erc20Decimals: 18,
+	}))
+	epochID := newUUID()
+	pending := &PendingEpoch{ID: epochID, StartHeight: 10, StartTime: 100}
+	require.NoError(t, createEpoch(ctx, app, pending, id))
+	getSingleton().instances.Set(*id, &rewardExtensionInfo{
+		userProvidedData: *upd,
+		currentEpoch:     pending,
+		synced:           true,
+		active:           true,
+		ownedBalance:     maaDec(t, "0"),
+	})
+
+	maa := ethcommon.HexToAddress("0x3333333333333333333333333333333333333333")
+	counterparty := ethcommon.HexToAddress("0x4444444444444444444444444444444444444444")
+	require.NoError(t, creditBalance(ctx, app, id, maa, maaDec(t, "100")))
+
+	restrictedCtx := maaEngineCtx(true, maa.Hex())
+	unflaggedCtx := maaEngineCtx(false, maa.Hex())
+
+	balance := func(addr ethcommon.Address) string {
+		bal, err := balanceOf(ctx, app, id, addr)
+		require.NoError(t, err)
+		if bal == nil {
+			return "0"
+		}
+		return bal.String()
+	}
+
+	// 1) Collateral escrow (the place_buy_order shape) must keep working.
+	require.NoError(t, maaMetaMethod(t, "lock").Handler(restrictedCtx, app, []any{id, maaDec(t, "10")}, maaNoResult))
+	require.Equal(t, "90", balance(maa))
+
+	// 2) The network paying a counterparty (the matching/refund shape) must
+	//    keep working even while the execution is flagged restricted.
+	require.NoError(t, maaMetaMethod(t, "unlock").Handler(restrictedCtx, app, []any{id, counterparty.Hex(), maaDec(t, "4")}, maaNoResult))
+	require.Equal(t, "4", balance(counterparty))
+
+	// 3) transfer is rejected and moves nothing.
+	err = maaMetaMethod(t, "transfer").Handler(restrictedCtx, app, []any{id, counterparty.Hex(), maaDec(t, "10")}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr)
+	require.Equal(t, "90", balance(maa))
+	require.Equal(t, "4", balance(counterparty))
+
+	// 4) bridge (the L1 off-ramp) is rejected and moves nothing — including
+	//    the omitted-amount whole-balance form.
+	err = maaMetaMethod(t, "bridge").Handler(restrictedCtx, app, []any{id, counterparty.Hex(), nil}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr)
+	require.Equal(t, "90", balance(maa))
+
+	// 5) Control: the SAME transfer succeeds once unflagged — the boundary
+	//    keys on the flag, not on the caller being an MAA, so the owner's
+	//    withdrawal path stays open.
+	require.NoError(t, maaMetaMethod(t, "transfer").Handler(unflaggedCtx, app, []any{id, counterparty.Hex(), maaDec(t, "10")}, maaNoResult))
+	require.Equal(t, "80", balance(maa))
+	require.Equal(t, "14", balance(counterparty))
+}

--- a/node/exts/erc20-bridge/erc20/meta_sql_test.go
+++ b/node/exts/erc20-bridge/erc20/meta_sql_test.go
@@ -43,6 +43,16 @@ func newTestDB() (*pg.DB, error) {
 const defaultCaller = "owner"
 
 func setup(t *testing.T, tx sql.DB) *common.App {
+	// Each call builds a fresh interpreter, which fires the engine-ready hooks —
+	// including ordered-sync's, which guards against double-init with a
+	// process-global flag. Tests that call setup() more than once (subtests or
+	// loops, each on its own rolled-back tx) would otherwise trip "already
+	// initialized" on the second call, since the global outlives the tx. Reset
+	// the package globals here so every setup() starts from a clean slate,
+	// independent of how many times a single test calls it.
+	orderedsync.ForTestingReset()
+	ForTestingResetSingleton()
+
 	interp, err := interpreter.NewInterpreter(context.Background(), tx, &common.Service{}, nil, nil, nil)
 	require.NoError(t, err)
 

--- a/node/txapp/maa_route.go
+++ b/node/txapp/maa_route.go
@@ -20,20 +20,25 @@ import (
 // rewritten to the MAA for the inner call.
 //
 // Security model ("operate the wallet within limits"):
-//   - The MAA must be a known, joined instance (created by maa_join, issue #1).
+//   - The MAA must be a known, joined instance (created by maa_join).
 //   - The OUTER signer must be the rule's restricted address (the agent) OR the
 //     instance's unrestricted address (the owner); otherwise the signer has no
 //     authority over this MAA. The signer is read WHILE @caller is still the
 //     signer's own identity, before any rewrite.
 //   - The inner (namespace, action) must be in the rule's allow-list. This holds
-//     for BOTH roles (plan lifecycle 4a: the unrestricted owner acts "as the MAA
-//     [for] any allow-listed action"). Raw value-moving primitives are never
-//     allow-listed, so neither role can move funds out via this route. The
-//     owner's withdraw-with-commission is a separate action (issue #4); the
-//     restricted role's hard no-exit guarantee at any depth is the token
-//     boundary (issue #3).
-//   - The inner call is TOP-LEVEL, so SYSTEM-only ops (mint/issue/lock_admin/
-//     unlock) stay blocked even though @caller is now the MAA.
+//     for BOTH roles: the unrestricted owner, too, acts as the MAA only through
+//     allow-listed actions. Raw value-moving primitives are never allow-listed,
+//     so neither role can move funds out via this route; the owner withdraws
+//     through a dedicated withdrawal action instead. The restricted role's hard
+//     no-exit guarantee at any depth is the erc20 token boundary (see below).
+//   - When the signer is the RESTRICTED key, the child context carries
+//     TxContext.MAARestricted, which the erc20 token boundary checks at ANY
+//     call depth to reject out-movement of the MAA's funds (transfer/bridge)
+//     and privileged token ops (issue/lock_admin). The allow-list alone
+//     cannot give that guarantee: it sees only the top-level action name.
+//     Nor can the top-level call: it blocks only a BARE SYSTEM target —
+//     a SYSTEM precompile wrapped inside an action body runs in a subscope
+//     and is not stopped by the SYSTEM gate.
 //
 // Gas/nonce are paid by the OUTER signer; the MAA never pays gas. The MAA's
 // identity is assumed only for the duration of the inner action.
@@ -56,10 +61,10 @@ func (d *maaExecRoute) Price(ctx context.Context, app *common.App, tx *types.Tra
 }
 
 func (d *maaExecRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *types.Transaction) (types.TxCode, error) {
-	// ACTIVATION CHOKEPOINT (issue #7): once fork-height infrastructure lands,
-	// reject MAAExec before its activation height here, mirroring the
-	// MigrationStatus guards in transferRoute.PreTx. Until then availability is
-	// "this binary is deployed", which the coordinated rollout (#7) flag-days.
+	// ACTIVATION CHOKEPOINT: once fork-height infrastructure lands, reject
+	// MAAExec before its activation height here, mirroring the
+	// MigrationStatus guards in transferRoute.PreTx. Until then availability
+	// is "this binary is deployed", which the coordinated rollout flag-days.
 
 	payload := &types.MAAExec{}
 	if err := payload.UnmarshalBinary(tx.Body.Payload); err != nil {
@@ -101,7 +106,7 @@ func (d *maaExecRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Tr
 	signer := ethcommon.HexToAddress(ctx.Caller).Bytes()
 
 	// 1) Resolve the MAA instance and its rule's restricted/unrestricted keys.
-	//    maa_get_instance JOINs the instance to its rule (issue #1 getter); a
+	//    maa_get_instance JOINs the instance to its rule (rule-store getter); a
 	//    missing row means this address was never joined -> not a known MAA.
 	var ruleID, restricted, unrestricted []byte
 	found := false
@@ -142,7 +147,7 @@ func (d *maaExecRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Tr
 		return types.CodeInvalidSender, "", fmt.Errorf(
 			"signer 0x%x is neither the restricted nor the unrestricted key of MAA 0x%x", signer, d.maaAddress)
 	}
-	_ = role // role is recorded/used by issues #3/#4; allow-list below applies to both.
+	// The role decides the no-exit flag set on the child context in step 4.
 
 	// 3) Enforce the allow-list (applies to both roles). The getter orders rows
 	//    deterministically; we only test membership, so there is no map iteration
@@ -170,10 +175,17 @@ func (d *maaExecRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Tr
 
 	// 4) Re-enter the engine AS the MAA. Clone the tx context and rewrite @caller
 	//    to the MAA's checksummed address (the same format a real signer's
-	//    identifier takes). This is a TOP-LEVEL call, so the SYSTEM gate stays
-	//    active and SYSTEM-only ops remain unreachable.
+	//    identifier takes). The call is top-level, which rejects a bare SYSTEM
+	//    target — but SYSTEM precompiles wrapped inside an action body run in
+	//    subscopes and ARE reachable, so the restricted role's hard no-exit
+	//    guarantee is the MAARestricted flag, enforced at the erc20 token
+	//    boundary at any call depth. The flag is set ONLY on the child
+	//    context: the getters above ran under the outer signer's unflagged
+	//    context, and the unrestricted owner's executions stay unflagged so
+	//    the owner's withdrawal flow keeps working.
 	childTx := *ctx
 	childTx.Caller = ethcommon.BytesToAddress(d.maaAddress).Hex()
+	childTx.MAARestricted = role == "restricted"
 	childEngineCtx := &common.EngineContext{TxContext: &childTx, OverrideAuthz: false}
 
 	var logs string

--- a/node/txapp/maa_route_test.go
+++ b/node/txapp/maa_route_test.go
@@ -50,11 +50,19 @@ type fakeMAAEngine struct {
 	innerNamespace string
 	innerAction    string
 	innerArgs      []any
+	// innerRestricted is TxContext.MAARestricted as seen by the inner action —
+	// the no-exit flag the erc20 token boundary enforces.
+	innerRestricted bool
+	// getterRestricted records whether ANY of the route's own getter lookups
+	// (maa_get_instance / maa_get_allowed_actions) ran with MAARestricted set.
+	// They must not: they run under the outer signer's unflagged context.
+	getterRestricted bool
 }
 
 func (f *fakeMAAEngine) Call(ctx *common.EngineContext, db sql.DB, namespace, action string, args []any, resultFn func(*common.Row) error) (*common.CallResult, error) {
 	switch action {
 	case "maa_get_instance":
+		f.getterRestricted = f.getterRestricted || ctx.TxContext.MAARestricted
 		if f.instanceKnown {
 			row := &common.Row{Values: []any{
 				hexAddr0x(maaAddr20),      // 0 maa_address
@@ -69,6 +77,7 @@ func (f *fakeMAAEngine) Call(ctx *common.EngineContext, db sql.DB, namespace, ac
 		}
 		return &common.CallResult{}, nil
 	case "maa_get_allowed_actions":
+		f.getterRestricted = f.getterRestricted || ctx.TxContext.MAARestricted
 		for _, a := range f.allow {
 			row := &common.Row{Values: []any{a[0], a[1], nil}}
 			if err := resultFn(row); err != nil {
@@ -83,6 +92,7 @@ func (f *fakeMAAEngine) Call(ctx *common.EngineContext, db sql.DB, namespace, ac
 		f.innerNamespace = namespace
 		f.innerAction = action
 		f.innerArgs = args
+		f.innerRestricted = ctx.TxContext.MAARestricted
 		return &common.CallResult{}, nil
 	}
 }
@@ -160,6 +170,12 @@ func TestMAAExecRoute_RestrictedRunsAllowlistedAction(t *testing.T) {
 	gotArg, ok := eng.innerArgs[0].(*string)
 	require.Truef(t, ok, "arg should decode to *string, got %T", eng.innerArgs[0])
 	assert.Equal(t, "0xabc", *gotArg)
+
+	// The restricted signer's inner execution must carry the no-exit flag the
+	// token boundary enforces — and ONLY the inner execution; the route's own
+	// getter lookups run under the outer signer's unflagged ctx.
+	assert.True(t, eng.innerRestricted, "inner ctx must carry MAARestricted for the restricted signer")
+	assert.False(t, eng.getterRestricted, "the route's getter lookups must run unflagged")
 }
 
 func TestMAAExecRoute_UnrestrictedOwnerAlsoLimitedToAllowlist(t *testing.T) {
@@ -170,6 +186,9 @@ func TestMAAExecRoute_UnrestrictedOwnerAlsoLimitedToAllowlist(t *testing.T) {
 	require.Equal(t, types.CodeOk, code)
 	require.True(t, eng.innerCalled)
 	assert.Equal(t, ethcommon.BytesToAddress(maaAddr20).Hex(), eng.innerCaller)
+	// The owner's execution must stay unflagged: the owner's withdrawal flow
+	// moves funds out and must not trip the token boundary.
+	assert.False(t, eng.innerRestricted, "the unrestricted owner's inner ctx must NOT carry MAARestricted")
 }
 
 func TestMAAExecRoute_DefaultsEmptyNamespaceToMain(t *testing.T) {


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4037

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added restriction mechanism that blocks certain token operations (transfer, bridge, issue, lock_admin) when executed under a restricted Modular Agent Address context.

* **Bug Fixes**
  * Improved test reliability by fixing transaction handling and initialization state management in ERC20 tests.
  * Increased test balance values to ensure sufficient funds for withdrawal operations.

* **Tests**
  * Added comprehensive test coverage for the restricted agent execution guard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->