### PR TITLE
chore: let the owner always withdraw from its agent wallet

### DIFF
--- a/node/txapp/maa_route.go
+++ b/node/txapp/maa_route.go
@@ -28,9 +28,17 @@ import (
 //   - The inner (namespace, action) must be in the rule's allow-list. This holds
 //     for BOTH roles: the unrestricted owner, too, acts as the MAA only through
 //     allow-listed actions. Raw value-moving primitives are never allow-listed,
-//     so neither role can move funds out via this route; the owner withdraws
-//     through a dedicated withdrawal action instead. The restricted role's hard
-//     no-exit guarantee at any depth is the erc20 token boundary (see below).
+//     so neither role can move funds out via an allow-listed action; the
+//     restricted role's hard no-exit guarantee at any depth is the erc20 token
+//     boundary (see below).
+//   - EXCEPTION — the dedicated owner-exit (withdrawal) actions are role-gated
+//     INSTEAD of allow-list-gated: the UNRESTRICTED owner may always run them,
+//     whether or not a rule lists them (rules are immutable, so an
+//     allow-list-bound exit would permanently lock an owner out of their own
+//     funds the moment a rule forgot to include it — the owner's control of
+//     their funds must not depend on how well a rule was curated), and the
+//     RESTRICTED key may never run them, not even when a rule lists them
+//     (withdrawing is the owner's act).
 //   - When the signer is the RESTRICTED key, the child context carries
 //     TxContext.MAARestricted, which the erc20 token boundary checks at ANY
 //     call depth to reject out-movement of the MAA's funds (transfer/bridge)
@@ -149,28 +157,44 @@ func (d *maaExecRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Tr
 	}
 	// The role decides the no-exit flag set on the child context in step 4.
 
-	// 3) Enforce the allow-list (applies to both roles). The getter orders rows
-	//    deterministically; we only test membership, so there is no map iteration
-	//    or order dependence in the consensus path.
-	allowed := false
-	res, err = app.Engine.Call(makeEngineCtx(ctx), app.DB, engine.DefaultNamespace, "maa_get_allowed_actions",
-		[]any{ruleID}, func(r *common.Row) error {
-			ns, _ := r.Values[0].(string)
-			act, _ := r.Values[1].(string)
-			if ns == d.namespace && act == d.action {
-				allowed = true
-			}
-			return nil
-		})
-	if err != nil {
-		return codeForEngineError(err), "", err
-	}
-	if res.Error != nil {
-		return types.CodeUnknownError, "", res.Error
-	}
-	if !allowed {
-		return types.CodeInvalidSender, "", fmt.Errorf(
-			"action %s.%s is not in the allow-list for MAA 0x%x", d.namespace, d.action, d.maaAddress)
+	// 3) Gate the inner action. The dedicated owner-exit (withdrawal) actions are
+	//    role-gated INSTEAD of allow-list-gated; everything else must be in the
+	//    rule's allow-list, for both roles.
+	if d.isOwnerExitAction() {
+		// Rejecting the restricted key here is defense-in-depth — even reached
+		// through a wrapper action, its exit legs are stopped at the erc20 token
+		// boundary by MAARestricted — but failing fast, before re-entry, gives a
+		// clear error with zero side effects. The unrestricted owner proceeds to
+		// re-entry without an allow-list test: the owner can always exit.
+		if role == "restricted" {
+			return types.CodeInvalidSender, "", fmt.Errorf(
+				"action %s.%s withdraws the agent wallet's funds and is reserved for the unrestricted owner of MAA 0x%x",
+				d.namespace, d.action, d.maaAddress)
+		}
+	} else {
+		// Enforce the allow-list (applies to both roles). The getter orders rows
+		// deterministically; we only test membership, so there is no map iteration
+		// or order dependence in the consensus path.
+		allowed := false
+		res, err = app.Engine.Call(makeEngineCtx(ctx), app.DB, engine.DefaultNamespace, "maa_get_allowed_actions",
+			[]any{ruleID}, func(r *common.Row) error {
+				ns, _ := r.Values[0].(string)
+				act, _ := r.Values[1].(string)
+				if ns == d.namespace && act == d.action {
+					allowed = true
+				}
+				return nil
+			})
+		if err != nil {
+			return codeForEngineError(err), "", err
+		}
+		if res.Error != nil {
+			return types.CodeUnknownError, "", res.Error
+		}
+		if !allowed {
+			return types.CodeInvalidSender, "", fmt.Errorf(
+				"action %s.%s is not in the allow-list for MAA 0x%x", d.namespace, d.action, d.maaAddress)
+		}
 	}
 
 	// 4) Re-enter the engine AS the MAA. Clone the tx context and rewrite @caller
@@ -202,6 +226,23 @@ func (d *maaExecRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Tr
 		return types.CodeUnknownError, logs, res.Error
 	}
 	return 0, logs, nil
+}
+
+// isOwnerExitAction reports whether the requested inner action is one of the
+// dedicated owner-exit (withdrawal) actions in the engine's default namespace.
+// These move the agent wallet's funds out with the agreed commission and are
+// role-gated rather than allow-list-gated (see the type doc). The names are
+// normalized with the SAME strings.ToLower the engine applies when resolving a
+// Call, so any spelling that would execute a withdrawal action is classified as
+// one — an exact-case test here could be dodged by a case variant. The list
+// must stay in sync with the dedicated withdrawal actions the network's
+// migrations define.
+func (d *maaExecRoute) isOwnerExitAction() bool {
+	if strings.ToLower(d.namespace) != engine.DefaultNamespace {
+		return false
+	}
+	action := strings.ToLower(d.action)
+	return action == "maa_withdraw" || action == "maa_bridge_out"
 }
 
 // hexColumnToBytes reads a "0x"-prefixed hex string column from a getter row and

--- a/node/txapp/maa_route_test.go
+++ b/node/txapp/maa_route_test.go
@@ -18,10 +18,12 @@ import (
 // These tests exercise the consensus-critical decisions of maaExecRoute in
 // isolation, against a fake engine: who may act as a MAA (role resolution by
 // RAW BYTES, since identifiers are checksummed but the rule store emits
-// lowercase hex), what they may run (allow-list), and that the inner call is
-// re-entered with @caller rewritten to the MAA. A real-engine end-to-end test
-// (create_rule -> join -> maa_exec an order-book action) belongs in the node
-// integration suite; here we pin the branch logic deterministically.
+// lowercase hex), what they may run (the allow-list, plus the role-gated
+// owner-exit actions that bypass it for the owner and reject the restricted
+// key), and that the inner call is re-entered with @caller rewritten to the
+// MAA. A real-engine end-to-end test (create_rule -> join -> maa_exec an
+// order-book action) belongs in the node integration suite; here we pin the
+// branch logic deterministically.
 
 var (
 	maaRestricted   = bytes.Repeat([]byte{0x11}, 20)
@@ -229,12 +231,112 @@ func TestMAAExecRoute_NonAllowlistedActionRejected(t *testing.T) {
 	assert.False(t, eng.innerCalled, "a non-allow-listed action must NOT run")
 }
 
+func TestMAAExecRoute_OwnerExitBypassesAllowlist(t *testing.T) {
+	// The dedicated owner-exit (withdrawal) actions are role-gated, not
+	// allow-list-gated: the unrestricted owner can always exit, even though no
+	// rule lists them (rules are immutable — an allow-list-bound exit would
+	// permanently lock an owner out of their own funds). Case variants and the
+	// empty namespace resolve to the same action in the engine, so they get the
+	// same treatment.
+	for _, tc := range []struct {
+		name, namespace, action string
+	}{
+		{"maa_withdraw", "main", "maa_withdraw"},
+		{"maa_bridge_out", "main", "maa_bridge_out"},
+		{"action case variant", "main", "MAA_WITHDRAW"},
+		{"empty namespace defaults to main", "", "maa_withdraw"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eng := newKnownEngine() // allow-list contains only ob_place_order
+			code, err := runMAAExec(t, eng, maaUnrestricted, tc.namespace, tc.action)
+			require.NoError(t, err)
+			require.Equal(t, types.CodeOk, code)
+			require.True(t, eng.innerCalled, "the owner's exit must run without being allow-listed")
+			assert.Equal(t, ethcommon.BytesToAddress(maaAddr20).Hex(), eng.innerCaller,
+				"the exit must run as the MAA so it debits the MAA's funds")
+			assert.False(t, eng.innerRestricted, "the owner's exit must run unflagged or its transfer legs would be blocked")
+			assert.False(t, eng.getterRestricted, "the route's getter lookups must run unflagged")
+		})
+	}
+}
+
+func TestMAAExecRoute_RestrictedCannotTriggerOwnerExit(t *testing.T) {
+	// Withdrawing is the owner's act: the restricted key must be rejected BEFORE
+	// re-entry — even when a rule (mistakenly) allow-lists the exit action, and
+	// regardless of name casing (the engine resolves namespace and action names
+	// case-insensitively, so a case variant would execute the same action). The
+	// allow-listed rows double as dodge detectors: if the role gate missed the
+	// spelling, the allow-list path would let the call through to re-entry.
+	for _, tc := range []struct {
+		name, namespace, action string
+		allow                   [][2]string
+	}{
+		{"not allow-listed", "main", "maa_withdraw", nil},
+		{"even when allow-listed", "main", "maa_withdraw", [][2]string{{"main", "maa_withdraw"}}},
+		{"bridge out", "main", "maa_bridge_out", nil},
+		{"action case variant", "main", "MAA_WITHDRAW", [][2]string{{"main", "MAA_WITHDRAW"}}},
+		{"namespace case variant", "MAIN", "maa_withdraw", [][2]string{{"MAIN", "maa_withdraw"}}},
+		{"empty namespace defaults to main", "", "maa_withdraw", nil},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			eng := newKnownEngine()
+			if tc.allow != nil {
+				eng.allow = append(eng.allow, tc.allow...)
+			}
+			code, err := runMAAExec(t, eng, maaRestricted, tc.namespace, tc.action)
+			require.Error(t, err)
+			require.ErrorContains(t, err, "reserved for the unrestricted owner",
+				"the rejection must come from the owner-exit role gate, not the allow-list")
+			assert.Equal(t, types.CodeInvalidSender, code)
+			assert.False(t, eng.innerCalled, "the restricted key's exit attempt must not reach re-entry")
+		})
+	}
+}
+
+func TestMAAExecRoute_OwnerExitGatingIsDefaultNamespaceOnly(t *testing.T) {
+	// An action that merely SHARES the withdrawal name in another namespace is a
+	// normal action: allow-list-gated for both roles, no owner bypass and no
+	// restricted-reject at the route (a real exit nested inside it would still be
+	// stopped at the erc20 token boundary for the restricted role).
+	eng := newKnownEngine()
+	code, err := runMAAExec(t, eng, maaUnrestricted, "other", "maa_withdraw")
+	require.Error(t, err, "outside the default namespace the owner gets no allow-list bypass")
+	assert.Equal(t, types.CodeInvalidSender, code)
+	assert.False(t, eng.innerCalled)
+
+	eng = newKnownEngine()
+	eng.allow = append(eng.allow, [2]string{"other", "maa_withdraw"})
+	code, err = runMAAExec(t, eng, maaRestricted, "other", "maa_withdraw")
+	require.NoError(t, err, "an allow-listed same-named action in another namespace follows the normal path")
+	require.Equal(t, types.CodeOk, code)
+	require.True(t, eng.innerCalled)
+	assert.True(t, eng.innerRestricted, "the restricted role's normal-path execution stays flagged for the boundary")
+}
+
 func TestMAAExecRoute_BadAddressLengthRejectedInPreTx(t *testing.T) {
 	// A payload whose maa_address is not 20 bytes must be rejected at decode time.
 	payloadBytes, err := (types.MAAExec{
 		MAAAddress: bytes.Repeat([]byte{0x33}, 19),
 		Namespace:  "main",
 		Action:     "ob_place_order",
+	}).MarshalBinary()
+	require.NoError(t, err)
+	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}
+	ctx := &common.TxContext{Ctx: context.Background(), Caller: ethcommon.BytesToAddress(maaRestricted).Hex()}
+
+	route := &maaExecRoute{}
+	code, err := route.PreTx(ctx, nil, tx)
+	require.Error(t, err)
+	assert.Equal(t, types.CodeEncodingError, code)
+}
+
+func TestMAAExecRoute_EmptyActionRejectedInPreTx(t *testing.T) {
+	// A payload with no inner action must be rejected at decode time, before any
+	// state lookups.
+	payloadBytes, err := (types.MAAExec{
+		MAAAddress: maaAddr20,
+		Namespace:  "main",
+		Action:     "",
 	}).MarshalBinary()
 	require.NoError(t, err)
 	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4038

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced access controls for owner-initiated withdrawal and bridge-out operations, with improved role-based restrictions.

* **Tests**
  * Added comprehensive test coverage for owner-exit action authorization, including bypass verification for permitted users and rejection validation for restricted signers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->