### PR TITLE
chore: hold maa_exec until a network-scheduled activation height

### DIFF
--- a/app/setup/genesis.go
+++ b/app/setup/genesis.go
@@ -40,12 +40,13 @@ type genesisFlagConfig struct {
 }
 
 type networkParams struct {
-	withGas       bool
-	leader        string
-	dbOwner       string
-	maxBlockSize  int64
-	joinExpiry    time.Duration
-	maxVotesPerTx int64
+	withGas             bool
+	leader              string
+	dbOwner             string
+	maxBlockSize        int64
+	joinExpiry          time.Duration
+	maxVotesPerTx       int64
+	maaActivationHeight int64
 }
 
 func GenesisCmd() *cobra.Command {
@@ -142,6 +143,7 @@ func bindNetworkParamsFlags(cmd *cobra.Command, cfg *networkParams) {
 	cmd.Flags().Int64Var(&cfg.maxBlockSize, maxBlockSizeFlag, 0, "maximum block size")
 	cmd.Flags().DurationVar(&cfg.joinExpiry, joinExpiryFlag, 0, "Number of blocks before a join proposal expires")
 	cmd.Flags().Int64Var(&cfg.maxVotesPerTx, maxVotesPerTxFlag, 0, "Maximum votes per transaction")
+	cmd.Flags().Int64Var(&cfg.maaActivationHeight, maaActivationHeightFlag, 0, "Block height at which the maa_exec transaction route activates (0 = not activated)")
 }
 
 const (
@@ -154,6 +156,8 @@ const (
 	maxBlockSizeFlag  = "max-block-size"
 	joinExpiryFlag    = "join-expiry"
 	maxVotesPerTxFlag = "max-votes-per-tx"
+
+	maaActivationHeightFlag = "maa-activation-height"
 )
 
 // mergeGenesisFlags merges the genesis configuration flags with the given configuration.
@@ -303,6 +307,10 @@ func mergeNetworkParamFlags(conf *config.GenesisConfig, cmd *cobra.Command, flag
 
 	if cmd.Flags().Changed(maxVotesPerTxFlag) {
 		conf.MaxVotesPerTx = flagCfg.maxVotesPerTx
+	}
+
+	if cmd.Flags().Changed(maaActivationHeightFlag) {
+		conf.MAAActivationHeight = flagCfg.maaActivationHeight
 	}
 
 	return conf, nil

--- a/core/types/params.go
+++ b/core/types/params.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"reflect"
 	"sort"
+	"strings"
 
 	"github.com/trufnetwork/kwil-db/core/crypto"
 )
@@ -114,6 +115,19 @@ type NetworkParameters struct {
 	// migration on nodes of the old network. The "param" tag is used since json
 	// is explicitly omitted via the "json:"-" tag.
 	MigrationStatus MigrationStatus `json:"-" param:"migration_status"`
+
+	// MAAActivationHeight is the block height at which the maa_exec
+	// transaction route (Modular Agent Addresses) becomes available. Zero
+	// means MAAExec is not activated on this network; transactions are
+	// rejected at mempool admission and at the route's PreTx. The zero
+	// value MUST stay invisible to consensus — omitted from the JSON
+	// serialization (stored into kwild_chain.params every block) and
+	// skipped in Hash (validated in every block header as
+	// NetworkParamsHash) — so a binary carrying this field stays
+	// byte-identical, block for block, to one that predates it until the
+	// network explicitly schedules activation via a param_updates
+	// resolution (or genesis, for new networks).
+	MAAActivationHeight int64 `json:"maa_activation_height,omitempty"`
 }
 
 // ParamUpdates is the mechanism by which changes to network parameters are
@@ -133,15 +147,16 @@ type ParamName = string
 
 // The ParamName values correspond to the fields of the NetworkParameters struct.
 var (
-	ParamNameLeader           ParamName
-	ParamNameMaxBlockSize     ParamName
-	ParamNameJoinExpiry       ParamName
-	ParamNameDisabledGasCosts ParamName
-	ParamNameMaxVotesPerTx    ParamName
-	ParamNameMigrationStatus  ParamName
+	ParamNameLeader              ParamName
+	ParamNameMaxBlockSize        ParamName
+	ParamNameJoinExpiry          ParamName
+	ParamNameDisabledGasCosts    ParamName
+	ParamNameMaxVotesPerTx       ParamName
+	ParamNameMigrationStatus     ParamName
+	ParamNameMAAActivationHeight ParamName
 )
 
-const numParams = 6
+const numParams = 7
 
 // setParamNames sets the ParamName constants based on the json tags of a struct
 // (intended for NetworkParameters, but any for unit testing). This looks crazy,
@@ -159,6 +174,9 @@ func setParamNames(np any) {
 		if fieldTag == "" {
 			panic(fmt.Sprintf("field %v lacks a json tag", field.Name))
 		}
+		// The param name is the json name only — options like ",omitempty"
+		// are not part of it.
+		fieldTag, _, _ = strings.Cut(fieldTag, ",")
 		if fieldTag == "-" {
 			fieldTag = field.Tag.Get("param")
 		}
@@ -175,6 +193,8 @@ func setParamNames(np any) {
 			ParamNameMaxVotesPerTx = fieldTag
 		case "MigrationStatus":
 			ParamNameMigrationStatus = fieldTag
+		case "MAAActivationHeight":
+			ParamNameMAAActivationHeight = fieldTag
 		default:
 			panic(fmt.Sprintf("unknown field %v", fieldName))
 		}
@@ -216,6 +236,8 @@ func MergeUpdates(np *NetworkParameters, updates ParamUpdates) (err error) {
 			np.MaxVotesPerTx = update.(int64)
 		case ParamNameMigrationStatus:
 			np.MigrationStatus = update.(MigrationStatus)
+		case ParamNameMAAActivationHeight:
+			np.MAAActivationHeight = update.(int64)
 		default:
 			return fmt.Errorf("unknown field %v", paramName)
 		}
@@ -339,7 +361,7 @@ func (pu ParamUpdates) MarshalBinary() ([]byte, error) {
 			} else {
 				return nil, fmt.Errorf("invalid type for %s", key)
 			}
-		case ParamNameMaxBlockSize, ParamNameMaxVotesPerTx:
+		case ParamNameMaxBlockSize, ParamNameMaxVotesPerTx, ParamNameMAAActivationHeight:
 			if val, ok := value.(int64); ok {
 				if err := binary.Write(buf, binary.LittleEndian, val); err != nil {
 					return nil, err
@@ -423,7 +445,7 @@ func (pu *ParamUpdates) UnmarshalBinary(data []byte) error {
 				return err
 			}
 			updates[paramName] = expiry
-		case ParamNameMaxBlockSize, ParamNameMaxVotesPerTx:
+		case ParamNameMaxBlockSize, ParamNameMaxVotesPerTx, ParamNameMAAActivationHeight:
 			var val int64
 			if err := binary.Read(buf, binary.LittleEndian, &val); err != nil {
 				return err
@@ -479,7 +501,7 @@ func (pu *ParamUpdates) UnmarshalJSON(b []byte) error {
 			pu0[pn] = pk
 
 		// the int64 params
-		case ParamNameMaxBlockSize, ParamNameJoinExpiry, ParamNameMaxVotesPerTx:
+		case ParamNameMaxBlockSize, ParamNameJoinExpiry, ParamNameMaxVotesPerTx, ParamNameMAAActivationHeight:
 			var i int64
 			if err := json.Unmarshal(v, &i); err != nil {
 				return err
@@ -512,12 +534,13 @@ func (pu *ParamUpdates) UnmarshalJSON(b []byte) error {
 func (np NetworkParameters) ToMap() map[ParamName]any {
 	// Create a map using ParamNames as keys.
 	return map[ParamName]any{
-		ParamNameLeader:           np.Leader,
-		ParamNameMaxBlockSize:     np.MaxBlockSize,
-		ParamNameJoinExpiry:       np.JoinExpiry,
-		ParamNameDisabledGasCosts: np.DisabledGasCosts,
-		ParamNameMaxVotesPerTx:    np.MaxVotesPerTx,
-		ParamNameMigrationStatus:  np.MigrationStatus,
+		ParamNameLeader:              np.Leader,
+		ParamNameMaxBlockSize:        np.MaxBlockSize,
+		ParamNameJoinExpiry:          np.JoinExpiry,
+		ParamNameDisabledGasCosts:    np.DisabledGasCosts,
+		ParamNameMaxVotesPerTx:       np.MaxVotesPerTx,
+		ParamNameMigrationStatus:     np.MigrationStatus,
+		ParamNameMAAActivationHeight: np.MAAActivationHeight,
 	}
 }
 
@@ -572,7 +595,8 @@ func (np *NetworkParameters) Equals(other *NetworkParameters) bool {
 		np.JoinExpiry == other.JoinExpiry &&
 		np.DisabledGasCosts == other.DisabledGasCosts &&
 		np.MaxVotesPerTx == other.MaxVotesPerTx &&
-		np.MigrationStatus == other.MigrationStatus
+		np.MigrationStatus == other.MigrationStatus &&
+		np.MAAActivationHeight == other.MAAActivationHeight
 }
 
 func (np *NetworkParameters) SanityChecks() error {
@@ -606,9 +630,11 @@ func (np NetworkParameters) String() string {
 	Join Expiry: %d
 	Disabled Gas Costs: %t
 	Max Votes Per Tx: %d
-	Migration Status: %s`,
+	Migration Status: %s
+	MAA Activation Height: %d`,
 		&np.Leader, np.MaxBlockSize, np.JoinExpiry,
-		np.DisabledGasCosts, np.MaxVotesPerTx, np.MigrationStatus)
+		np.DisabledGasCosts, np.MaxVotesPerTx, np.MigrationStatus,
+		np.MAAActivationHeight)
 }
 
 func (np *NetworkParameters) Hash() Hash {
@@ -623,6 +649,15 @@ func (np *NetworkParameters) Hash() Hash {
 	binary.Write(hasher, SerializationByteOrder, np.DisabledGasCosts)
 	binary.Write(hasher, SerializationByteOrder, np.MaxVotesPerTx)
 	hasher.Write([]byte(np.MigrationStatus))
+
+	// Parameters added after live networks genesised are hashed only when
+	// set, as tagged records: a zero value must produce the exact hash a
+	// binary that predates the parameter computes, or deploying the new
+	// binary would itself fork block-header validation (NetworkParamsHash).
+	if np.MAAActivationHeight != 0 {
+		hasher.Write([]byte(ParamNameMAAActivationHeight))
+		binary.Write(hasher, SerializationByteOrder, np.MAAActivationHeight)
+	}
 
 	return hasher.Sum(nil)
 }

--- a/core/types/params_test.go
+++ b/core/types/params_test.go
@@ -803,6 +803,12 @@ func TestNetworkParametersHash(t *testing.T) {
 				np.MigrationStatus = "inactive"
 			},
 		},
+		{
+			name: "different maa activation height",
+			mutator: func(np *NetworkParameters) {
+				np.MAAActivationHeight = 500
+			},
+		},
 	}
 
 	baseHash := baseParams.Hash()
@@ -818,4 +824,55 @@ func TestNetworkParametersHash(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNetworkParametersZeroMAAActivationHeightIsInvisible(t *testing.T) {
+	// MAAActivationHeight was added after live networks genesised. While it
+	// is zero (MAAExec not activated), both the params hash — validated in
+	// every block header as NetworkParamsHash — and the JSON serialization —
+	// stored into kwild_chain.params every block, inside the hashed block
+	// transaction — MUST be byte-identical to what a binary WITHOUT the
+	// field produces, or deploying the new binary would itself fork the
+	// network. The goldens below were captured from the code base
+	// immediately before the field existed (commit 7d3dce4d), over the
+	// values TN mainnet actually runs.
+	pub, err := crypto.UnmarshalSecp256k1PublicKey([]byte{0x2, 0xe0, 0x9d, 0x79, 0x32, 0xde, 0xf1, 0x1d, 0x82, 0x72, 0xdd, 0x3b, 0x58, 0x9d, 0xf8, 0xb1, 0xcf, 0x7a, 0xff, 0xb0, 0x41, 0x50, 0x19, 0x4f, 0xc2, 0x28, 0xf8, 0x17, 0xae, 0xba, 0xb2, 0xc9, 0xda})
+	require.NoError(t, err)
+
+	np := &NetworkParameters{
+		Leader:           PublicKey{pub},
+		MaxBlockSize:     6291456,
+		JoinExpiry:       Duration(604800000000000), // 168h
+		DisabledGasCosts: true,
+		MaxVotesPerTx:    200,
+		MigrationStatus:  NoActiveMigration,
+	}
+
+	const preFieldHash = "72018aca345b2a1e6aed6469c70e077230e45065314c905025d2308194b94ea8"
+	const preFieldJSON = `{"leader":{"type":"secp256k1","key":"02e09d7932def11d8272dd3b589df8b1cf7affb04150194fc228f817aebab2c9da"},"max_block_size":6291456,"join_expiry":"168h0m0s","disabled_gas_costs":true,"max_votes_per_tx":200,"migration_status":"NoActiveMigration"}`
+
+	require.Equal(t, preFieldHash, np.Hash().String())
+	bts, err := np.MarshalBinary()
+	require.NoError(t, err)
+	require.Equal(t, preFieldJSON, string(bts))
+
+	// Setting the parameter is the consensus-visible activation event: both
+	// the header hash and the stored bytes change, on every upgraded node at
+	// the same block.
+	np.MAAActivationHeight = 1_000_000
+	require.NotEqual(t, preFieldHash, np.Hash().String())
+	btsActivated, err := np.MarshalBinary()
+	require.NoError(t, err)
+	require.Contains(t, string(btsActivated), `"maa_activation_height":1000000`)
+
+	// The activated form round-trips...
+	var back NetworkParameters
+	require.NoError(t, back.UnmarshalBinary(btsActivated))
+	require.True(t, np.Equals(&back))
+
+	// ...and bytes stored by a pre-field binary load with the parameter at
+	// zero: not activated.
+	var old NetworkParameters
+	require.NoError(t, old.UnmarshalBinary(bts))
+	require.EqualValues(t, 0, old.MAAActivationHeight)
 }

--- a/node/txapp/maa_route.go
+++ b/node/txapp/maa_route.go
@@ -69,10 +69,16 @@ func (d *maaExecRoute) Price(ctx context.Context, app *common.App, tx *types.Tra
 }
 
 func (d *maaExecRoute) PreTx(ctx *common.TxContext, svc *common.Service, tx *types.Transaction) (types.TxCode, error) {
-	// ACTIVATION CHOKEPOINT: once fork-height infrastructure lands, reject
-	// MAAExec before its activation height here, mirroring the
-	// MigrationStatus guards in transferRoute.PreTx. Until then availability
-	// is "this binary is deployed", which the coordinated rollout flag-days.
+	// ACTIVATION CHOKEPOINT: MAAExec is height-gated by the
+	// maa_activation_height network parameter, mirroring the
+	// MigrationStatus guards in transferRoute.PreTx. The mempool applies
+	// the same gate at admission (applyTransaction), keeping pre-activation
+	// transactions out of blocks entirely; this execution-time check makes
+	// a block that nonetheless carries one fail deterministically on every
+	// upgraded node.
+	if code, err := maaExecActivationGate(ctx); err != nil {
+		return code, err
+	}
 
 	payload := &types.MAAExec{}
 	if err := payload.UnmarshalBinary(tx.Body.Payload); err != nil {
@@ -226,6 +232,29 @@ func (d *maaExecRoute) InTx(ctx *common.TxContext, app *common.App, tx *types.Tr
 		return types.CodeUnknownError, logs, res.Error
 	}
 	return 0, logs, nil
+}
+
+// maaExecActivationGate rejects MAAExec until the network's scheduled
+// activation height, read from the consensus-agreed maa_activation_height
+// network parameter. Zero means MAA was never activated on this network;
+// a missing context is treated the same way — the gate fails closed. The
+// wrapped ErrUnknownPayloadType makes the rejection read (and broadcast-map,
+// via BroadcastErrorToCode) like the route does not exist, which is exactly
+// what a pre-MAA binary reports for this payload type.
+func maaExecActivationGate(ctx *common.TxContext) (types.TxCode, error) {
+	if ctx == nil || ctx.BlockContext == nil || ctx.BlockContext.ChainContext == nil ||
+		ctx.BlockContext.ChainContext.NetworkParameters == nil {
+		return types.CodeInvalidTxType, fmt.Errorf("%w: maa_exec activation height unavailable", types.ErrUnknownPayloadType)
+	}
+	activation := ctx.BlockContext.ChainContext.NetworkParameters.MAAActivationHeight
+	if activation == 0 {
+		return types.CodeInvalidTxType, fmt.Errorf("%w: maa_exec is not activated on this network", types.ErrUnknownPayloadType)
+	}
+	if ctx.BlockContext.Height < activation {
+		return types.CodeInvalidTxType, fmt.Errorf("%w: maa_exec activates at height %d, current height %d",
+			types.ErrUnknownPayloadType, activation, ctx.BlockContext.Height)
+	}
+	return 0, nil
 }
 
 // isOwnerExitAction reports whether the requested inner action is one of the

--- a/node/txapp/maa_route_test.go
+++ b/node/txapp/maa_route_test.go
@@ -129,10 +129,7 @@ func runMAAExec(t *testing.T, eng *fakeMAAEngine, signer []byte, namespace, acti
 	require.NoError(t, err)
 
 	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}
-	ctx := &common.TxContext{
-		Ctx:    context.Background(),
-		Caller: ethcommon.BytesToAddress(signer).Hex(), // checksummed, like a real signer
-	}
+	ctx := maaActivatedTxContext(signer)
 	app := &common.App{Engine: eng}
 
 	route := &maaExecRoute{}
@@ -141,6 +138,23 @@ func runMAAExec(t *testing.T, eng *fakeMAAEngine, signer []byte, namespace, acti
 	}
 	code, _, err := route.InTx(ctx, app, tx)
 	return code, err
+}
+
+// maaActivatedTxContext builds a TxContext whose network has MAAExec
+// activated (maa_activation_height = 1, at height 1), so route tests
+// exercise the post-activation behavior. signer is the raw 20-byte address
+// of the outer tx signer.
+func maaActivatedTxContext(signer []byte) *common.TxContext {
+	return &common.TxContext{
+		Ctx:    context.Background(),
+		Caller: ethcommon.BytesToAddress(signer).Hex(), // checksummed, like a real signer
+		BlockContext: &common.BlockContext{
+			Height: 1,
+			ChainContext: &common.ChainContext{
+				NetworkParameters: &types.NetworkParameters{MAAActivationHeight: 1},
+			},
+		},
+	}
 }
 
 func newKnownEngine() *fakeMAAEngine {
@@ -322,7 +336,7 @@ func TestMAAExecRoute_BadAddressLengthRejectedInPreTx(t *testing.T) {
 	}).MarshalBinary()
 	require.NoError(t, err)
 	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}
-	ctx := &common.TxContext{Ctx: context.Background(), Caller: ethcommon.BytesToAddress(maaRestricted).Hex()}
+	ctx := maaActivatedTxContext(maaRestricted)
 
 	route := &maaExecRoute{}
 	code, err := route.PreTx(ctx, nil, tx)
@@ -340,10 +354,91 @@ func TestMAAExecRoute_EmptyActionRejectedInPreTx(t *testing.T) {
 	}).MarshalBinary()
 	require.NoError(t, err)
 	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}
-	ctx := &common.TxContext{Ctx: context.Background(), Caller: ethcommon.BytesToAddress(maaRestricted).Hex()}
+	ctx := maaActivatedTxContext(maaRestricted)
 
 	route := &maaExecRoute{}
 	code, err := route.PreTx(ctx, nil, tx)
 	require.Error(t, err)
 	assert.Equal(t, types.CodeEncodingError, code)
+}
+
+func TestMAAExecActivationGate(t *testing.T) {
+	gateCtx := func(activation, height int64) *common.TxContext {
+		return &common.TxContext{
+			Ctx: context.Background(),
+			BlockContext: &common.BlockContext{
+				Height: height,
+				ChainContext: &common.ChainContext{
+					NetworkParameters: &types.NetworkParameters{MAAActivationHeight: activation},
+				},
+			},
+		}
+	}
+
+	t.Run("fails closed without context", func(t *testing.T) {
+		for name, ctx := range map[string]*common.TxContext{
+			"nil ctx":           nil,
+			"nil block context": {Ctx: context.Background()},
+			"nil chain context": {Ctx: context.Background(), BlockContext: &common.BlockContext{}},
+			"nil params":        {Ctx: context.Background(), BlockContext: &common.BlockContext{ChainContext: &common.ChainContext{}}},
+		} {
+			code, err := maaExecActivationGate(ctx)
+			require.Error(t, err, name)
+			assert.Equal(t, types.CodeInvalidTxType, code, name)
+			assert.ErrorIs(t, err, types.ErrUnknownPayloadType, name)
+		}
+	})
+
+	t.Run("zero means never activated", func(t *testing.T) {
+		code, err := maaExecActivationGate(gateCtx(0, 1_000_000))
+		require.Error(t, err)
+		assert.Equal(t, types.CodeInvalidTxType, code)
+		assert.ErrorContains(t, err, "not activated")
+	})
+
+	t.Run("rejected below the activation height", func(t *testing.T) {
+		code, err := maaExecActivationGate(gateCtx(100, 99))
+		require.Error(t, err)
+		assert.Equal(t, types.CodeInvalidTxType, code)
+		assert.ErrorContains(t, err, "activates at height 100")
+	})
+
+	t.Run("active at and after the activation height", func(t *testing.T) {
+		for _, h := range []int64{100, 101, 1 << 40} {
+			code, err := maaExecActivationGate(gateCtx(100, h))
+			require.NoError(t, err)
+			assert.Equal(t, types.TxCode(0), code)
+		}
+	})
+}
+
+func TestMAAExecRoute_RejectedBeforeActivation(t *testing.T) {
+	// A well-formed MAAExec is rejected in PreTx when the network has not
+	// reached (or never scheduled) activation. The rejection wraps
+	// ErrUnknownPayloadType so it reads exactly like a pre-MAA binary's
+	// response to this payload type.
+	payloadBytes, err := (types.MAAExec{
+		MAAAddress: maaAddr20,
+		Namespace:  "main",
+		Action:     "ob_place_order",
+	}).MarshalBinary()
+	require.NoError(t, err)
+	tx := &types.Transaction{Body: &types.TransactionBody{Payload: payloadBytes}}
+
+	route := &maaExecRoute{}
+
+	// Not scheduled at all.
+	ctx := maaActivatedTxContext(maaRestricted)
+	ctx.BlockContext.ChainContext.NetworkParameters.MAAActivationHeight = 0
+	code, err := route.PreTx(ctx, nil, tx)
+	require.Error(t, err)
+	assert.Equal(t, types.CodeInvalidTxType, code)
+	assert.ErrorIs(t, err, types.ErrUnknownPayloadType)
+
+	// Scheduled, not yet reached.
+	ctx.BlockContext.ChainContext.NetworkParameters.MAAActivationHeight = ctx.BlockContext.Height + 10
+	code, err = route.PreTx(ctx, nil, tx)
+	require.Error(t, err)
+	assert.Equal(t, types.CodeInvalidTxType, code)
+	assert.ErrorIs(t, err, types.ErrUnknownPayloadType)
 }

--- a/node/txapp/mempool.go
+++ b/node/txapp/mempool.go
@@ -91,6 +91,16 @@ func (m *mempool) applyTransaction(ctx *common.TxContext, tx *types.Transaction,
 		}
 	}
 
+	// MAAExec is height-gated by the maa_activation_height network
+	// parameter. Rejecting at admission keeps pre-activation transactions
+	// out of mempools and therefore out of blocks; the route's PreTx
+	// enforces the same rule at execution as defense in depth.
+	if tx.Body.PayloadType == types.PayloadTypeMAAExec {
+		if _, err := maaExecActivationGate(ctx); err != nil {
+			return err
+		}
+	}
+
 	// Migration proposals and its approvals are not allowed once the migration is approved
 	if tx.Body.PayloadType == types.PayloadTypeCreateResolution {
 		res := &types.CreateResolution{}

--- a/node/txapp/mempool_test.go
+++ b/node/txapp/mempool_test.go
@@ -175,3 +175,49 @@ type mockRebroadcast struct{}
 func (m *mockRebroadcast) MarkRebroadcast(ctx context.Context, ids []*types.UUID) error {
 	return nil
 }
+
+func Test_MempoolMAAExecActivationGate(t *testing.T) {
+	privkey, pubkey, _ := crypto.GenerateSecp256k1Key(nil)
+	m := &mempool{
+		accounts:   make(map[string]*types.Account),
+		accountMgr: &mockAccount{},
+		log:        log.DiscardLogger,
+		nodeIdent:  auth.GetNodeSigner(privkey),
+	}
+
+	params := &types.NetworkParameters{
+		Leader:           types.PublicKey{PublicKey: pubkey},
+		DisabledGasCosts: true,
+	}
+	txCtx := &common.TxContext{
+		Ctx:    context.Background(),
+		Caller: "A",
+		BlockContext: &common.BlockContext{
+			Height:       5,
+			ChainContext: &common.ChainContext{NetworkParameters: params},
+		},
+	}
+	db := &mockDb{}
+	rebroadcast := &mockRebroadcast{}
+
+	maaTx := newTx(t, 1, "A")
+	maaTx.Body.PayloadType = types.PayloadTypeMAAExec
+
+	// Never activated: rejected at admission, reading like an unknown
+	// payload type — the same answer a pre-MAA binary gives.
+	err := m.applyTransaction(txCtx, maaTx, db, rebroadcast)
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrUnknownPayloadType)
+
+	// Scheduled but not reached: still rejected.
+	params.MAAActivationHeight = txCtx.BlockContext.Height + 1
+	err = m.applyTransaction(txCtx, maaTx, db, rebroadcast)
+	require.Error(t, err)
+	require.ErrorIs(t, err, types.ErrUnknownPayloadType)
+
+	// At the activation height: admitted, proceeding to ordinary nonce
+	// handling like any other transaction.
+	params.MAAActivationHeight = txCtx.BlockContext.Height
+	err = m.applyTransaction(txCtx, maaTx, db, rebroadcast)
+	require.NoError(t, err)
+}


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4117

Activating the `maa_exec` route on a running network is currently a flag-day: the route is live the moment a binary carrying it is deployed, so a mixed-version fleet forks — an old binary skips an in-block `MAAExec` with `CodeInvalidTxType` while a new binary executes it, diverging TxResults and changesets. This PR makes activation a network-agreed, height-scheduled event.

## What this does

- **`maa_activation_height` consensus parameter** (`core/types/params.go`). `0` (the default) means `maa_exec` is not activated; a non-zero `H` activates the route from block `H` on. New networks set it in genesis (`kwild setup genesis --maa-activation-height`); live networks schedule it with the stock resolution flow (`kwild consensus propose -u '{"maa_activation_height": H}'`).
- **The zero value is invisible to consensus.** The params hash is carried in every block header (`Header.NetworkParamsHash`, validated in `consensus/block.go`), and the params JSON is rewritten into `kwild_chain.params` inside every hashed block transaction. The field is therefore `omitempty` in the stored JSON and skipped in `Hash()` while zero, so a binary with this PR is byte-identical in consensus, block for block, to one without it — until the network explicitly schedules activation. The binary upgrade itself is hash-neutral; the scheduling resolution is the only consensus-visible event, and a straggler node still on an old binary halts cleanly on header validation instead of forking silently. `TestNetworkParametersZeroMAAActivationHeightIsInvisible` pins this with goldens captured from the pre-change code over mainnet's actual parameter values.
- **Dual gate.** Mempool admission (`applyTransaction`, beside the existing migration gates) keeps pre-activation `MAAExec` out of mempools and blocks entirely; `maaExecRoute.PreTx` (the activation chokepoint marked since the route landed) fails one deterministically on every node if a leader force-includes it anyway. Both wrap `ErrUnknownPayloadType`, so the rejection reads exactly like a pre-MAA binary's answer to this payload type.

## How it is verified

- Unit: gate matrix (fail-closed without context / never activated / below height / at and after height), mempool admission tests, and the existing route suite under an activated context.
- `test/integration/maa_activation_test.go` (`TestMAAExecActivation`) rehearses the full rollout on a real 3-validator network, driving the literal `maaExecRoute` with raw hand-signed `MAAExec` transactions: genesis without activation → broadcast rejected; activation scheduled via a `param_updates` resolution, every node converging on `H`; rejected below `H`; from `H` on the inner action executes as the MAA (`@caller` rewritten, identical state on all three nodes); a signer that is neither of the instance's keys fails deterministically; and the AppHash is asserted equal across nodes at every height through the activation fork.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a network parameter `maa-activation-height` to configure when MAA execution becomes active.
  * Implemented activation-height gating to enforce MAA transaction availability after the configured activation height.

* **Tests**
  * Added comprehensive test coverage for MAA activation behavior, including mempool admission gating and end-to-end integration testing.

* **Chores**
  * Updated test module dependencies to latest compatible versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->