### PR TITLE
chore: let a restricted agent pay write fees from its wallet

### DIFF
--- a/node/exts/erc20-bridge/erc20/meta_extension.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension.go
@@ -35,6 +35,7 @@ import (
 
 	"github.com/trufnetwork/kwil-db/common"
 	kwilcrypto "github.com/trufnetwork/kwil-db/core/crypto"
+	coreauth "github.com/trufnetwork/kwil-db/core/crypto/auth"
 	"github.com/trufnetwork/kwil-db/core/log"
 	"github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/kwil-db/core/utils/order"
@@ -860,15 +861,22 @@ func init() {
 						// There is no security risk if somebody calls this directly
 						AccessModifiers: []precompiles.Modifier{precompiles.PUBLIC},
 						Handler: func(ctx *common.EngineContext, app *common.App, inputs []any, resultFn func([]any) error) error {
-							// MAA token boundary: a restricted agent must never move
-							// the MAA's funds out, at any call depth.
-							if err := maaRestrictedGuard(ctx, "transfer"); err != nil {
-								return err
-							}
-
 							id := inputs[0].(*types.UUID)
 							to := inputs[1].(string)
 							amount := inputs[2].(*types.Decimal)
+
+							// MAA token boundary: a restricted agent must never move
+							// the MAA's funds out, at any call depth — with ONE
+							// exception: the protocol write-fee, a transfer whose
+							// recipient is the block leader's sender address
+							// (@leader_sender in fee-charging actions). The leader is
+							// consensus-determined, never parameter-controlled, so the
+							// agent still cannot steer funds to an address it chooses.
+							if err := maaRestrictedGuard(ctx, "transfer"); err != nil {
+								if !maaIsLeaderFeeRecipient(ctx, to) {
+									return err
+								}
+							}
 
 							if amount.IsNegative() {
 								return fmt.Errorf("amount cannot be negative")
@@ -2018,11 +2026,53 @@ func callDisable(ctx *common.EngineContext, app *common.App, id *types.UUID) err
 // the privileged issue and lock_admin (no agent flow needs them). NOT gated:
 // lock (escrow into the network bucket — order placement needs it) and unlock
 // (the network crediting a user — matching, refunds and settlement need it).
+// The transfer call site carves out ONE exception via maaIsLeaderFeeRecipient:
+// the protocol write-fee to the block leader, so a restricted agent can run
+// fee-charging actions (stream creation / record inserts) on the wallet's
+// escrow.
 func maaRestrictedGuard(ctx *common.EngineContext, op string) error {
 	if ctx.TxContext != nil && ctx.TxContext.MAARestricted {
 		return fmt.Errorf("%s is not allowed under a restricted agent (MAA) execution: the restricted key cannot move funds out of the agent wallet", op)
 	}
 	return nil
+}
+
+// maaIsLeaderFeeRecipient reports whether `to` is the current block leader's
+// sender address — the recipient fee-charging actions resolve from
+// @leader_sender. It mirrors the engine's @leader_sender derivation for the
+// transaction's authenticator (node/engine/interpreter leaderCompactIDForAuth)
+// so the two agree byte for byte. Only the eth_personal_sign scheme yields an
+// address-shaped sender (Keccak(uncompressed pubkey)[12:]); under any other
+// authenticator @leader_sender can never be a valid transfer recipient, so
+// there is nothing to except. Every failure path returns false — the guard
+// stays closed.
+func maaIsLeaderFeeRecipient(ctx *common.EngineContext, to string) bool {
+	txc := ctx.TxContext
+	if txc == nil || txc.BlockContext == nil || txc.BlockContext.Proposer == nil {
+		return false
+	}
+	if !strings.EqualFold(txc.Authenticator, coreauth.EthPersonalSignAuth) {
+		return false
+	}
+	proposer := txc.BlockContext.Proposer
+	if proposer.Type() != kwilcrypto.KeyTypeSecp256k1 {
+		return false
+	}
+	pubKey, err := kwilcrypto.UnmarshalPublicKey(proposer.Bytes(), kwilcrypto.KeyTypeSecp256k1)
+	if err != nil {
+		return false
+	}
+	secpPub, ok := pubKey.(*kwilcrypto.Secp256k1PublicKey)
+	if !ok {
+		return false
+	}
+	toAddr, err := ethAddressFromHex(to)
+	if err != nil {
+		return false
+	}
+	// Raw-byte compare: engine identifiers may be EIP-55 checksummed while
+	// SQL emits lowercase hex — string comparison would be a consensus bug.
+	return bytes.Equal(toAddr.Bytes(), kwilcrypto.EthereumAddressFromPubKey(secpPub))
 }
 
 func (e *extensionInfo) lockTokens(ctx context.Context, app *common.App, id *types.UUID, from string, amount *types.Decimal) error {

--- a/node/exts/erc20-bridge/erc20/meta_extension_maa_guard_test.go
+++ b/node/exts/erc20-bridge/erc20/meta_extension_maa_guard_test.go
@@ -4,12 +4,15 @@ package erc20
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	ethcommon "github.com/ethereum/go-ethereum/common"
 	"github.com/stretchr/testify/require"
 
 	"github.com/trufnetwork/kwil-db/common"
+	kwilcrypto "github.com/trufnetwork/kwil-db/core/crypto"
+	coreauth "github.com/trufnetwork/kwil-db/core/crypto/auth"
 	"github.com/trufnetwork/kwil-db/core/types"
 	"github.com/trufnetwork/kwil-db/extensions/precompiles"
 	"github.com/trufnetwork/kwil-db/node/exts/evm-sync/chains"
@@ -90,6 +93,81 @@ func TestMAARestrictedGuard_BlocksExitPrimitives(t *testing.T) {
 		require.Error(t, err, "%s must be rejected under restricted MAA execution", tc.method)
 		require.ErrorContains(t, err, maaGuardErr, "%s must fail with the guard error", tc.method)
 	}
+}
+
+// maaLeaderProposer generates a secp256k1 proposer key and returns it with its
+// eth_personal_sign sender address — what @leader_sender resolves to for the
+// fee transfer's recipient.
+func maaLeaderProposer(t *testing.T) (kwilcrypto.PublicKey, ethcommon.Address) {
+	t.Helper()
+	_, pub, err := kwilcrypto.GenerateSecp256k1Key(nil)
+	require.NoError(t, err)
+	secpPub, ok := pub.(*kwilcrypto.Secp256k1PublicKey)
+	require.True(t, ok)
+	return pub, ethcommon.BytesToAddress(kwilcrypto.EthereumAddressFromPubKey(secpPub))
+}
+
+// maaEngineCtxWithLeader is maaEngineCtx with the proposer and authenticator a
+// real block execution carries — the inputs the leader-fee exception keys on.
+func maaEngineCtxWithLeader(restricted bool, caller string, proposer kwilcrypto.PublicKey, authenticator string) *common.EngineContext {
+	ctx := maaEngineCtx(restricted, caller)
+	ctx.TxContext.BlockContext.Proposer = proposer
+	ctx.TxContext.Authenticator = authenticator
+	return ctx
+}
+
+// TestMAARestrictedGuard_LeaderFeeException: the ONE carve-out in the token
+// boundary — a restricted MAA execution may transfer to the block leader's
+// sender address (the protocol write-fee, @leader_sender in fee-charging
+// actions) and to no one else. The allowed case is proven by the handler
+// proceeding PAST the guard into its own amount validation (app is nil, so
+// reaching state would panic — nothing ran past the validation). Every
+// degraded context — no proposer, wrong authenticator, non-secp proposer —
+// must fail CLOSED with the guard error, even with the leader as recipient.
+func TestMAARestrictedGuard_LeaderFeeException(t *testing.T) {
+	id := uuidForChainAndEscrow("1", "0x00000000000000000000000000000000000000cc")
+	maa := ethcommon.HexToAddress("0x3333333333333333333333333333333333333333").Hex()
+	other := ethcommon.HexToAddress("0x4444444444444444444444444444444444444444").Hex()
+	proposer, leaderAddr := maaLeaderProposer(t)
+
+	// Allowed: recipient IS the leader → past the guard, into amount validation.
+	ctx := maaEngineCtxWithLeader(true, maa, proposer, coreauth.EthPersonalSignAuth)
+	err := maaMetaMethod(t, "transfer").Handler(ctx, nil, []any{&id, leaderAddr.Hex(), maaDec(t, "-1")}, maaNoResult)
+	require.ErrorContains(t, err, "amount cannot be negative", "a leader-fee transfer must pass the guard into the handler's own validation")
+	require.NotContains(t, err.Error(), maaGuardErr)
+
+	// The SQL fee path emits the recipient as lowercase hex without 0x — the
+	// compare must be raw-byte, not string-shape sensitive.
+	err = maaMetaMethod(t, "transfer").Handler(ctx, nil, []any{&id, strings.ToLower(leaderAddr.Hex()[2:]), maaDec(t, "-1")}, maaNoResult)
+	require.ErrorContains(t, err, "amount cannot be negative", "lowercase no-0x leader hex must match byte-for-byte")
+	require.NotContains(t, err.Error(), maaGuardErr)
+
+	// Any other recipient stays blocked, leader present or not.
+	err = maaMetaMethod(t, "transfer").Handler(ctx, nil, []any{&id, other, maaDec(t, "10")}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr, "a non-leader recipient must stay blocked")
+
+	// The exception is transfer-only: bridge to the leader is still an exit.
+	err = maaMetaMethod(t, "bridge").Handler(ctx, nil, []any{&id, leaderAddr.Hex(), maaDec(t, "10")}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr, "bridge must stay blocked even toward the leader")
+
+	// Fail closed: no proposer in context.
+	err = maaMetaMethod(t, "transfer").Handler(maaEngineCtx(true, maa), nil, []any{&id, leaderAddr.Hex(), maaDec(t, "10")}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr, "no proposer → no exception")
+
+	// Fail closed: a non-address authenticator scheme (sender is a pubkey, so
+	// @leader_sender can never be a transfer recipient).
+	err = maaMetaMethod(t, "transfer").Handler(
+		maaEngineCtxWithLeader(true, maa, proposer, coreauth.Secp256k1Auth), nil,
+		[]any{&id, leaderAddr.Hex(), maaDec(t, "10")}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr, "non-eth authenticator → no exception")
+
+	// Fail closed: an ed25519 proposer has no eth address.
+	_, edPub, err := kwilcrypto.GenerateEd25519Key(nil)
+	require.NoError(t, err)
+	err = maaMetaMethod(t, "transfer").Handler(
+		maaEngineCtxWithLeader(true, maa, edPub, coreauth.EthPersonalSignAuth), nil,
+		[]any{&id, leaderAddr.Hex(), maaDec(t, "10")}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr, "non-secp proposer → no exception")
 }
 
 // TestMAARestrictedGuard_LockAndUnlockNotGated: lock (collateral escrow) and
@@ -216,4 +294,16 @@ func TestMAARestrictedBoundary_TradingSurvivesExitsBlocked(t *testing.T) {
 	require.NoError(t, maaMetaMethod(t, "transfer").Handler(unflaggedCtx, app, []any{id, counterparty.Hex(), maaDec(t, "10")}, maaNoResult))
 	require.Equal(t, "80", balance(maa))
 	require.Equal(t, "14", balance(counterparty))
+
+	// 6) The leader-fee exception on real balances: a RESTRICTED execution can
+	//    pay the protocol write-fee (transfer to @leader_sender) and the funds
+	//    actually move — while the same amount to anyone else still bounces.
+	proposer, leaderAddr := maaLeaderProposer(t)
+	leaderCtx := maaEngineCtxWithLeader(true, maa.Hex(), proposer, coreauth.EthPersonalSignAuth)
+	require.NoError(t, maaMetaMethod(t, "transfer").Handler(leaderCtx, app, []any{id, leaderAddr.Hex(), maaDec(t, "5")}, maaNoResult))
+	require.Equal(t, "75", balance(maa))
+	require.Equal(t, "5", balance(leaderAddr))
+	err = maaMetaMethod(t, "transfer").Handler(leaderCtx, app, []any{id, counterparty.Hex(), maaDec(t, "5")}, maaNoResult)
+	require.ErrorContains(t, err, maaGuardErr)
+	require.Equal(t, "75", balance(maa))
 }


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4040

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new exception to the MAA transfer restriction that permits transfers to the block leader's fee-charging sender address during restricted execution.

* **Tests**
  * Extended test coverage to validate the leader-fee exception behavior, verifying that transfers succeed when conditions are met and fail securely when proposer information is missing or incorrect.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->