### PR TITLE
build: raise postgres work_mem to keep sorts in memory

### DIFF
--- a/contrib/docker/postgres.dockerfile
+++ b/contrib/docker/postgres.dockerfile
@@ -21,4 +21,4 @@ COPY ./pginit.sql /docker-entrypoint-initdb.d/init.sql
 # 'track_commit_timestamp' is not required, but may be useful for debugging.
 CMD ["postgres", "-c", "wal_level=logical", "-c", "max_wal_senders=10", "-c", "max_replication_slots=10", \
 	"-c", "track_commit_timestamp=true", "-c", "wal_sender_timeout=0", "-c", "max_prepared_transactions=200", \
-	"-c", "max_locks_per_transaction=4096", "-c", "max_connections=128"]
+	"-c", "max_locks_per_transaction=4096", "-c", "max_connections=128", "-c", "work_mem=64MB"]


### PR DESCRIPTION
resolves: https://github.com/truflation/website/issues/4272

Adds `-c work_mem=64MB` to the kwil-postgres image CMD so large sorts and hash joins run in memory instead of spilling to disk (the Postgres default is 4MB). Already applied at runtime on the mainnet nodes; this makes it the default for all deployments that use the image.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the PostgreSQL container startup settings to use a higher memory work setting, which may improve database performance for some workloads.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->