### PR TITLE
feat: broadcast arbitrary payloads from the core client

### DIFF
--- a/core/client/client.go
+++ b/core/client/client.go
@@ -307,6 +307,27 @@ func (c *Client) ExecuteSQL(ctx context.Context, stmt string, params map[string]
 	return c.txClient.Broadcast(ctx, tx, syncBcastFlag(txOpts.SyncBcast))
 }
 
+// ExecutePayload signs and broadcasts an arbitrary transaction payload using the
+// client's signer, nonce, and fee estimation — the same construction path as
+// Execute and Transfer. It is the escape hatch for payload types the client has
+// no typed convenience method for, such as extension payloads like MAAExec.
+// Prefer the typed methods (Execute, Transfer, ExecuteSQL) for ordinary actions.
+func (c *Client) ExecutePayload(ctx context.Context, payload types.Payload, opts ...clientType.TxOpt) (types.Hash, error) {
+	txOpts := clientType.GetTxOpts(opts)
+	tx, err := c.newTx(ctx, payload, txOpts)
+	if err != nil {
+		return types.Hash{}, err
+	}
+
+	c.logger.Debug("execute payload",
+		"payload_type", payload.Type(),
+		"signature_type", tx.Signature.Type,
+		"signature", base64.StdEncoding.EncodeToString(tx.Signature.Data),
+		"fee", tx.Body.Fee.String(), "nonce", tx.Body.Nonce)
+
+	return c.txClient.Broadcast(ctx, tx, syncBcastFlag(txOpts.SyncBcast))
+}
+
 // Call calls an action. It returns the result records.
 func (c *Client) Call(ctx context.Context, namespace string, action string, inputs []any) (*types.CallResult, error) {
 	encoded, err := EncodeInputs(inputs)

--- a/core/client/execute_payload_test.go
+++ b/core/client/execute_payload_test.go
@@ -1,0 +1,89 @@
+package client_test
+
+import (
+	"context"
+	"math/big"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/trufnetwork/kwil-db/core/client"
+	clientType "github.com/trufnetwork/kwil-db/core/client/types"
+	"github.com/trufnetwork/kwil-db/core/crypto"
+	"github.com/trufnetwork/kwil-db/core/crypto/auth"
+	rpcclient "github.com/trufnetwork/kwil-db/core/rpc/client"
+	"github.com/trufnetwork/kwil-db/core/types"
+)
+
+// stubRPC is a minimal RPCClient: it embeds the interface so that any method we
+// do not override panics if called, and implements only the four the
+// WrapClient + ExecutePayload path exercises (Health, GetAccount, EstimateCost,
+// Broadcast). It captures the transaction handed to Broadcast for assertions.
+type stubRPC struct {
+	client.RPCClient
+	acctNonce int64
+	estFee    *big.Int
+	gotTx     *types.Transaction
+}
+
+func (s *stubRPC) Health(ctx context.Context) (*types.Health, error) {
+	return &types.Health{ChainInfo: types.ChainInfo{ChainID: "test-chain"}, Healthy: true}, nil
+}
+
+func (s *stubRPC) GetAccount(ctx context.Context, id *types.AccountID, status types.AccountStatus) (*types.Account, error) {
+	return &types.Account{ID: id, Nonce: s.acctNonce}, nil
+}
+
+func (s *stubRPC) EstimateCost(ctx context.Context, tx *types.Transaction) (*big.Int, error) {
+	return s.estFee, nil
+}
+
+func (s *stubRPC) Broadcast(ctx context.Context, tx *types.Transaction, sync rpcclient.BroadcastWait) (types.Hash, error) {
+	s.gotTx = tx
+	return types.Hash{0x01}, nil
+}
+
+// TestClient_ExecutePayload proves the generic escape hatch signs and broadcasts
+// an arbitrary payload (here MAAExec, the motivating extension payload) with the
+// nonce from the account, the fee from EstimateCost, and the payload preserved
+// byte-for-byte through the wire round-trip.
+func TestClient_ExecutePayload(t *testing.T) {
+	ctx := context.Background()
+
+	pk, err := crypto.Secp256k1PrivateKeyFromHex(
+		"0000000000000000000000000000000000000000000000000000000000000001")
+	require.NoError(t, err)
+	signer := &auth.EthPersonalSigner{Key: *pk}
+
+	stub := &stubRPC{acctNonce: 5, estFee: big.NewInt(123)}
+	c, err := client.WrapClient(ctx, stub, &clientType.Options{
+		Signer:            signer,
+		ChainID:           "test-chain",
+		SkipVerifyChainID: true,
+		Silence:           true,
+	})
+	require.NoError(t, err)
+
+	payload := &types.MAAExec{
+		MAAAddress: make([]byte, 20),
+		Namespace:  "main",
+		Action:     "example_action",
+	}
+
+	h, err := c.ExecutePayload(ctx, payload)
+	require.NoError(t, err)
+	require.Equal(t, types.Hash{0x01}, h, "returns the hash from Broadcast")
+
+	require.NotNil(t, stub.gotTx, "Broadcast must be called")
+	require.Equal(t, uint64(6), stub.gotTx.Body.Nonce, "account nonce 5 + 1")
+	require.Equal(t, "123", stub.gotTx.Body.Fee.String(), "fee from EstimateCost")
+	require.Equal(t, types.PayloadTypeMAAExec, stub.gotTx.Body.PayloadType)
+	require.NotEmpty(t, stub.gotTx.Signature.Data, "transaction is signed")
+
+	// The payload survives serialization byte-for-byte.
+	var got types.MAAExec
+	require.NoError(t, got.UnmarshalBinary(stub.gotTx.Body.Payload))
+	require.Equal(t, payload.Namespace, got.Namespace)
+	require.Equal(t, payload.Action, got.Action)
+	require.Equal(t, payload.MAAAddress, got.MAAAddress)
+}

--- a/core/client/execute_payload_test.go
+++ b/core/client/execute_payload_test.go
@@ -24,6 +24,7 @@ type stubRPC struct {
 	acctNonce int64
 	estFee    *big.Int
 	gotTx     *types.Transaction
+	gotSync   rpcclient.BroadcastWait
 }
 
 func (s *stubRPC) Health(ctx context.Context) (*types.Health, error) {
@@ -40,6 +41,7 @@ func (s *stubRPC) EstimateCost(ctx context.Context, tx *types.Transaction) (*big
 
 func (s *stubRPC) Broadcast(ctx context.Context, tx *types.Transaction, sync rpcclient.BroadcastWait) (types.Hash, error) {
 	s.gotTx = tx
+	s.gotSync = sync
 	return types.Hash{0x01}, nil
 }
 
@@ -86,4 +88,12 @@ func TestClient_ExecutePayload(t *testing.T) {
 	require.Equal(t, payload.Namespace, got.Namespace)
 	require.Equal(t, payload.Action, got.Action)
 	require.Equal(t, payload.MAAAddress, got.MAAAddress)
+
+	// Options thread through to the broadcast wait mode: default is accept-on-broadcast,
+	// and WithSyncBroadcast(true) waits for commit.
+	require.Equal(t, rpcclient.BroadcastWaitAccept, stub.gotSync, "no opts → accept on broadcast")
+
+	_, err = c.ExecutePayload(ctx, payload, clientType.WithSyncBroadcast(true))
+	require.NoError(t, err)
+	require.Equal(t, rpcclient.BroadcastWaitCommit, stub.gotSync, "WithSyncBroadcast(true) → wait for commit")
 }


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4128

Adds a generic Client.ExecutePayload(ctx, payload, opts...) — the single source of truth for transaction construction (signer/nonce/fee/sign/broadcast), so callers can submit transaction payload types the client has no typed convenience for (e.g. the MAAExec extension payload added in #2). Mirrors Execute/Transfer/ExecuteSQL; covered by a unit test.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for executing and broadcasting custom payloads with automatic transaction signing, fee estimation, and nonce management.

* **Tests**
  * Added unit tests to verify payload execution functionality, including signature validation, fee derivation, and transaction serialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->