### PR TITLE
chore: keep crediting bridge deposits when an RPC caps getLogs

### DIFF
--- a/node/exts/evm-sync/instance.go
+++ b/node/exts/evm-sync/instance.go
@@ -263,12 +263,13 @@ func (l *listenerInfo) listen(ctx context.Context, service *common.Service, even
 		}
 
 		indiv := &individualListener{
-			chain:            l.chain,
-			syncConf:         syncConf,
-			chainConf:        chainConf,
-			client:           ethClient,
-			orderedSyncTopic: l.uniqueName,
-			getLogsFunc:      l.getLogs,
+			chain:               l.chain,
+			syncConf:            syncConf,
+			chainConf:           chainConf,
+			client:              ethClient,
+			orderedSyncTopic:    l.uniqueName,
+			getLogsFunc:         l.getLogs,
+			blockSyncChunkDelay: defaultBlockSyncChunkDelay,
 		}
 
 		// Run the listener - this blocks until an error occurs or context is cancelled

--- a/node/exts/evm-sync/listener.go
+++ b/node/exts/evm-sync/listener.go
@@ -185,7 +185,13 @@ type individualListener struct {
 	orderedSyncTopic string
 	// getLogsFunc gets logs for a given range of blocks.
 	getLogsFunc GetBlockLogsFunc
+	// blockSyncChunkDelay is the pause between successful chunk requests during catch-up,
+	// a naive guard against RPC rate limits. Defaults to defaultBlockSyncChunkDelay.
+	blockSyncChunkDelay time.Duration
 }
+
+// defaultBlockSyncChunkDelay is the pause between successful catch-up chunk requests.
+const defaultBlockSyncChunkDelay = 500 * time.Millisecond
 
 // GetBlockLogsFunc is a function that provides an ethereum client and a range of blocks and returns the logs for that range.
 type GetBlockLogsFunc func(ctx context.Context, client *ethclient.Client, startBlock, endBlock uint64, logger log.Logger) ([]*EthLog, error)
