### PR TITLE
perf: keep top-holder queries fast at scale

### DIFF
--- a/node/exts/erc20-bridge/erc20/meta_schema.sql
+++ b/node/exts/erc20-bridge/erc20/meta_schema.sql
@@ -32,6 +32,12 @@ CREATE TABLE IF NOT EXISTS balances (
     CONSTRAINT balance_must_be_positive CHECK (balance >= 0)
 );
 
+-- index for ordered top-holder lookups: WHERE reward_id = $id [AND balance >= $min]
+-- ORDER BY balance {ASC|DESC} LIMIT $n. Without it, ordering a token's balances is a
+-- sequential scan + top-N sort. A btree on (reward_id, balance) is scanned forward for
+-- ASC and backward for DESC, and also serves the balance-threshold range.
+CREATE INDEX IF NOT EXISTS idx_balances_reward_balance ON balances(reward_id, balance);
+
 -- epochs holds the epoch information.
 -- An epoch is a group of rewards that are issued in a given time/block range.
 -- Epochs have 3 states:

--- a/node/exts/erc20-bridge/erc20/meta_sql.go
+++ b/node/exts/erc20-bridge/erc20/meta_sql.go
@@ -788,7 +788,10 @@ func getVersion(ctx context.Context, app *common.App) (version int64, notYetSet 
 	return version, false, nil
 }
 
-var currentVersion = int64(2)
+// currentVersion is the meta-schema version. Bumping it makes OnStart re-run the
+// idempotent createSchema on existing nodes to pick up additive schema changes.
+// v3: add idx_balances_reward_balance for ordered top-holder lookups.
+var currentVersion = int64(3)
 
 // setVersionToCurrent sets the version of the meta extension to currentVersion.
 func setVersionToCurrent(ctx context.Context, app *common.App) error {

--- a/node/exts/erc20-bridge/erc20/meta_sql_test.go
+++ b/node/exts/erc20-bridge/erc20/meta_sql_test.go
@@ -722,3 +722,38 @@ func TestGetWalletEpochs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, epochsReturned, 0, "should return no epochs when all are claimed")
 }
+
+// TestBalancesRewardBalanceIndex verifies the ordered top-holder index exists on
+// kwil_erc20_meta.balances after the schema is created, so that
+// "WHERE reward_id = $id [AND balance >= $min] ORDER BY balance {ASC|DESC} LIMIT $n"
+// is served by an index instead of a sequential scan + top-N sort (trufscan #185).
+func TestBalancesRewardBalanceIndex(t *testing.T) {
+	ctx := context.Background()
+	db, err := newTestDB()
+	require.NoError(t, err)
+	defer db.Close()
+
+	tx, err := db.BeginTx(ctx)
+	require.NoError(t, err)
+	defer tx.Rollback(ctx) // always rollback
+
+	orderedsync.ForTestingReset()
+	defer orderedsync.ForTestingReset()
+	ForTestingResetSingleton()
+	defer ForTestingResetSingleton()
+
+	setup(t, tx) // runs genesis createSchema at currentVersion
+
+	// pg_indexes is a standard Postgres catalog view; read it via the raw pg path.
+	res, err := tx.Execute(ctx, `SELECT indexdef FROM pg_indexes
+		WHERE schemaname = 'kwil_erc20_meta'
+		  AND tablename = 'balances'
+		  AND indexname = 'idx_balances_reward_balance'`)
+	require.NoError(t, err)
+	require.Len(t, res.Rows, 1, "idx_balances_reward_balance must exist on kwil_erc20_meta.balances")
+
+	indexdef, ok := res.Rows[0][0].(string)
+	require.True(t, ok, "indexdef should be text")
+	require.Contains(t, indexdef, "reward_id", "index should lead with reward_id")
+	require.Contains(t, indexdef, "balance", "index should include balance")
+}


### PR DESCRIPTION
## What

Adds a Postgres index `idx_balances_reward_balance` on `kwil_erc20_meta.balances(reward_id, balance)` and bumps the erc20 meta-schema version so existing nodes pick it up on upgrade.

## Why

Ordered balance lookups — `WHERE reward_id = $id [AND balance >= $min] ORDER BY balance LIMIT $n` — currently do a sequential scan + top-N sort on `balances`. This backs the upcoming node "ordered balances / richlist" action, and the index keeps those queries fast as a token's holder count grows.

Kuneiform's `CREATE INDEX` grammar has no per-column `DESC`, but a plain `(reward_id, balance)` btree is scanned backward for `ORDER BY balance DESC`, forward for `ASC`, and also serves the `balance >= threshold` range — so it covers every pattern without a separate sort.

## How it ships

Additive and `IF NOT EXISTS`. `currentVersion` 2 → 3 makes `OnStart` re-run the idempotent `createSchema` on existing nodes. Index creation is consensus-neutral (indexes don't affect app hash).

## Test

New `TestBalancesRewardBalanceIndex` asserts the index exists on `kwil_erc20_meta.balances` after schema creation. The full erc20 package suite passes.

## Related

- resolves: trufnetwork/trufscan#185


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Performance Improvements**
  - Improved performance for top-holder lookups and balance-threshold queries.
  - Ordered balance results can now be retrieved more efficiently, especially on larger datasets.
- **Bug Fixes**
  - Existing deployments automatically receive the performance enhancement during schema updates without affecting stored balances.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->