@@ -214,28 +220,11 @@ func (i *individualListener) listen(ctx context.Context, eventstore listeners.Ev
 	lastConfirmedBlock := currentBlock - i.chain.RequiredConfirmations
 	logger.Infof(fmt.Sprintf("catching up from block %d to block %d", startBlock, lastConfirmedBlock))
 
-	// we will now sync all logs from the starting height to the current height,
-	// in chunks of config.BlockSyncChunkSize
-	for {
-		if startBlock >= lastConfirmedBlock {
-			break
-		}
-
-		toBlock := min(startBlock+i.chainConf.BlockSyncChunkSize, lastConfirmedBlock)
-
-		err = i.processEvents(ctx, startBlock, toBlock, eventstore, logger)
-		if err != nil {
-			// NOTE: this will cause the listener stops.
-			return fmt.Errorf("sync up blocks failed, %w", err)
-		}
-
-		startBlock = toBlock
-
-		// naive way to avoid reaching the RPC ratelimit, as most of them calculate limit(computing) by per second.
-		// depends on network and RPC service, this loop might easily reach provided RPC ratelimit
-		// for example, at the time of write, Arbitrum has 314m blocks, whereas Ethereum has 22m blocks.
-		time.Sleep(time.Millisecond * 500)
+	// sync all logs from the starting height to the last confirmed height in chunks.
+	if err := i.syncBlockChunks(ctx, eventstore, startBlock, lastConfirmedBlock, logger); err != nil {
+		return err
 	}
+	startBlock = lastConfirmedBlock
 
 	logger.Info(fmt.Sprintf("synced up to block %d", lastConfirmedBlock))
 
@@ -265,6 +254,45 @@ func (i *individualListener) listen(ctx context.Context, eventstore listeners.Ev
 	}
 
 	return nil
+}
+
+// syncBlockChunks processes events from startBlock up to lastConfirmedBlock in chunks of
+// BlockSyncChunkSize. When a request fails it halves the chunk size and retries the same
+// range, rather than stalling forever on the same oversized request. This recovers from RPC
+// providers that cap eth_getLogs by block range or result count (e.g. "exceed maximum block
+// range", "Request contains invalid block params") without operator intervention. The retry is
+// bounded: once the chunk size reaches one block and still fails, the error is real and is
+// returned (so a genuine outage surfaces and the listener's normal recovery/backoff kicks in).
+func (i *individualListener) syncBlockChunks(ctx context.Context, eventStore listeners.EventStore, startBlock, lastConfirmedBlock int64, logger log.Logger) error {
+	chunkSize := i.chainConf.BlockSyncChunkSize
+	for {
+		if startBlock >= lastConfirmedBlock {
+			return nil
+		}
+
+		toBlock := min(startBlock+chunkSize, lastConfirmedBlock)
+
+		err := i.processEvents(ctx, startBlock, toBlock, eventStore, logger)
+		if err != nil {
+			if chunkSize > 1 {
+				chunkSize /= 2
+				logger.Warn("block sync chunk failed; halving chunk size and retrying",
+					"chain", i.chain.Name, "from", startBlock, "to", toBlock,
+					"new_chunk_size", chunkSize, "err", err)
+				continue
+			}
+			// NOTE: even a single-block request failed, so this is a real error (not a
+			// provider range limit). This will cause the listener to stop and recover.
+			return fmt.Errorf("sync up blocks failed, %w", err)
+		}
+
+		startBlock = toBlock
+
+		// naive way to avoid reaching the RPC ratelimit, as most of them calculate limit(computing) by per second.
+		// depends on network and RPC service, this loop might easily reach provided RPC ratelimit
+		// for example, at the time of write, Arbitrum has 314m blocks, whereas Ethereum has 22m blocks.
+		time.Sleep(i.blockSyncChunkDelay)
+	}
 }
 
 func (i *individualListener) processEvents(ctx context.Context, from, to int64, eventStore listeners.EventStore, logger log.Logger) error {

--- a/node/exts/evm-sync/listener_test.go
+++ b/node/exts/evm-sync/listener_test.go
@@ -1,10 +1,14 @@
 package evmsync
 
 import (
+	"context"
+	"errors"
 	"testing"
 
+	"github.com/ethereum/go-ethereum/ethclient"
 	"github.com/stretchr/testify/require"
 	"github.com/trufnetwork/kwil-db/config"
+	"github.com/trufnetwork/kwil-db/core/log"
 	"github.com/trufnetwork/kwil-db/node/exts/evm-sync/chains"
 )
 
@@ -111,5 +115,117 @@ func TestGetChainConf(t *testing.T) {
 		_, err := getChainConf(cfg, chains.Ethereum)
 		require.Error(t, err)
 		require.Contains(t, err.Error(), "block_sync_chunk_size must be greater than 0")
+	})
+}
+
+// fakeEventStore is an in-memory listeners.EventStore for testing the catch-up loop.
+type fakeEventStore struct {
+	kv map[string][]byte
+}
+
+func newFakeEventStore() *fakeEventStore { return &fakeEventStore{kv: map[string][]byte{}} }
+
+func (f *fakeEventStore) Set(_ context.Context, key, value []byte) error {
+	f.kv[string(key)] = value
+	return nil
+}
+func (f *fakeEventStore) Get(_ context.Context, key []byte) ([]byte, error) {
+	return f.kv[string(key)], nil
+}
+func (f *fakeEventStore) Delete(_ context.Context, key []byte) error {
+	delete(f.kv, string(key))
+	return nil
+}
+func (f *fakeEventStore) Broadcast(_ context.Context, _ string, _ []byte) error { return nil }
+
+func newTestChunkListener(chunkSize int64, getLogs GetBlockLogsFunc) *individualListener {
+	return &individualListener{
+		chain:               chains.ChainInfo{Name: chains.Chain("test")},
+		chainConf:           &chainConfig{BlockSyncChunkSize: chunkSize},
+		client:              &ethClient{}, // getLogsFunc ignores the (nil) inner client
+		orderedSyncTopic:    "test_topic",
+		getLogsFunc:         getLogs,
+		blockSyncChunkDelay: 0, // no inter-chunk sleep in tests
+	}
+}
+
+// TestSyncBlockChunks_AdaptiveChunking pins the behavior that prevents the testnet incident
+// where the hoodi deposit listener wedged: a single oversized eth_getLogs request must not
+// permanently stall catch-up. Instead the chunk size halves and retries until the request
+// fits the provider's range/result limit.
+func TestSyncBlockChunks_AdaptiveChunking(t *testing.T) {
+	ctx := context.Background()
+	logger := log.DiscardLogger
+
+	t.Run("halves chunk size when the RPC rejects an oversized range", func(t *testing.T) {
+		const providerLimit = 4 // max blocks the fake RPC allows per (inclusive) getLogs request
+		var calls int
+		var processed [][2]uint64 // (from,to) of every range actually fetched & processed
+		getLogs := func(_ context.Context, _ *ethclient.Client, from, to uint64, _ log.Logger) ([]*EthLog, error) {
+			calls++
+			// eth_getLogs is inclusive on both ends, so a [from,to] request fetches to-from+1 blocks.
+			if to-from+1 > providerLimit {
+				return nil, errors.New("exceed maximum block range: 4")
+			}
+			processed = append(processed, [2]uint64{from, to})
+			return nil, nil // empty logs -> processEvents just advances the last-seen height
+		}
+		// Default-style oversized chunk (64) over a 16-block gap with a 4-block provider limit.
+		l := newTestChunkListener(64, getLogs)
+		es := newFakeEventStore()
+
+		err := l.syncBlockChunks(ctx, es, 0, 16, logger)
+		require.NoError(t, err, "catch-up must recover by shrinking the request")
+
+		got, err := getLastSeenHeight(ctx, es, l.orderedSyncTopic)
+		require.NoError(t, err)
+		require.Equal(t, int64(16), got, "should sync all the way to the target despite the oversized default chunk")
+		require.Greater(t, calls, 1, "should have retried after the first oversized request")
+
+		// The fetched ranges must each fit the provider limit and together cover every block
+		// in [0,16] with no gaps. (Boundary blocks may be re-fetched -- overlap is expected and
+		// harmless -- but a GAP would mean skipped blocks / lost events.)
+		covered := make([]bool, 17)
+		for _, r := range processed {
+			require.LessOrEqual(t, r[1]-r[0]+1, uint64(providerLimit), "each fetched range must fit the provider limit")
+			for b := r[0]; b <= r[1]; b++ {
+				covered[b] = true
+			}
+		}
+		for b := range 17 {
+			require.Truef(t, covered[b], "block %d must be covered by some chunk (no gaps)", b)
+		}
+	})
+
+	t.Run("errors (does not loop forever) when even a small request keeps failing", func(t *testing.T) {
+		getLogs := func(_ context.Context, _ *ethclient.Client, _, _ uint64, _ log.Logger) ([]*EthLog, error) {
+			return nil, errors.New("Request contains invalid block params")
+		}
+		l := newTestChunkListener(8, getLogs)
+		es := newFakeEventStore()
+
+		err := l.syncBlockChunks(ctx, es, 0, 16, logger)
+		require.Error(t, err, "a persistently failing RPC must surface an error, not spin")
+		require.Contains(t, err.Error(), "sync up blocks failed")
+	})
+
+	t.Run("no provider limit: syncs in full configured chunks", func(t *testing.T) {
+		var maxSpan uint64
+		getLogs := func(_ context.Context, _ *ethclient.Client, from, to uint64, _ log.Logger) ([]*EthLog, error) {
+			if to-from > maxSpan {
+				maxSpan = to - from
+			}
+			return nil, nil
+		}
+		l := newTestChunkListener(8, getLogs)
+		es := newFakeEventStore()
+
+		err := l.syncBlockChunks(ctx, es, 0, 20, logger)
+		require.NoError(t, err)
+
+		got, err := getLastSeenHeight(ctx, es, l.orderedSyncTopic)
+		require.NoError(t, err)
+		require.Equal(t, int64(20), got)
+		require.LessOrEqual(t, maxSpan, uint64(8), "should never request more than the configured chunk size")
 	})
 }


### PR DESCRIPTION
The EVM bridge listener catches up by requesting eth_getLogs over [lastSeen, head] in chunks of block_sync_chuck_size (default 1,000,000). When that range exceeds what the RPC provider allows, the provider rejects every request (e.g. "exceed maximum block range", "Request contains invalid block params"); the catch-up loop returns the error, stops, and then retries the identical oversized request forever. The listener never advances, so bridge deposits and withdrawals stop being picked up.

Make catch-up adaptive: on a failed chunk, halve the chunk size and retry the same range instead of giving up. The retry is bounded -- once the chunk is a single block and still fails, the error is real and is surfaced, so a genuine outage still triggers the normal recovery/backoff. A mis-sized or unset block_sync_chuck_size can no longer wedge the listener.

The split is consensus-safe: sub-ranges are contiguous and processEvents chains via the persisted lastHeightWithEvent/lastSeenHeight, so the ordered resolution sequence is identical regardless of how the range is chunked.

Covered by TestSyncBlockChunks_AdaptiveChunking: halves on an oversized range, surfaces an error instead of looping forever, and respects the configured chunk size when there is no provider limit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved block synchronization reliability with adaptive retry logic that automatically reduces request chunk sizes on failures, better handling RPC provider limitations and preventing sync stalls.

* **New Features**
  * Added configurable delay parameter to control pause intervals during block catch-up operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->